### PR TITLE
Fix dtype casting after unfold

### DIFF
--- a/physicsnemo/utils/patching.py
+++ b/physicsnemo/utils/patching.py
@@ -598,7 +598,7 @@ def image_batching(
             patch_shape_y - overlap_pix - boundary_pix,
             patch_shape_x - overlap_pix - boundary_pix,
         ),
-    ).to(input_padded.dtype)
+    ).view(input_padded.dtype)
     x_unfold = rearrange(
         x_unfold,
         "b (c p_h p_w) (nb_p_h nb_p_w) -> (nb_p_w nb_p_h b) c p_h p_w",


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
After unfold we need to undo the `view(dtype)` with another `view(...)` instead of a `.to`. For instance,
```
t = torch.arange(10)
t.view(torch.float64).to(t.dtype)
```
gives only zeros and this affected the computation of `global_index`.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->