### PR TITLE
Modernize logger interface

### DIFF
--- a/test/datapipes/common/cuda_graphs.py
+++ b/test/datapipes/common/cuda_graphs.py
@@ -64,7 +64,7 @@ def check_cuda_graphs(
     iterations: int = 5,
     warmup_length: int = 3,
 ) -> bool:
-    """Tests if a datapipe is compatable with cuda graphs
+    """Tests if a datapipe is compatible with cuda graphs
 
     Parameters
     ----------
@@ -89,7 +89,7 @@ def check_cuda_graphs(
     one should use the `input_fn` to preprocess a batch to that form.
     """
     if not datapipe.meta.cuda_graphs:
-        logger.warn("Datapipe does not support cuda graphs, skipping")
+        logger.warning("Datapipe does not support cuda graphs, skipping")
         return True
 
     model = MiniNetwork().cuda()

--- a/test/utils/test_capture.py
+++ b/test/utils/test_capture.py
@@ -88,7 +88,7 @@ def test_capture_training(
         if optimizers:
             optim = optimizers.FusedAdam(model.parameters(), lr=0.001)
         else:
-            logger.warn("Apex not installed, skipping fused Adam tests")
+            logger.warning("Apex not installed, skipping fused Adam tests")
             return
 
     # Create training step function with optimization wrapper
@@ -152,7 +152,7 @@ def test_capture_training_meta(
         if optimizers:
             optim = optimizers.FusedAdam(model.parameters(), lr=0.001)
         else:
-            logger.warn("Apex not installed, skipping fused Adam tests")
+            logger.warning("Apex not installed, skipping fused Adam tests")
             return
 
     # Test control via meta data


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->