### PR TITLE
Gating on Datapipes - prototype

### DIFF
--- a/physicsnemo/datapipes/cae/__init__.py
+++ b/physicsnemo/datapipes/cae/__init__.py
@@ -14,5 +14,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .domino_datapipe import DoMINODataPipe
-from .mesh_datapipe import MeshDatapipe
+from physicsnemo.utils.version_check import check_package_installed
+
+# This could and should be reoragnized into meta-data level requirements on pipelines.
+domino_datapipe_requirements = ["warp", "scipy"]
+mesh_datapipe_requirements = ["vtk"]
+
+
+def __getattr__(name):
+    """
+    This file is meant to provide information
+    """
+    if name == "DoMINODataPipe":
+        missing = [
+            p for p in domino_datapipe_requirements if not check_package_installed(p)
+        ]
+
+        if missing:
+            raise ImportError(
+                f"Cannot import DoMINODataPipe: Missing required packages: {', '.join(missing)}"
+            )
+        else:
+            from .domino_datapipe import DoMINODataPipe
+
+            return DoMINODataPipe
+
+    if name == "MeshDatapipe":
+        missing = [
+            p for p in mesh_datapipe_requirements if not check_package_installed(p)
+        ]
+        if missing:
+            raise ImportError(
+                f"Cannot import MeshDatapipe: Missing required packages: {', '.join(missing)}"
+            )
+        else:
+            from .mesh_datapipe import MeshDatapipe
+
+            return MeshDatapipe
+
+    raise AttributeError(
+        f"module 'physicsnemo.datapipes.cae' has no attribute '{name}'"
+    )

--- a/physicsnemo/utils/version_check.py
+++ b/physicsnemo/utils/version_check.py
@@ -36,6 +36,32 @@ VERSION_REQUIREMENTS = {
 }
 
 
+def check_package_installed(package_name: str, error_msg: Optional[str] = None) -> bool:
+    """
+    Check if a package is installed.
+
+    Args:
+        package_name: Name of the package to check
+        error_msg: Optional custom error message
+
+    Returns:
+        True if package is installed
+
+    Raises:
+        ImportError: If package is not installed
+    """
+    try:
+        importlib.import_module(package_name)
+        return True
+    except ImportError:
+        msg = (
+            error_msg
+            or f"Package {package_name} is required but not installed, or broken."
+        )
+        print(msg)
+        return False
+
+
 def check_min_version(
     package_name: str, min_version: str, error_msg: Optional[str] = None
 ) -> bool:
@@ -86,7 +112,44 @@ def check_module_requirements(module_path: str) -> None:
         check_min_version(package, min_version)
 
 
-def require_version(package_name: str, min_version: str):
+def require_installed_package(package_name: str, error_msg: Optional[str] = None):
+    """
+    Decorator that prevents a function from being called unless the
+    specified package is installed.
+
+    Args:
+        package_name: Name of the package to check
+        error_msg: Optional custom error message
+
+    Returns:
+        Decorator function that checks package installation before execution
+
+    Example:
+        @require_installed_package("torch")
+        def my_function():
+            # This function will only execute if torch is installed
+            pass
+    """
+
+    def decorator(func):
+        import functools
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # Verify the package is installed before executing
+            check_package_installed(package_name, error_msg)
+
+            # If we get here, package is installed
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def require_version(
+    package_name: str, min_version: str, error_msg: Optional[str] = None
+):
     """
     Decorator that prevents a function from being called unless the
     specified package meets the minimum version requirement.
@@ -94,6 +157,7 @@ def require_version(package_name: str, min_version: str):
     Args:
         package_name: Name of the package to check
         min_version: Minimum required version string (e.g. '2.3')
+        error_msg: Optional custom error message
 
     Returns:
         Decorator function that checks version requirement before execution
@@ -110,8 +174,11 @@ def require_version(package_name: str, min_version: str):
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
+            # Verify the package is installed
+            check_package_installed(package_name)
+
             # Verify the package meets minimum version before executing
-            check_min_version(package_name, min_version)
+            check_min_version(package_name, min_version, error_msg)
 
             # If we get here, version check passed
             return func(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "A deep learning framework for AI-driven multi-physics systems"
 readme = "README.md"
 requires-python = ">=3.10"
-license = "Apache-2.0"
+license = {file="LICENSE.txt"}
 dependencies = [
     "certifi>=2023.7.22",
     "fsspec>=2023.1.0",


### PR DESCRIPTION
This commit adds a new, small functionality to physicsnemo's version check tools, to see if a package is installed.

Then, the import of the datapipes leverages this tool to prevent missing imports from Domino datapipe (and the other way, if vtk is missing or broken, don't let mesh datapipe prevent domino datapipe.)

Some details:

- use check_min_version to require a minimum installed version.
- the __init__.py file in physicsnemo/datapipes/cae now wraps both datapipes in a function.
  - python 3.7 enabled __getattr__ at module level. (https://peps.python.org/pep-0562/)
  - this function now performs requirement checking on these imports before returning.
  - If an import fails, it will print an informative message about it in the ImportError.


Closes #847

# **ADDITIONALLY** 
This fixes an error I encountered in the pyproject.toml license listing.  We should check this carefully before merging.  Passing `license="Apache 2.0"` did not work, but passing `license={file="LICENSE.txt"}` appears to work.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [X] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->