### PR TITLE
Fix CUPY float/int datatype casting.

### DIFF
--- a/physicsnemo/datapipes/cae/domino_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_datapipe.py
@@ -563,8 +563,8 @@ class DoMINODataPipe(Dataset):
 
         # geom_centers = self.array_provider.float32(geom_centers)
 
-        surf_grid_max_min = xp.concatenate([s_min, s_max], axis=0)
-
+        surf_grid_max_min = xp.stack([s_min, s_max])
+        
         return_dict = {
             "length_scale": length_scale,
             "surf_grid": surf_grid,

--- a/physicsnemo/datapipes/cae/domino_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_datapipe.py
@@ -513,6 +513,10 @@ class DoMINODataPipe(Dataset):
 
         xp = self.array_provider
 
+        # Make sure the mesh_indices_flattened is an integer array:
+        if mesh_indices_flattened.dtype != xp.int32:
+            mesh_indices_flattened = mesh_indices_flattened.astype(xp.int32)
+
         length_scale = xp.amax(xp.amax(stl_vertices, 0) - xp.amin(stl_vertices, 0))
 
         center_of_mass = calculate_center_of_mass(stl_centers, stl_sizes)

--- a/physicsnemo/utils/sdf.py
+++ b/physicsnemo/utils/sdf.py
@@ -118,13 +118,10 @@ def signed_distance_field(
     # If cupy arrays come in, we have to convert them to numpy arrays:
     return_cupy = False
     if isinstance(mesh_vertices, cp.ndarray):
-        mesh_vertices = mesh_vertices.get()
         return_cupy = True
     if isinstance(mesh_indices, cp.ndarray):
-        mesh_indices = mesh_indices.get()
         return_cupy = True
     if isinstance(input_points, cp.ndarray):
-        input_points = input_points.get()
         return_cupy = True
 
     # Convert numpy to warp arrays:
@@ -135,7 +132,6 @@ def signed_distance_field(
 
     mesh = wp.Mesh(mesh_vertices, mesh_indices)
 
-    # sdf_points = wp.array(input_points, dtype=wp.vec3)
     sdf = wp.zeros(shape=sdf_points.shape, dtype=wp.float32, device=sdf_points.device)
     sdf_hit_point = wp.zeros(
         shape=sdf_points.shape, dtype=wp.vec3f, device=sdf_points.device


### PR DESCRIPTION
This commit addresses an issue where the mesh indexes were being improperly converted to float32 at some point.  This enables the preprocessing workflow to stay on the GPU for this section, if the data is on GPU.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->