### PR TITLE
Making the unit tests' nfs-data-dir configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,14 +214,16 @@ The pipeline has following stages:
     test, you will have to review your changes and fix the issues.
     To run pytest locally you can simply run `pytest` inside the `test` folder.
 
-    While writing these tests, we encourage you to make use of the
-    [`@nfs_data_or_fail`](https://github.com/NVIDIA/physicsnemo/blob/main/test/pytest_utils.py#L92)
-    and the [`@import_of_fail`](https://github.com/NVIDIA/physicsnemo/blob/main/test/pytest_utils.py#L25)
-    decorators to appropriately skip your tests for developers and users not having your
-    test specific datasets and dependencies respectively. The CI has these datasets and
-    dependencies so your tests will get executed during CI.
-    This mechanism helps us provide a better developer and user experience
-    when working with the unit tests.
+    While writing these tests, we encourage you to make use of the [`@import_of_fail`](https://github.com/NVIDIA/physicsnemo/blob/main/test/pytest_utils.py#L25)
+    decorator to appropriately skip your tests for developers and users not having your
+    test specific dependencies. This mechanism helps us provide a better developer and
+    user experience when working with the unit tests.
+
+    Some of the tests require test data to be run; otherwise, they will be skipped.
+    To get the data (available to NVIDIANs only), set the `TEST_DATA_DIR` environment variable
+    to a desired value and run make get-data. After that, pytest will use the same
+    variable to find the test data. Alternatively, you can pass it explicitly using
+    `pytest --nfs-data-dir=<path to test data>`.
 
 6. `doctest`
     Checks if the examples in the docstrings run and produce desired outputs.

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ editable-install:
 		pip install -e .[dev] --config-settings editable_mode=strict
 
 get-data:
-	mkdir -p /data && \
-		mkdir -p /data/nfs/ && \
-		git -C /data/nfs/modulus-data pull || \
-		git clone https://gitlab-master.nvidia.com/modulus/modulus-data.git /data/nfs/modulus-data
+	test -n "$(TEST_DATA_DIR)" || { echo "Error: TEST_DATA_DIR should be set"; exit 1; }
+	mkdir -p $(TEST_DATA_DIR) && \
+	rm -rf $(TEST_DATA_DIR)/modulus-data && \
+	git clone https://gitlab-master.nvidia.com/modulus/modulus-data.git $(TEST_DATA_DIR)/modulus-data && \
+	echo "Test data has been saved in ${TEST_DATA_DIR}"
 
 setup-ci:
 	pip install pre-commit && \

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,12 +13,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
+import pathlib
 from collections import defaultdict
 
 import pytest
 
-file_timings = defaultdict(float)
+NFS_DATA_PATH = "/data/nfs/modulus-data"
 
 # Total time per file
 file_timings = defaultdict(float)
@@ -49,6 +50,23 @@ def pytest_addoption(parser):
         default=False,
         help="fail tests if required modules are missing",
     )
+    parser.addoption(
+        "--nfs-data-dir", action="store", default=None, help="path to test data"
+    )
+
+
+@pytest.fixture(scope="session")
+def nfs_data_dir(request):
+    data_dir = pathlib.Path(
+        request.config.getoption("--nfs-data-dir")
+        or os.environ.get("TEST_DATA_DIR", NFS_DATA_PATH)
+    )
+    if not data_dir.exists():
+        pytest.skip(
+            "NFS volumes not set up with CI data repo. Run `make get-data` from the root directory of the repo"
+        )
+    print(f"Using {data_dir} as data directory")
+    return data_dir
 
 
 def pytest_configure(config):

--- a/test/datapipes/test_ahmed_body.py
+++ b/test/datapipes/test_ahmed_body.py
@@ -16,7 +16,7 @@
 
 import pytest
 import torch
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 
 from . import common
 
@@ -24,17 +24,13 @@ Tensor = torch.Tensor
 
 
 @pytest.fixture
-def data_dir():
-    path = "/data/nfs/modulus-data/datasets/ahmed_body/"
-    return path
+def data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/ahmed_body")
 
 
-@nfsdata_or_fail
 @import_or_fail(["vtk", "pyvista", "dgl"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_ahmed_body_constructor(data_dir, device, pytestconfig):
-
-    # _nfsdata_or_fail(pytestconfig)
     from physicsnemo.datapipes.gnn.ahmed_body_dataset import AhmedBodyDataset
 
     # construct dataset

--- a/test/datapipes/test_bsms.py
+++ b/test/datapipes/test_bsms.py
@@ -22,9 +22,8 @@ dgl = pytest.importorskip("dgl")
 
 
 @pytest.fixture
-def ahmed_data_dir():
-    path = "/data/nfs/modulus-data/datasets/ahmed_body/"
-    return path
+def ahmed_data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/ahmed_body")
 
 
 @import_or_fail("sparse_dot_mkl")

--- a/test/datapipes/test_climate.py
+++ b/test/datapipes/test_climate.py
@@ -16,7 +16,7 @@
 
 import pytest
 import torch
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 
 from . import common
 
@@ -24,36 +24,32 @@ Tensor = torch.Tensor
 
 
 @pytest.fixture
-def data_dir():
-    path = "/data/nfs/modulus-data/datasets/hdf5/test/"
-    return path
+def data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/hdf5/test")
 
 
 @pytest.fixture
-def stats_files():
+def stats_files(nfs_data_dir):
     return {
-        "mean": "/data/nfs/modulus-data/datasets/hdf5/stats/global_means.npy",
-        "std": "/data/nfs/modulus-data/datasets/hdf5/stats/global_stds.npy",
+        "mean": nfs_data_dir.joinpath("datasets/hdf5/stats/global_means.npy"),
+        "std": nfs_data_dir.joinpath("datasets/hdf5/stats/global_stds.npy"),
     }
 
 
 @pytest.fixture
-def metadata_path():
-    path = "/data/nfs/modulus-data/datasets/hdf5/data.json"
-    return path
+def metadata_path(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/hdf5/data.json")
 
 
 @pytest.fixture
-def lsm_filename():
-    path = "/data/nfs/modulus-data/datasets/hdf5/static/land_sea_mask.nc"
-    return path
+def lsm_filename(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/hdf5/static/land_sea_mask.nc")
 
 
 @pytest.fixture
-def geopotential_filename():
+def geopotential_filename(nfs_data_dir):
     """Geopotential file."""
-    path = "/data/nfs/modulus-data/datasets/hdf5/static/geopotential.nc"
-    return path
+    return nfs_data_dir.joinpath("datasets/hdf5/static/geopotential.nc")
 
 
 # default keyword args for DRY
@@ -75,7 +71,6 @@ datapipe_kwargs = dict(
 )
 
 # Skip CPU tests because too slow
-@nfsdata_or_fail
 @import_or_fail("netCDF4")
 @pytest.mark.parametrize("device", ["cuda:0"])
 def test_climate_hdf5_constructor(
@@ -187,7 +182,6 @@ def test_climate_hdf5_constructor(
         pass
 
 
-@nfsdata_or_fail
 @import_or_fail("netCDF4")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_climate_hdf5_device(
@@ -231,7 +225,6 @@ def test_climate_hdf5_device(
 
 
 # Skip CPU tests because too slow
-@nfsdata_or_fail
 @import_or_fail("netCDF4")
 @pytest.mark.parametrize("data_channels", [[0, 1]])
 @pytest.mark.parametrize("num_steps", [2])
@@ -324,7 +317,6 @@ def test_climate_hdf5_shape(
 
 
 # Skip CPU tests because too slow
-@nfsdata_or_fail
 @import_or_fail("netCDF4")
 @pytest.mark.parametrize("num_steps", [1, 2])
 @pytest.mark.parametrize("stride", [1, 3])
@@ -378,7 +370,6 @@ def test_era5_hdf5_sequence(
 
 
 # Skip CPU tests because too slow
-@nfsdata_or_fail
 @import_or_fail("netCDF4")
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("stride", [1, 3])
@@ -435,7 +426,6 @@ def test_era5_hdf5_shuffle(
     assert common.check_shuffle(tensors, shuffle, stride, 8)
 
 
-@nfsdata_or_fail
 @import_or_fail("netCDF4")
 @pytest.mark.parametrize("device", ["cuda:0"])
 def test_era5_hdf5_cudagraphs(

--- a/test/datapipes/test_drivaernet.py
+++ b/test/datapipes/test_drivaernet.py
@@ -16,7 +16,7 @@
 
 import pytest
 import torch
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 
 from . import common
 
@@ -24,11 +24,10 @@ Tensor = torch.Tensor
 
 
 @pytest.fixture
-def data_dir():
-    return "/data/nfs/modulus-data/datasets/drivaernet/"
+def data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/drivaernet/")
 
 
-@nfsdata_or_fail
 @import_or_fail(["vtk", "pyvista", "dgl"])
 @pytest.mark.parametrize("cache_graph", [True, False])
 def test_drivaernet_init(data_dir, cache_graph, tmp_path, pytestconfig):

--- a/test/datapipes/test_healpix.py
+++ b/test/datapipes/test_healpix.py
@@ -20,7 +20,7 @@ import warnings
 from pathlib import Path
 
 import pytest
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
@@ -32,9 +32,8 @@ xr = pytest.importorskip("xarray")
 
 
 @pytest.fixture
-def data_dir():
-    path = "/data/nfs/modulus-data/datasets/healpix/"
-    return path
+def data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/healpix")
 
 
 @pytest.fixture
@@ -44,9 +43,8 @@ def dataset_name():
 
 
 @pytest.fixture
-def create_path():
-    path = "/data/nfs/modulus-data/datasets/healpix/merge"
-    return path
+def create_path(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/healpix/merge")
 
 
 def delete_dataset(create_path, dataset_name):
@@ -94,7 +92,6 @@ def scaling_double_dict():
 
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
-@nfsdata_or_fail
 def test_open_time_series_on_the_fly(create_path, pytestconfig):
     from physicsnemo.datapipes.healpix.data_modules import (
         open_time_series_dataset_classic_on_the_fly,
@@ -112,7 +109,7 @@ def test_open_time_series_on_the_fly(create_path, pytestconfig):
     assert isinstance(ds, xr.Dataset)
 
     test_var = variables[0]
-    base = xr.open_dataset(create_path + "/" + test_var + ".nc")
+    base = xr.open_dataset(str(create_path.joinpath(f"{test_var}.nc")))
     ds_var = ds.inputs.sel(channel_in=test_var)
 
     assert ds_var.equals(base[test_var])
@@ -121,7 +118,6 @@ def test_open_time_series_on_the_fly(create_path, pytestconfig):
 
 
 @import_or_fail("omegaconf")
-@nfsdata_or_fail
 def test_open_time_series(data_dir, dataset_name, pytestconfig):
     # check for failure of non-existant dataset
     from physicsnemo.datapipes.healpix.data_modules import (
@@ -139,7 +135,6 @@ def test_open_time_series(data_dir, dataset_name, pytestconfig):
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("numpy")
-@nfsdata_or_fail
 def test_create_time_series(data_dir, dataset_name, create_path, pytestconfig):
 
     from physicsnemo.datapipes.healpix.data_modules import (
@@ -162,7 +157,7 @@ def test_create_time_series(data_dir, dataset_name, create_path, pytestconfig):
     # create new dataset
     # open a base dataset to compare against
     test_var = list(scaling.keys())[0]
-    base = xr.open_dataset(create_path + "/" + test_var + ".nc")
+    base = xr.open_dataset(str(create_path.joinpath(f"{test_var}.nc")))
     # scale our test variable
     base[test_var] = np.log(base[test_var] + scaling[test_var]["log_epsilon"]) - np.log(
         scaling[test_var]["log_epsilon"]
@@ -185,7 +180,7 @@ def test_create_time_series(data_dir, dataset_name, create_path, pytestconfig):
 
     # and with constants
     const = list(constants.keys())[0]
-    const_ds = xr.open_dataset(create_path + "/" + const + ".nc")
+    const_ds = xr.open_dataset(str(create_path.joinpath(f"{const}.nc")))
     ds = create_time_series_dataset_classic(
         src_directory=create_path,
         dst_directory=create_path,
@@ -204,7 +199,6 @@ def test_create_time_series(data_dir, dataset_name, create_path, pytestconfig):
 
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
-@nfsdata_or_fail
 def test_TimeSeriesDataset_initialization(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
@@ -302,7 +296,6 @@ def test_TimeSeriesDataset_initialization(
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("numpy")
-@nfsdata_or_fail
 def test_TimeSeriesDataset_get_constants(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
@@ -329,7 +322,6 @@ def test_TimeSeriesDataset_get_constants(
 
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
-@nfsdata_or_fail
 def test_TimeSeriesDataset_len(data_dir, dataset_name, scaling_dict, pytestconfig):
     from physicsnemo.datapipes.healpix.timeseries_dataset import TimeSeriesDataset
 
@@ -374,7 +366,6 @@ def test_TimeSeriesDataset_len(data_dir, dataset_name, scaling_dict, pytestconfi
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("numpy")
-@nfsdata_or_fail
 def test_TimeSeriesDataset_get(
     data_dir, dataset_name, scaling_double_dict, pytestconfig
 ):
@@ -484,7 +475,6 @@ def test_TimeSeriesDataset_get(
 
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
-@nfsdata_or_fail
 def test_TimeSeriesDataModule_initialization(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
@@ -573,7 +563,6 @@ def test_TimeSeriesDataModule_initialization(
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("numpy")
-@nfsdata_or_fail
 def test_TimeSeriesDataModule_get_constants(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
@@ -651,7 +640,6 @@ def test_TimeSeriesDataModule_get_constants(
 
 
 @import_or_fail("omegaconf")
-@nfsdata_or_fail
 def test_TimeSeriesDataModule_get_dataloaders(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):

--- a/test/datapipes/test_healpix_couple.py
+++ b/test/datapipes/test_healpix_couple.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 import torch as th
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
@@ -35,9 +35,8 @@ xr = pytest.importorskip("xarray")
 
 
 @pytest.fixture
-def data_dir():
-    path = "/data/nfs/modulus-data/datasets/healpix/"
-    return path
+def data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/healpix")
 
 
 @pytest.fixture
@@ -47,9 +46,8 @@ def dataset_name():
 
 
 @pytest.fixture
-def create_path():
-    path = "/data/nfs/modulus-data/datasets/healpix/merge"
-    return path
+def create_path(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/healpix/merge")
 
 
 @dataclass
@@ -107,7 +105,6 @@ def scaling_double_dict():
 @import_or_fail("netCDF4")
 @import_or_fail("pandas")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_ConstantCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
 
     from physicsnemo.datapipes.healpix.couplers import (
@@ -243,9 +240,7 @@ def test_ConstantCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
 @import_or_fail("netCDF4")
 @import_or_fail("pandas")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_TrailingAverageCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
-
     from physicsnemo.datapipes.healpix.couplers import (
         TrailingAverageCoupler,
     )
@@ -409,7 +404,6 @@ def test_TrailingAverageCoupler(data_dir, dataset_name, scaling_dict, pytestconf
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_initialization(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
@@ -521,7 +515,6 @@ def test_CoupledTimeSeriesDataset_initialization(
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_get_constants(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
@@ -572,7 +565,6 @@ def test_CoupledTimeSeriesDataset_get_constants(
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_len(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
@@ -660,7 +652,6 @@ def test_CoupledTimeSeriesDataset_len(
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_get(
     data_dir, dataset_name, scaling_double_dict, pytestconfig
 ):
@@ -836,7 +827,6 @@ def test_CoupledTimeSeriesDataset_get(
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataModule_initialization(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
@@ -946,7 +936,6 @@ def test_CoupledTimeSeriesDataModule_initialization(
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataModule_get_constants(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
@@ -1043,7 +1032,6 @@ def test_CoupledTimeSeriesDataModule_get_constants(
 
 
 @import_or_fail("omegaconf")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataModule_get_dataloaders(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
@@ -1121,7 +1109,6 @@ def test_CoupledTimeSeriesDataModule_get_dataloaders(
 
 
 @import_or_fail("omegaconf")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataModule_get_coupled_vars(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
@@ -1203,7 +1190,6 @@ def test_CoupledTimeSeriesDataModule_get_coupled_vars(
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @import_or_fail("xarray")
-@nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_next_integration(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):

--- a/test/datapipes/test_lagrangian.py
+++ b/test/datapipes/test_lagrangian.py
@@ -16,7 +16,7 @@
 
 import pytest
 import torch
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 
 from . import common
 
@@ -27,11 +27,10 @@ Tensor = torch.Tensor
 
 
 @pytest.fixture
-def data_dir():
-    return "/data/nfs/modulus-data/datasets/water"
+def data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/water")
 
 
-@nfsdata_or_fail
 @import_or_fail(["tensorflow", "dgl"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_lagrangian_dataset_constructor(data_dir, device, pytestconfig):

--- a/test/datapipes/test_mesh_datapipe.py
+++ b/test/datapipes/test_mesh_datapipe.py
@@ -20,13 +20,10 @@ import random
 import pytest
 from pytest_utils import import_or_fail
 
-# from pytest_utils import nfsdata_or_fail
-
 
 @pytest.fixture
-def cgns_data_dir():
-    path = "/data/nfs/modulus-data/datasets/sample_formats/"
-    return path
+def cgns_data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/sample_formats")
 
 
 @import_or_fail(["vtk", "warp"])
@@ -156,7 +153,6 @@ def test_mesh_datapipe(device, tmp_path, pytestconfig):
         assert data[0]["x"].shape == (1, 10, 1)
 
 
-# @nfsdata_or_fail
 # @import_or_fail(["vtk"])
 # @pytest.mark.parametrize("device", ["cuda", "cpu"])
 # def test_mesh_datapipe_cgns(device, cgns_data_dir, pytestconfig):

--- a/test/datapipes/test_stokes.py
+++ b/test/datapipes/test_stokes.py
@@ -16,7 +16,7 @@
 
 import pytest
 import torch
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 
 from . import common
 
@@ -24,16 +24,13 @@ Tensor = torch.Tensor
 
 
 @pytest.fixture
-def data_dir():
-    path = "/data/nfs/modulus-data/datasets/stokes/"
-    return path
+def data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/stokes")
 
 
-@nfsdata_or_fail
 @import_or_fail(["vtk", "pyvista", "dgl"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_stokes_constructor(data_dir, device, pytestconfig):
-    # _nfsdata_or_fail(pytestconfig)
     from physicsnemo.datapipes.gnn.stokes_dataset import StokesDataset
 
     # construct dataset

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -21,7 +21,7 @@ from typing import Sequence
 import numpy as np
 import pytest
 import torch
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 
 from physicsnemo.metrics.climate.healpix_loss import (
     BaseMSE,
@@ -228,9 +228,8 @@ def test_WeightedMSE(device, test_data, rtol: float = 1e-3, atol: float = 1e-3):
 
 
 @pytest.fixture
-def data_dir():
-    path = "/data/nfs/modulus-data/datasets/healpix/"
-    return path
+def data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/healpix/")
 
 
 @pytest.fixture
@@ -239,7 +238,6 @@ def dataset_name():
     return name
 
 
-@nfsdata_or_fail
 @import_or_fail("xarray")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_OceanMSE(
@@ -319,7 +317,6 @@ def test_OceanMSE(
     )
 
 
-@nfsdata_or_fail
 @import_or_fail("xarray")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_WeightedOceanMSE(

--- a/test/models/meshgraphnet/test_bsms_mgn.py
+++ b/test/models/meshgraphnet/test_bsms_mgn.py
@@ -17,15 +17,14 @@
 import pytest
 import torch
 from models.common import validate_forward_accuracy
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 
 dgl = pytest.importorskip("dgl")
 
 
 @pytest.fixture
-def ahmed_data_dir():
-    path = "/data/nfs/modulus-data/datasets/ahmed_body/"
-    return path
+def ahmed_data_dir(nfs_data_dir):
+    return nfs_data_dir.joinpath("datasets/ahmed_body")
 
 
 @import_or_fail(["sparse_dot_mkl", "dgl"])
@@ -89,7 +88,6 @@ def test_bsms_mgn_forward(pytestconfig, device):
     )
 
 
-@nfsdata_or_fail
 @import_or_fail(["sparse_dot_mkl", "dgl"])
 def test_bsms_mgn_ahmed(pytestconfig, ahmed_data_dir):
     from physicsnemo.datapipes.gnn.ahmed_body_dataset import AhmedBodyDataset

--- a/test/models/test_fcn_mip_plugin.py
+++ b/test/models/test_fcn_mip_plugin.py
@@ -22,18 +22,16 @@ import shutil
 import numpy as np
 import pytest
 import torch
-from pytest_utils import import_or_fail, nfsdata_or_fail
+from pytest_utils import import_or_fail
 
 from physicsnemo.models.dlwp import DLWP
 from physicsnemo.utils.filesystem import Package
 
 
 @pytest.fixture
-def dlwp_data_dir():
+def dlwp_data_dir(nfs_data_dir):
     """Data dir for dlwp package"""
-
-    path = "/data/nfs/modulus-data/plugin_data/dlwp/"
-    return path
+    return nfs_data_dir.joinpath("plugin_data/dlwp/")
 
 
 def _copy_directory(src, dst):
@@ -106,7 +104,6 @@ def save_checkpoint(model, check_point_path, del_device_buffer=False):
 #     return package
 
 
-# @nfsdata_or_fail
 # @import_or_fail(["dgl", "ruamel.yaml", "tensorly", "torch_harmonics", "tltorch"])
 # def test_sfno(tmp_path, pytestconfig):
 #     """Test SFNO plugin"""
@@ -148,17 +145,15 @@ def save_untrained_dlwp(path):
     return package
 
 
-@nfsdata_or_fail
 @import_or_fail(["dgl", "ruamel.yaml", "tensorly", "torch_harmonics", "tltorch"])
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
-def test_dlwp(tmp_path, batch_size, device, pytestconfig):
+def test_dlwp(tmp_path, batch_size, device, dlwp_data_dir, pytestconfig):
 
     from physicsnemo.models.fcn_mip_plugin import dlwp
 
     package = save_untrained_dlwp(tmp_path)
-    source_dir = "/data/nfs/modulus-data/plugin_data/dlwp/"
-    _copy_directory(source_dir, tmp_path)
+    _copy_directory(dlwp_data_dir, tmp_path)
 
     model = dlwp(package, pretrained=True).to(device)
     x = torch.ones(batch_size, 2, 7, 721, 1440).to(device)
@@ -168,7 +163,6 @@ def test_dlwp(tmp_path, batch_size, device, pytestconfig):
     assert out.shape == x.shape
 
 
-@nfsdata_or_fail
 @import_or_fail(["dgl", "ruamel.yaml", "tensorly", "torch_harmonics", "tltorch"])
 @pytest.mark.parametrize("batch_size", [1, 2])
 def test__CozZenWrapper(batch_size, pytestconfig):

--- a/test/models/test_unet.py
+++ b/test/models/test_unet.py
@@ -18,15 +18,17 @@ import random
 
 import pytest
 import torch
-
-from physicsnemo.models.unet import UNet
+from pytest_utils import import_or_fail
 
 from . import common
 
 
+@import_or_fail(["transformer_engine"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_unet_forward(device):
+def test_unet_forward(device, pytestconfig):
     """Test unet forward pass"""
+    from physicsnemo.models.unet import UNet
+
     torch.manual_seed(0)
     # Construct unet3d model
     model = UNet(
@@ -42,9 +44,12 @@ def test_unet_forward(device):
     assert common.validate_forward_accuracy(model, (invar,))
 
 
+@import_or_fail(["transformer_engine"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_unet_constructor(device):
+def test_unet_constructor(device, pytestconfig):
     """Test unet constructor options"""
+    from physicsnemo.models.unet import UNet
+
     # Define dictionary of constructor args
     for depth in [2, 3]:
         if depth == 2:

--- a/test/pytest_utils.py
+++ b/test/pytest_utils.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import importlib
-import os
 from functools import wraps
 
 import pytest
@@ -87,25 +86,3 @@ def _import_or_fail(module_names, config, min_versions=None):
                             )
             except ModuleNotFoundError:
                 pytest.importorskip(module_name, min_version)
-
-
-def nfsdata_or_fail(test_func):
-    @pytest.mark.usefixtures("pytestconfig")
-    @wraps(test_func)
-    def wrapper(*args, **kwargs):
-        pytestconfig = kwargs.get("pytestconfig")
-        if pytestconfig is None:
-            raise ValueError(
-                "pytestconfig must be passed as an argument when using the nfsdata_required_decorator."
-            )
-        _nfsdata_or_fail(pytestconfig)
-        return test_func(*args, **kwargs)
-
-    return wrapper
-
-
-def _nfsdata_or_fail(config):
-    if not os.path.exists("/data/nfs/modulus-data"):
-        pytest.skip(
-            "NFS volumes not set up with CI data repo. Run `make get-data` from the root directory of the repo"
-        )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Some of the unit tests require test data, currently it's hardcoded to `/data/nfs/modulus-data` and defined in a few places independently. `@nfsdata_or_fail` decorator is used to check if the expected path is present on the system and marks test as skipped if it needs data, but it is not there.
The problem with that approach is that you need root permissions to be able to create this `/data` folder on the system.
We should be more flexible and allow user to override that default path if needed.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->