### PR TITLE
Adding abokov-nv to authorized users to trigger blossom-ci.yml

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -61,7 +61,8 @@ jobs:
            github.actor == 'hakhondzadeh' ||
            github.actor == 'peterdsharpe' ||
            github.actor == 'coreyjadams' ||
-           github.actor == 'CharlelieLrt'
+           github.actor == 'CharlelieLrt' ||
+           github.actor == 'abokov-nv'
          )  
     steps:
       - name: Check if comment is issued by authorized person


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Adding abokov-nv to authorized users to trigger blossom-ci.yml

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->