### PR TITLE
[Minor] Profiling Cleanup

### DIFF
--- a/physicsnemo/utils/profiling/line_profile.py
+++ b/physicsnemo/utils/profiling/line_profile.py
@@ -89,7 +89,7 @@ class LineProfileWrapper(PhysicsNeMoProfilerWrapper, metaclass=_Profiler_Singlet
         # Get the output directory:
         out_top = self.output_dir(output_top)
         with open(out_top / Path("profiler_stats.txt"), "w") as stats:
-            self._profiler.print_stats(stream=stats)
+            self._profiler.print_stats(stream=stats, stripzeros=True)
 
         # Make this profiler completed:
         self.finalized = True


### PR DESCRIPTION
Reduce profiling output by not printing profiles for functions that don't get called.  

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->