### PR TITLE
Add itertools.islice in validation for Dali datapipe

### DIFF
--- a/examples/weather/graphcast/validation_base.py
+++ b/examples/weather/graphcast/validation_base.py
@@ -82,7 +82,9 @@ class Validation:
             "num_samples_per_year": self.num_samples_per_year_train,
             "device": self.dist.device,
         }
-        for i, data in enumerate(self.val_datapipe):
+        val_data_iter = iter(itertools.islice(self.val_datapipe, len(self.val_datapipe)))
+        for i in range(len(self.val_datapipe)):
+            data = next(val_data_iter)
             invar = data[0]["invar"]
             outvar = data[0]["outvar"][0]
             try:


### PR DESCRIPTION
Using itertools.islice helps streamline the validation loop by limiting the number of batches processed, making validation more time-efficient without extra overhead.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->