### PR TITLE
Fix broken image links in AGN example

### DIFF
--- a/examples/cfd/external_aerodynamics/aero_graph_net/README.md
+++ b/examples/cfd/external_aerodynamics/aero_graph_net/README.md
@@ -94,7 +94,7 @@ Output of the model are:
 
 ![Comparison between the AeroGraphNet prediction and the
 ground truth for surface pressure, wall shear stresses, and the drag coefficient for one
-of the samples from the test dataset.](../../../docs/img/ahmed_body_results.png)
+of the samples from the test dataset.](../../../../docs/img/ahmed_body_results.png)
 
 The input to the model is in form of a `.vtp` file and is then converted to
 bi-directional DGL graphs in the dataloader. The final results are also written in the
@@ -122,7 +122,7 @@ dataset caching (on by default) to speed up the subsequent data loading and trai
 
 ![Comparison between the AeroGraphNet prediction and the
 ground truth for surface pressure, wall shear stresses, and absolute error for one
-of the samples from the test dataset.](../../../docs/img/drivaernet_results.png)
+of the samples from the test dataset.](../../../../docs/img/drivaernet_results.png)
 
 ## Model training
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

Fixing image paths in README due to the previous change that pushed the example one level down the hierarchy.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->