### PR TITLE
Bug fix configure domino pipeline device

### DIFF
--- a/examples/cfd/external_aerodynamics/domino/src/conf/config.yaml
+++ b/examples/cfd/external_aerodynamics/domino/src/conf/config.yaml
@@ -72,6 +72,8 @@ data: # Input directory for training and validation data
   bounding_box_surface: # Bounding box dimensions for car surface
     min: [-1.1, -1.2 , -0.32]
     max: [4.5 , 1.2  , 1.2]
+  gpu_preprocessing: true
+  gpu_output: true
 
 # ┌───────────────────────────────────────────┐
 # │          Domain Parallelism Settings      │

--- a/physicsnemo/datapipes/cae/domino_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_datapipe.py
@@ -1013,6 +1013,7 @@ class DoMINODataPipe(Dataset):
                 if isinstance(value, torch.Tensor) and value.is_cuda:
                     return_dict[key] = value.cpu()
 
+
         return return_dict
 
 
@@ -1418,6 +1419,13 @@ def create_domino_dataset(
             surface_sampling_algorithm=cfg.model.surface_sampling_algorithm,
         )
     else:
+        overrides = {}
+        if hasattr(cfg.data, "gpu_preprocessing"):
+            overrides["gpu_preprocessing"] = cfg.data.gpu_preprocessing
+
+        if hasattr(cfg.data, "gpu_output"):
+            overrides["gpu_output"] = cfg.data.gpu_output
+
         return DoMINODataPipe(
             input_path,
             phase=phase,
@@ -1441,6 +1449,7 @@ def create_domino_dataset(
             resample_surfaces=cfg.model.resampling_surface_mesh.resample,
             resampling_points=cfg.model.resampling_surface_mesh.points,
             surface_sampling_algorithm=cfg.model.surface_sampling_algorithm,
+            **overrides,
         )
 
 

--- a/physicsnemo/datapipes/cae/domino_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_datapipe.py
@@ -1013,7 +1013,6 @@ class DoMINODataPipe(Dataset):
                 if isinstance(value, torch.Tensor) and value.is_cuda:
                     return_dict[key] = value.cpu()
 
-
         return return_dict
 
 

--- a/physicsnemo/datapipes/cae/domino_sharded_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_sharded_datapipe.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import torch
 from dataclasses import asdict
 
 from physicsnemo.utils.version_check import check_module_requirements
@@ -64,6 +65,9 @@ class ShardedDoMINODataPipe(DoMINODataPipe):
         shard_grid,
         **config_overrides,
     ):
+
+        # if 'gpu_output' not in config_overrides:
+        config_overrides['gpu_output'] = True
 
         # First, initialize the super class.
         super().__init__(
@@ -122,9 +126,10 @@ class ShardedDoMINODataPipe(DoMINODataPipe):
             Replicate(),
         ]
         for key, value in single_dict.items():
-            single_dict[key] = ShardTensor.from_local(
-                value, self.domain_mesh, default_placement
-            )
+            if isinstance(value, torch.Tensor):
+                single_dict[key] = ShardTensor.from_local(
+                    value, self.domain_mesh, default_placement
+                )
 
         # # Now, shard the data.
         sharding = [

--- a/physicsnemo/datapipes/cae/domino_sharded_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_sharded_datapipe.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
 from dataclasses import asdict
+
+import torch
 
 from physicsnemo.utils.version_check import check_module_requirements
 
@@ -67,7 +68,7 @@ class ShardedDoMINODataPipe(DoMINODataPipe):
     ):
 
         # if 'gpu_output' not in config_overrides:
-        config_overrides['gpu_output'] = True
+        config_overrides["gpu_output"] = True
 
         # First, initialize the super class.
         super().__init__(


### PR DESCRIPTION
This PR fixes a bug: it's difficult to configure the data processing path in domino.

Now, the yaml config can be used to direct the device used for preprocessing.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->