### PR TITLE
Fix manager import with older pytorch (< 2.4.0)

### DIFF
--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -522,7 +522,7 @@ class DistributedManager(object):
 
     # Device mesh available in torch 2.4 or higher
     @require_version("torch", "2.4")
-    def get_mesh_group(self, mesh: dist.DeviceMesh) -> dist.ProcessGroup:
+    def get_mesh_group(self, mesh: "dist.DeviceMesh") -> dist.ProcessGroup:
         """
         Get the process group for a given mesh.
 


### PR DESCRIPTION
Wrap DeviceMesh in quotes for typing hint, to protect older torch versions from compatibility issues.

(The function is protected already, but the type annotation was using a type that didn't exist in older torch.)

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
closes #904 

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [X] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->