### PR TITLE
feature: add support for lead-time aware regression model

### DIFF
--- a/examples/generative/corrdiff/conf/base/model/lt_aware_regression.yaml
+++ b/examples/generative/corrdiff/conf/base/model/lt_aware_regression.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: lt_aware_regression
+# Model type.
+hr_mean_conditioning: False
+# No high-res conditioning for regression.
+
+# Default model parameters.
+model_args:
+  N_grid_channels: 4
+  # Number of channels for positional grid embeddings
+  embedding_type: "zero"
+  # Type of timestep embedding: 'positional' for DDPM++, 'fourier' for NCSN++,
+  # 'zero' for none
+  lead_time_channels: 4
+  # Number of channels for lead-time embeddings
+  lead_time_steps: 9
+  # Number of lead-time steps
+  model_type: "SongUNetPosLtEmbd"
+  # Type of model architecture: 'SongUNetPosLtEmbd' for lead-time aware UNet with
+  # positional embeddings, 'SongUNetPosEmbd' for UNet with positional
+  # embeddings, 'SongUNet' for UNet without positional embeddings,
+  # 'DhariwalUNet' for UNet with Fourier embeddings. If not provided, default
+  # to 'SongUNetPosEmbd'.

--- a/examples/generative/corrdiff/conf/base/training/lt_aware_regression.yaml
+++ b/examples/generative/corrdiff/conf/base/training/lt_aware_regression.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+    - base_all
+
+# Hyperparameters
+hp:
+    training_duration: 200000000
+    # Training duration based on the number of processed samples
+    total_batch_size: 256
+    # Total batch size
+    batch_size_per_gpu: "auto"
+    # Batch size per GPU
+
+perf:
+    songunet_checkpoint_level: 0  # 0 means no checkpointing
+
+# I/O
+io:
+    print_progress_freq: 1000
+    # How often to print progress
+    save_checkpoint_freq: 5000
+    # How often to save the checkpoints, measured in number of processed samples 

--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -260,7 +260,7 @@ def main(cfg: DictConfig) -> None:
             img_in_channels=img_in_channels + model_args["N_grid_channels"],
             **model_args,
         )
-    elif cfg.model.name == "lt_aware_ce_regression":
+    elif cfg.model.name in {"lt_aware_ce_regression", "lt_aware_regression"}:
         model = UNet(
             img_in_channels=img_in_channels
             + model_args["N_grid_channels"]
@@ -294,7 +294,8 @@ def main(cfg: DictConfig) -> None:
 
     # Check if regression model is used with patching
     if (
-        cfg.model.name in ["regression", "lt_aware_ce_regression"]
+        cfg.model.name
+        in ["regression", "lt_aware_ce_regression", "lt_aware_regression"]
         and patching is not None
     ):
         raise ValueError(
@@ -417,7 +418,7 @@ def main(cfg: DictConfig) -> None:
             regression_net=regression_net,
             hr_mean_conditioning=cfg.model.hr_mean_conditioning,
         )
-    elif cfg.model.name == "regression":
+    elif cfg.model.name in {"regression", "lt_aware_regression"}:
         loss_fn = RegressionLoss()
     elif cfg.model.name == "lt_aware_ce_regression":
         loss_fn = RegressionLossCE(prob_channels=prob_channels)

--- a/physicsnemo/metrics/diffusion/loss.py
+++ b/physicsnemo/metrics/diffusion/loss.py
@@ -379,6 +379,7 @@ class RegressionLoss:
         net: torch.nn.Module,
         img_clean: torch.Tensor,
         img_lr: torch.Tensor,
+        lead_time_label: Optional[torch.Tensor] = None,
         augment_pipe: Optional[
             Callable[[torch.Tensor], Tuple[torch.Tensor, Optional[torch.Tensor]]]
         ] = None,
@@ -391,10 +392,11 @@ class RegressionLoss:
         ----------
         net : torch.nn.Module
             The neural network model that will make predictions.
-            Expected signature: `net(x, img_lr,
+            Expected signature: `net(x, img_lr, lead_time_label=lead_time_label,
             augment_labels=augment_labels, force_fp32=False)`, where:
                 x (torch.Tensor): Tensor of shape (B, C_hr, H, W). Is zero-filled.
                 img_lr (torch.Tensor): Low-resolution input of shape (B, C_lr, H, W)
+                lead_time_label (torch.Tensor, optional): Optional lead time labels
                 augment_labels (torch.Tensor, optional): Optional augmentation
                 labels, returned by `augment_pipe`.
                 force_fp32 (bool, optional): Whether to force the model to use
@@ -409,6 +411,10 @@ class RegressionLoss:
         img_lr : torch.Tensor
             Low-resolution input images of shape (B, C_lr, H, W).
             Used as input to the neural network.
+
+        lead_time_label : Optional[torch.Tensor], optional
+            Lead time labels for temporal predictions, by default None.
+            Shape can vary based on model requirements, typically (B,) or scalar.
 
         augment_pipe : callable, optional
             An optional data augmentation function.
@@ -441,7 +447,18 @@ class RegressionLoss:
         y_lr = y_tot[:, img_clean.shape[1] :, :, :]
 
         zero_input = torch.zeros_like(y, device=img_clean.device)
-        D_yn = net(zero_input, y_lr, force_fp32=False, augment_labels=augment_labels)
+        if lead_time_label is not None:
+            D_yn = net(
+                zero_input,
+                y_lr,
+                lead_time_label=lead_time_label,
+                force_fp32=False,
+                augment_labels=augment_labels,
+            )
+        else:
+            D_yn = net(
+                zero_input, y_lr, force_fp32=False, augment_labels=augment_labels
+            )
         loss = weight * ((D_yn - y) ** 2)
 
         return loss


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
This PR adds support for lead-time awareness in the standard regression model by introducing `lt_aware_regression`.
Closes https://github.com/NVIDIA/physicsnemo/issues/918

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

