### PR TITLE
CorrDiff: inference bugfixes, cleanup, and documentation improvements

### DIFF
--- a/examples/generative/corrdiff/README.md
+++ b/examples/generative/corrdiff/README.md
@@ -505,7 +505,7 @@ The generated samples are saved in a NetCDF file with three main components:
 <img src="../../../docs/img/corrdiff_training_loss.png"/>
 </p>
 
-1. **Which hyperparameters are most important?**  
+6. **Which hyperparameters are most important?**  
    One of the most crucial hyperparameters is the patch size for a patch-based
    diffusion model (`patch_shape_x` and `patch_shape_y` in the configuration file). A larger
    patch size increases computational cost and GPU memory requirements, while a
@@ -527,6 +527,36 @@ The generated samples are saved in a NetCDF file with three main components:
    - Batch size per GPU (`training.hp.batch_size_per_gpu`): Number of samples
      processed in parallel on each GPU. It needs to be reduced if you encounter
      an out-of-memory error.
+
+7. **How do I set up validation during training?**  
+   CorrDiff supports validation during training through its configuration system. The validation approach is based on a separate validation configuration that inherits from and selectively overrides the training dataset settings.
+
+   **Configuration Example**:
+   ```yaml
+   # Training dataset configuration
+   dataset:
+     data_path: </path/to/training/data>
+     stats_path: </path/to/statistics.json>
+     output_variables: ["temperature", "humidity", "wind_speed"]
+     # Other dataset parameters...
+   
+   # Validation dataset configuration (optional)
+   validation:
+     data_path: </path/to/validation/data>  # Override training data path 
+     # All other parameters not specified here are inherited from the dataset section
+   ```
+
+   You only need to specify the parameters you want to override in the `validation` section. All other parameters will be inherited from the main `dataset` configuration. Common overrides include:
+   - Different data path for a separate validation set
+   - Smaller subset of variables to validate on
+   - Different time periods or spatial regions
+
+   **Implementation Note**: When a `validation` section is present in the
+   configuration, the training script automatically sets up a validation
+   dataset and periodically evaluates model performance against it. The
+   validation loss is logged by our built-in loggers and to Weights & Biases (if enabled).
+
+   **Early Stopping**: CorrDiff does not currently include built-in configurable early stopping. However, the training script saves multiple checkpoints throughout training and logs the associated validation losses. You can analyze these metrics after training to identify the optimal checkpoint with the lowest validation loss, effectively implementing a form of post-training early stopping.
 
 
 ## References

--- a/examples/generative/corrdiff/datasets/__init__.py
+++ b/examples/generative/corrdiff/datasets/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/generative/corrdiff/datasets/dataset.py
+++ b/examples/generative/corrdiff/datasets/dataset.py
@@ -93,7 +93,7 @@ def init_train_valid_datasets_from_config(
     batch_size: int = 1,
     seed: int = 0,
     validation_dataset_cfg: Union[dict, None] = None,
-    train_test_split: bool = True,
+    validation: bool = True,
 ) -> Tuple[
     base.DownscalingDataset,
     Iterable,
@@ -108,17 +108,17 @@ def init_train_valid_datasets_from_config(
     - dataloader_cfg (dict, optional): Configuration for the dataloader. Defaults to None.
     - batch_size (int): The number of samples in each batch of data. Defaults to 1.
     - seed (int): The random seed for dataset shuffling. Defaults to 0.
-    - train_test_split (bool): A flag to determine whether to create a validation dataset. Defaults to True.
+    - validation (bool): A flag to determine whether to create a validation dataset. Defaults to True.
 
     Returns:
-    - Tuple[base.DownscalingDataset, Iterable, Optional[base.DownscalingDataset], Optional[Iterable]]: A tuple containing the training dataset and iterator, and optionally the validation dataset and iterator if train_test_split is True.
+    - Tuple[base.DownscalingDataset, Iterable, Optional[base.DownscalingDataset], Optional[Iterable]]: A tuple containing the training dataset and iterator, and optionally the validation dataset and iterator if `validation` is True.
     """
 
     config = copy.deepcopy(dataset_cfg)
     (dataset, dataset_iter) = init_dataset_from_config(
         config, dataloader_cfg, batch_size=batch_size, seed=seed
     )
-    if train_test_split:
+    if validation:
         valid_dataset_cfg = copy.deepcopy(config)
         if validation_dataset_cfg:
             valid_dataset_cfg.update(validation_dataset_cfg)
@@ -139,9 +139,9 @@ def init_dataset_from_config(
 ) -> Tuple[base.DownscalingDataset, Iterable]:
     dataset_cfg = copy.deepcopy(dataset_cfg)
     dataset_type = dataset_cfg.pop("type", "cwb")
-    if "train_test_split" in dataset_cfg:
+    if "validation" in dataset_cfg:
         # handled by init_train_valid_datasets_from_config
-        del dataset_cfg["train_test_split"]
+        del dataset_cfg["validation"]
     dataset_init_func = known_datasets[dataset_type]
 
     dataset_obj = dataset_init_func(**dataset_cfg)

--- a/examples/generative/corrdiff/generate.py
+++ b/examples/generative/corrdiff/generate.py
@@ -142,6 +142,9 @@ def main(cfg: DictConfig) -> None:
         net_res = net_res.eval().to(device).to(memory_format=torch.channels_last)
         if cfg.generation.perf.force_fp16:
             net_res.use_fp16 = True
+        # Disable AMP for inference (even if model is trained with AMP)
+        if hasattr(net_res, "amp_mode"):
+            net_res.amp_mode = False
     else:
         net_res = None
 
@@ -153,6 +156,9 @@ def main(cfg: DictConfig) -> None:
         net_reg = net_reg.eval().to(device).to(memory_format=torch.channels_last)
         if cfg.generation.perf.force_fp16:
             net_reg.use_fp16 = True
+        # Disable AMP for inference (even if model is trained with AMP)
+        if hasattr(net_reg, "amp_mode"):
+            net_reg.amp_mode = False
     else:
         net_reg = None
 

--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -93,6 +93,13 @@ def cuda_profiler_stop():
         torch.cuda.profiler.stop()
 
 
+def profiler_emit_nvtx():
+    try:
+        return torch.autograd.profiler.emit_nvtx()
+    except (ImportError, AttributeError):
+        return nullcontext()
+
+
 # Train the CorrDiff model using the configurations in "conf/config_training.yaml"
 @hydra.main(version_base="1.2", config_path="conf", config_name="config_training")
 def main(cfg: DictConfig) -> None:
@@ -125,10 +132,10 @@ def main(cfg: DictConfig) -> None:
     logger0.info(f"Using dataset: {cfg.dataset.type}")
 
     if hasattr(cfg, "validation"):
-        train_test_split = True
+        validation = True
         validation_dataset_cfg = OmegaConf.to_container(cfg.validation)
     else:
-        train_test_split = False
+        validation = False
         validation_dataset_cfg = None
     fp_optimizations = cfg.training.perf.fp_optimizations
     songunet_checkpoint_level = cfg.training.perf.songunet_checkpoint_level
@@ -165,7 +172,7 @@ def main(cfg: DictConfig) -> None:
         batch_size=cfg.training.hp.batch_size_per_gpu,
         seed=0,
         validation_dataset_cfg=validation_dataset_cfg,
-        train_test_split=train_test_split,
+        validation=validation,
     )
 
     # Parse image configuration & update model args
@@ -219,7 +226,6 @@ def main(cfg: DictConfig) -> None:
     if hasattr(cfg.model, "model_args"):  # override defaults from config file
         model_args.update(OmegaConf.to_container(cfg.model.model_args))
 
-    optimization_mode = False
     use_torch_compile = False
     use_apex_gn = False
     profile_mode = False
@@ -441,7 +447,7 @@ def main(cfg: DictConfig) -> None:
 
     # enable profiler:
     with cuda_profiler():
-        with torch.autograd.profiler.emit_nvtx():
+        with profiler_emit_nvtx():
 
             while not done:
                 tick_start_nimg = cur_nimg

--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -21,6 +21,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.tensorboard import SummaryWriter
 import wandb
 from hydra.core.hydra_config import HydraConfig
+from contextlib import nullcontext
 
 from physicsnemo import Module
 from physicsnemo.models.diffusion import UNet, EDMPrecondSuperResolution
@@ -72,6 +73,24 @@ def checkpoint_list(path, suffix=".mdlus"):
     # Sort by index and return filenames
     checkpoints.sort(key=lambda x: x[0])
     return [file for _, file in checkpoints]
+
+
+# Define safe CUDA profiler tools that fallback to no-ops when CUDA is not available
+def cuda_profiler():
+    if torch.cuda.is_available():
+        return torch.cuda.profiler.profile()
+    else:
+        return nullcontext()
+
+
+def cuda_profiler_start():
+    if torch.cuda.is_available():
+        torch.cuda.profiler.start()
+
+
+def cuda_profiler_stop():
+    if torch.cuda.is_available():
+        torch.cuda.profiler.stop()
 
 
 # Train the CorrDiff model using the configurations in "conf/config_training.yaml"
@@ -421,7 +440,7 @@ def main(cfg: DictConfig) -> None:
         input_dtype = torch.float16
 
     # enable profiler:
-    with torch.cuda.profiler.profile():
+    with cuda_profiler():
         with torch.autograd.profiler.emit_nvtx():
 
             while not done:
@@ -430,11 +449,11 @@ def main(cfg: DictConfig) -> None:
 
                 if cur_nimg - start_nimg == 24 * cfg.training.hp.total_batch_size:
                     logger0.info(f"Starting Profiler at {cur_nimg}")
-                    torch.cuda.profiler.start()
+                    cuda_profiler_start()
 
                 if cur_nimg - start_nimg == 25 * cfg.training.hp.total_batch_size:
-                    logger0.info(f"Stoping Profiler at {cur_nimg}")
-                    torch.cuda.profiler.stop()
+                    logger0.info(f"Stopping Profiler at {cur_nimg}")
+                    cuda_profiler_stop()
 
                 with nvtx.annotate("Training iteration", color="green"):
                     # Compute & accumulate gradients

--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -94,9 +94,9 @@ def cuda_profiler_stop():
 
 
 def profiler_emit_nvtx():
-    try:
+    if torch.cuda.is_available():
         return torch.autograd.profiler.emit_nvtx()
-    except (ImportError, AttributeError):
+    else:
         return nullcontext()
 
 
@@ -724,14 +724,15 @@ def main(cfg: DictConfig) -> None:
                     fields += [
                         f"cpu_mem_gb {(psutil.Process(os.getpid()).memory_info().rss / 2**30):<6.2f}"
                     ]
-                    fields += [
-                        f"peak_gpu_mem_gb {(torch.cuda.max_memory_allocated(dist.device) / 2**30):<6.2f}"
-                    ]
-                    fields += [
-                        f"peak_gpu_mem_reserved_gb {(torch.cuda.max_memory_reserved(dist.device) / 2**30):<6.2f}"
-                    ]
+                    if torch.cuda.is_available():
+                        fields += [
+                            f"peak_gpu_mem_gb {(torch.cuda.max_memory_allocated(dist.device) / 2**30):<6.2f}"
+                        ]
+                        fields += [
+                            f"peak_gpu_mem_reserved_gb {(torch.cuda.max_memory_reserved(dist.device) / 2**30):<6.2f}"
+                        ]
+                        torch.cuda.reset_peak_memory_stats()
                     logger0.info(" ".join(fields))
-                    torch.cuda.reset_peak_memory_stats()
 
                 # Save checkpoints
                 if dist.world_size > 1:

--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -469,7 +469,7 @@ def main(cfg: DictConfig) -> None:
                         with nvtx.annotate(
                             f"accumulation round {n_i}", color="Magenta"
                         ):
-                            with nvtx.annotate(f"loading data", color="green"):
+                            with nvtx.annotate("loading data", color="green"):
                                 img_clean, img_lr, *lead_time_label = next(
                                     dataset_iterator
                                 )
@@ -570,7 +570,7 @@ def main(cfg: DictConfig) -> None:
                         n_average_loss_running_mean = 1
 
                     # Update weights.
-                    with nvtx.annotate(f"update weights", color="blue"):
+                    with nvtx.annotate("update weights", color="blue"):
                         lr_rampup = (
                             cfg.training.hp.lr_rampup
                         )  # ramp up the learning rate

--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -520,9 +520,8 @@ def main(cfg: DictConfig) -> None:
 
                             for patch_num_per_iter in patch_nums_iter:
                                 if patching is not None:
-                                    patching.set_patch_sum(patch_num_per_iter)
+                                    patching.set_patch_num(patch_num_per_iter)
                                     loss_fn_kwargs.update({"patching": patching})
-                                # pdb.set_trace()
                                 with nvtx.annotate(f"loss forward", color="green"):
                                     with torch.autocast(
                                         "cuda", dtype=amp_dtype, enabled=enable_amp
@@ -665,11 +664,10 @@ def main(cfg: DictConfig) -> None:
 
                                     for patch_num_per_iter in patch_nums_iter:
                                         if patching is not None:
-                                            patching.set_patch_sum(patch_num_per_iter)
+                                            patching.set_patch_num(patch_num_per_iter)
                                             loss_fn_kwargs.update(
                                                 {"patching": patching}
                                             )
-                                        # pdb.set_trace()
                                         with torch.autocast(
                                             "cuda", dtype=amp_dtype, enabled=enable_amp
                                         ):

--- a/physicsnemo/metrics/diffusion/loss.py
+++ b/physicsnemo/metrics/diffusion/loss.py
@@ -647,10 +647,6 @@ class ResidualLoss:
                 f"Batch size, height and width must match."
             )
 
-        rnd_normal = torch.randn([img_clean.shape[0], 1, 1, 1], device=img_clean.device)
-        sigma = (rnd_normal * self.P_std + self.P_mean).exp()
-        weight = (sigma**2 + self.sigma_data**2) / (sigma * self.sigma_data) ** 2
-
         # augment for conditional generation
         img_tot = torch.cat((img_clean, img_lr), dim=1)
         y_tot, augment_labels = (
@@ -680,7 +676,7 @@ class ResidualLoss:
                     )
                 self.y_mean = y_mean
 
-        # if on full domain:
+        # if on full domain, or if using patching without multi-iterations
         else:
             # form residual
             if lead_time_label is not None:
@@ -731,10 +727,11 @@ class ResidualLoss:
                 latent,
                 y_lr,
                 sigma,
-                embedding_selector=None,
-                global_index=patching.global_index(batch_size, img_clean.device)
-                if patching is not None
-                else None,
+                global_index=(
+                    patching.global_index(batch_size, img_clean.device)
+                    if patching is not None
+                    else None
+                ),
                 lead_time_label=lead_time_label,
                 augment_labels=augment_labels,
             )
@@ -743,10 +740,11 @@ class ResidualLoss:
                 latent,
                 y_lr,
                 sigma,
-                embedding_selector=None,
-                global_index=patching.global_index(batch_size, img_clean.device)
-                if patching is not None
-                else None,
+                global_index=(
+                    patching.global_index(batch_size, img_clean.device)
+                    if patching is not None
+                    else None
+                ),
                 augment_labels=augment_labels,
             )
         loss = weight * ((D_yn - y) ** 2)

--- a/physicsnemo/utils/patching.py
+++ b/physicsnemo/utils/patching.py
@@ -219,7 +219,7 @@ class RandomPatching2D(BasePatching2D):
         """
         return self._patch_num
 
-    def set_patch_sum(self, value: int) -> None:
+    def set_patch_num(self, value: int) -> None:
         """
         Set the number of patches to extract and reset patch indices.
         This is the only way to modify the patch_num value.


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
This PR addresses multiple bugs related to CorrDiff training and inference:
- It improves clarity regarding (cross-)validation through documentation and variable renaming.
- It removes duplicate code from `ResidualLoss`
- Automatically disables AMP for inference in `generate.py` (bug reported in #874).
- Implements no-ops fallbacks for profiling tools when torch is built without cuda support (useful to run hrrr-mini on CPU)

Closes #860.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

None.