### PR TITLE
Throw exception when directory not found

### DIFF
--- a/physicsnemo/utils/domino/utils.py
+++ b/physicsnemo/utils/domino/utils.py
@@ -356,7 +356,7 @@ def get_filenames(filepath: str, exclude_dirs: bool = False) -> List[str]:
             filenames.append(item)
         return filenames
     else:
-        FileNotFoundError()
+        raise FileNotFoundError()
 
 
 def calculate_pos_encoding(nx: ArrayType, d: int = 8) -> ArrayType:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
This small PR fixes the utils function `get_filenames` to throw an exception when directory not found.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->