### PR TITLE
A few fixes for the domino pipeline.

### DIFF
--- a/physicsnemo/datapipes/cae/domino_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_datapipe.py
@@ -251,6 +251,9 @@ class DoMINODataPipe(Dataset):
         # Perform config packaging and validation
         self.config = DoMINODataConfig(data_path=input_path, **data_config_overrides)
 
+        if not DistributedManager.is_initialized():
+            DistributedManager.initialize()
+
         dist = DistributedManager()
         if self.config.gpu_preprocessing or self.config.gpu_output:
             # Make sure we move data to the right device:
@@ -445,8 +448,8 @@ class DoMINODataPipe(Dataset):
         # Maybe move to GPU:
         with self.device_context:
             for key in data.keys():
-                data[key] = self.array_provider.asarray(data[key])
-
+                if data[key] is not None:
+                    data[key] = self.array_provider.asarray(data[key])
         return data
 
     @profile

--- a/physicsnemo/utils/domino/utils.py
+++ b/physicsnemo/utils/domino/utils.py
@@ -314,8 +314,6 @@ def pad_inp(arr: ArrayType, npoin: int, pad_value: float = 0.0) -> ArrayType:
     return arr_padded
 
 
-# CJA NOTE: the `sample_array` function is the same optimization I put into shuffle_array.
-# Keeping the cupy compatible version (mine)
 @profile
 def shuffle_array(
     arr: ArrayType,
@@ -323,6 +321,9 @@ def shuffle_array(
 ) -> Tuple[ArrayType, ArrayType]:
     """Function for shuffling arrays"""
     xp = array_type(arr)
+    if npoin > arr.shape[0]:
+        # If asking too many points, truncate the ask but still shuffle.
+        npoin = arr.shape[0]
     idx = xp.random.choice(arr.shape[0], size=npoin, replace=False)
     return arr[idx], idx
 
@@ -439,6 +440,9 @@ def area_weighted_shuffle_array(
     factor = 1.0
     total_area = xp.sum(area**factor)
     probs = area**factor / total_area
+
+    if npoin > arr.shape[0]:
+        npoin = arr.shape[0]
 
     idx = xp.arange(arr.shape[0])
 


### PR DESCRIPTION
- initialize the distributed manager, if it isn't already.
- For partial datasets (surface only, volumen only) don't move "None" objects to cupy.
- When sampling/shuffling, if the number of points is too high then don't error.  Instead, shuffle and rely on padding.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->