### PR TITLE
Creating an error when a SLURM variable isn't found, usually because …

### DIFF
--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -356,7 +356,11 @@ class DistributedManager(object):
         rank = int(os.environ.get("SLURM_PROCID"))
         world_size = int(os.environ.get("SLURM_NPROCS"))
         local_rank = int(os.environ.get("SLURM_LOCALID"))
-        addr = os.environ.get("SLURM_LAUNCH_NODE_IPADDR")
+        try:
+            addr = os.environ.get("SLURM_LAUNCH_NODE_IPADDR")
+        except TypeError:
+            raise EnvironmentError('SLURM variable "SLURM_LAUNCH_NODE_IPADDR" was not detected in the environment. Maybe you need to run with "srun"?')
+
 
         DistributedManager.setup(
             rank=rank,

--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -359,7 +359,10 @@ class DistributedManager(object):
         try:
             addr = os.environ.get("SLURM_LAUNCH_NODE_IPADDR")
         except TypeError:
-            raise EnvironmentError('SLURM variable "SLURM_LAUNCH_NODE_IPADDR" was not detected in the environment. Maybe you need to run with "srun"?')
+            raise EnvironmentError(
+                'SLURM variable "SLURM_LAUNCH_NODE_IPADDR" was not detected in the environment. Maybe you need to run with "srun"?'
+            )
+
 
 
         DistributedManager.setup(


### PR DESCRIPTION
Raising an environment error when the variable `SLURM_LAUNCH_NODE_IPADDR` is not found. This is usually because the user isn't running `SLURM` with `srun`, and instead using something like `sbatch`. So, instead of raising a `TypeError`, this will now raise an `EnvironmentError` and print some help.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
- Line 359 of `physicsnemo.distributed.manager` now has a `try: ... except TypeError:` statement.
- Addresses issue #819 

## Checklist

- [ x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ x] New or existing tests cover these changes.
- [ x] The documentation is up to date with these changes.
- [ x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

N/A