### PR TITLE
Update msc test with import_or_skip decorator

### DIFF
--- a/test/utils/test_checkpoint.py
+++ b/test/utils/test_checkpoint.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ruff: noqa: F401
 
 import os
 import shutil
@@ -28,7 +29,8 @@ from pytest_utils import import_or_fail
 from physicsnemo.distributed import DistributedManager
 from physicsnemo.models.mlp import FullyConnected
 
-mock_aws = pytest.importorskip("moto.mock_aws")    
+mock_aws = pytest.importorskip("moto.mock_aws")
+
 
 @pytest.fixture(params=["./checkpoints", "msc://checkpoint-test/checkpoints"])
 def checkpoint_folder(request) -> str:
@@ -75,6 +77,7 @@ def test_model_checkpointing(
 
     import boto3
     from moto import mock_aws
+
     from physicsnemo.launch.utils import load_checkpoint, save_checkpoint
 
     # Set up the mock with IAM credentials for access. These should match those in

--- a/test/utils/test_checkpoint.py
+++ b/test/utils/test_checkpoint.py
@@ -19,17 +19,16 @@ import shutil
 from pathlib import Path
 from typing import Callable
 
-import boto3
 import fsspec
 import pytest
 import torch
 import torch.nn as nn
-from moto import mock_aws
 from pytest_utils import import_or_fail
 
 from physicsnemo.distributed import DistributedManager
 from physicsnemo.models.mlp import FullyConnected
 
+mock_aws = pytest.importorskip("moto.mock_aws")    
 
 @pytest.fixture(params=["./checkpoints", "msc://checkpoint-test/checkpoints"])
 def checkpoint_folder(request) -> str:
@@ -62,7 +61,7 @@ def model_generator(request) -> Callable:
 
 
 @mock_aws
-@import_or_fail(["wandb", "mlflow"])
+@import_or_fail(["wandb", "mlflow", "boto3"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_model_checkpointing(
     device,
@@ -74,6 +73,8 @@ def test_model_checkpointing(
 ):
     """Test checkpointing util for model"""
 
+    import boto3
+    from moto import mock_aws
     from physicsnemo.launch.utils import load_checkpoint, save_checkpoint
 
     # Set up the mock with IAM credentials for access. These should match those in

--- a/test/utils/test_msc_public_read.py
+++ b/test/utils/test_msc_public_read.py
@@ -24,7 +24,7 @@ from pytest_utils import import_or_fail
 
 # Verifies that a Zarr file in a publicly accessible S3 bucket can be read using MSC (Multi-Storage Client).
 # See the [Multi-Storage Client README](/examples/multi_storage_client/README.md) for further information.
-@import_or_fail(["multi-storage-client"])
+@import_or_fail(["multistorageclient"])
 def test_msc_read(pytestconfig):
 
     # Point at the MSC config file which specifies access information for the S3 bucket

--- a/test/utils/test_msc_public_read.py
+++ b/test/utils/test_msc_public_read.py
@@ -17,9 +17,9 @@
 
 import os
 from pathlib import Path
-from pytest_utils import import_or_fail
 
 import zarr
+from pytest_utils import import_or_fail
 
 
 # Verifies that a Zarr file in a publicly accessible S3 bucket can be read using MSC (Multi-Storage Client).

--- a/test/utils/test_msc_public_read.py
+++ b/test/utils/test_msc_public_read.py
@@ -17,13 +17,15 @@
 
 import os
 from pathlib import Path
+from pytest_utils import import_or_fail
 
 import zarr
 
 
 # Verifies that a Zarr file in a publicly accessible S3 bucket can be read using MSC (Multi-Storage Client).
 # See the [Multi-Storage Client README](/examples/multi_storage_client/README.md) for further information.
-def test_msc_read():
+@import_or_fail(["multi-storage-client"])
+def test_msc_read(pytestconfig):
 
     # Point at the MSC config file which specifies access information for the S3 bucket
     current_file = Path(__file__).resolve()


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Updating some tests to use the `import_or_fail` decorator. 

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->