### PR TITLE
Revert incorrect line in deterministic sampler (#974)

### DIFF
--- a/physicsnemo/utils/generative/deterministic_sampler.py
+++ b/physicsnemo/utils/generative/deterministic_sampler.py
@@ -334,8 +334,7 @@ def deterministic_sampler(
                 ).to(torch.float64)
             d_prime = (
                 sigma_deriv(t_prime) / sigma(t_prime) + s_deriv(t_prime) / s(t_prime)
-            ) * x_prime
-            -sigma_deriv(t_prime) * s(t_prime) / sigma(t_prime) * denoised
+            ) * x_prime - sigma_deriv(t_prime) * s(t_prime) / sigma(t_prime) * denoised
             x_next = x_hat + h * (
                 (1 - 1 / (2 * alpha)) * d_cur + 1 / (2 * alpha) * d_prime
             )


### PR DESCRIPTION
* Revert incorrect line in deterministic sampler

* minor version bump

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Rebase 1.1.1-rc branch

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->