### PR TITLE
Fix healpix test dataloader DistributedSampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments `profile_mode` and `amp_mode` cannot be overriden by
   `from_checkpoint`. They are now properties that can be dynamically changed
   *after* the model instantiation.
+- Updated healpix data module to use correct `DistributedSampler` target for
+  test data loader
 
 ### Deprecated
 

--- a/physicsnemo/datapipes/healpix/data_modules.py
+++ b/physicsnemo/datapipes/healpix/data_modules.py
@@ -776,7 +776,7 @@ class TimeSeriesDataModule:
         sampler = None
         if num_shards > 1:
             sampler = DistributedSampler(
-                self.val_dataset,
+                self.test_dataset,
                 num_replicas=num_shards,
                 rank=shard_id,
                 shuffle=False,


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Fixes #988, using the test dataset object to instantiate `DistributedSampler`. As far as I can tell none of the examples or current known use-cases are exposed to this issue due to not using the `test_dataloader` method in distributed mode, but good to fix in general.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->