### PR TITLE
fix(deps): add torch-cluster and torch-scatter to pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2025-06-05
 
+### Dependencies
+- Added `torch-cluster` and `torch-scatter` to `pyproject.toml` under dependencies.
+
+[1.0.2] - 2025-06-14
+
 ### Added
 
 - Added ReGen score-based data assimilation example
@@ -390,3 +395,6 @@ weather models
 ### Added
 
 - Initial public release.
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "treelib>=1.2.5",
     "xarray>=2023.1.0",
     "zarr>=2.14.2",
+    "torch-cluster>=1.6.0",
+    "torch-scatter>=2.0.9",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -69,7 +71,7 @@ makani = [
 
 fignet = [
     "jaxtyping>=0.2",
-    "torch_scatter>=2.1",
+    "torch-scatter>=2.1",
     "torchinfo>=1.8",
     "warp-lang>=1.0",
     "webdataset>=0.2",


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->

# Fix: Add `torch-cluster` and `torch-scatter` dependencies for `mesh_reduced` model

The `mesh_reduced.py` model depends on `torch-cluster` and `torch-scatter` libraries, but these dependencies were not listed in `pyproject.toml`. This caused source-based installations and tests to fail since those packages were missing.

## Description
- Added `torch-cluster` and `torch-scatter` to `pyproject.toml` under dependencies.
- Verified the `vortex_shedding_mesh_reduced` example works end-to-end.
- Kept the `mesh_reduced.py` model and associated example intact as they are still used.

### Impact
This change resolves installation and test failures related to missing `torch-cluster` and `torch-scatter` dependencies and improves user experience for source installs.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo/issues/898) is linked to this pull request.

## Dependencies
- `torch-cluster`
- `torch-scatter`

<!-- Call out any new dependencies needed if any -->