### PR TITLE
Make NVIDIA Dali optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,14 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   support surface for `physicsnemo.distributed` functionality.
 - Merged SongUNetPosLtEmb with SongUNetPosEmb, add support for batch>1
 
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
 ### Dependencies
 
 - Made `nvidia.dali` an optional dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0a0] - 2025-05-XX
+## [1.1.0] - 2025-06-05
 
 ### Added
 
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Dependencies
+
+- Made `nvidia.dali` an optional dependency
 
 ## [1.0.1] - 2025-03-25
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN FILE="/etc/pip/constraint.txt" && \
     else \
         echo "File not found: $FILE"; \
     fi
+RUN pip install --no-cache-dir "nvidia_dali_cuda120>=1.35.0"
 RUN pip install --no-cache-dir "h5py>=3.7.0" "netcdf4>=1.6.3" "ruamel.yaml>=0.17.22" "scikit-learn>=1.0.2" "cftime>=1.6.2" "einops>=0.7.0"
 RUN pip install --no-cache-dir "hydra-core>=1.2.0" "termcolor>=2.1.1" "wandb>=0.13.7" "pydantic>=1.10.2" "imageio" "moviepy" "tqdm>=4.60.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "certifi>=2023.7.22",
     "fsspec>=2023.1.0",
     "numpy>=1.22.4",
-    "nvidia_dali_cuda120>=1.35.0",
     "onnx>=1.14.0",
     "packaging>=24.2",
     "s3fs>=2023.5.0",
@@ -85,6 +84,7 @@ shardtensor = [
 ]
 
 all = [
+    "nvidia_dali_cuda120>=1.35.0",
     "h5py>=3.7.0",
     "netcdf4>=1.6.3",
     "ruamel.yaml>=0.17.22",


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Make the dali package optional. 

This allows the following steps to run from the base install:
```
conda create --name custom-env python=3.12
conda activate custom-env
# install physicsnemo (will work for pypi after this release)
pip install .
# install example specific deps
pip install -r requirements.txt
# execute the example
python train_fno_darcy.py
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->