### PR TITLE
Fixes DeprecationWarning introduced in setuptools>=77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "A deep learning framework for AI-driven multi-physics systems"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "Apache 2.0"}
+license = "Apache 2.0"
 dependencies = [
     "certifi>=2023.7.22",
     "fsspec>=2023.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "A deep learning framework for AI-driven multi-physics systems"
 readme = "README.md"
 requires-python = ">=3.10"
-license = "Apache 2.0"
+license = "Apache-2.0"
 dependencies = [
     "certifi>=2023.7.22",
     "fsspec>=2023.1.0",
@@ -28,7 +28,6 @@ dependencies = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

When installing PhysicsNeMo from source with `setuptools>=77` (current latest release is v78), the following deprecation warning is emitted during install, from PhysicsNeMo:

```
      SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
      !!

              ********************************************************************************
              Please use a simple string containing a SPDX expression for `project.license`. You can also
      use `project.license-files`. (Both options available on setuptools>=77.0.0).

              By 2026-Feb-18, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for
      details.
              ********************************************************************************

      !!
```

This originates from `pyproject.toml`, which previously contained:
```
license = {text = "Apache 2.0"}
```
and should now be the following [SPDX-compatible identifier](https://spdx.org/licenses/):
```
license = "Apache-2.0"
```

Related:
- [PEP 639](https://peps.python.org/pep-0639/)
- https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/
- https://github.com/pypa/setuptools/issues/4903

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [N/A] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->