### PR TITLE
Use earth2grid HEALPixPad kernels when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test data loader
 - Existing DGL-based vortex shedding example has been renamed to `vortex_shedding_mgn_dgl`.
   Added new `vortex_shedding_mgn` example that uses PyTorch Geometric instead.
+- HEALPixLayer can now use earth2grid HEALPix padding ops, if desired
 
 ### Deprecated
 

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
@@ -37,7 +37,6 @@ Details on the HEALPix can be found at https://iopscience.iop.org/article/10.108
 
 """
 
-import sys
 import warnings
 
 import torch

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
@@ -38,16 +38,16 @@ Details on the HEALPix can be found at https://iopscience.iop.org/article/10.108
 """
 
 import sys
+import warnings
 
 import torch
 import torch as th
 
-sys.path.append("/home/disk/quicksilver/nacc/dlesm/HealPixPad")
 have_healpixpad = True
 try:
-    from healpixpad import HEALPixPad
+    from earth2grid.healpix._padding import pad as hpx_pad
 except ImportError:
-    print("Warning, cannot find healpixpad module")
+    warnings.warn("Cannot find earth2grid HEALPix padding op, falling back to slower implementation. Install earth2grid to use faster implementation: https://github.com/NVlabs/earth2grid.git")
     have_healpixpad = False
 
 
@@ -151,7 +151,7 @@ class HEALPixPaddingv2(th.nn.Module):
         super().__init__()
         self.unfold = HEALPixUnfoldFaces(num_faces=12)
         self.fold = HEALPixFoldFaces()
-        self.padding = HEALPixPad(padding=padding)
+        self.padding = padding
 
     def forward(self, x):  # pragma: no cover
         """
@@ -171,7 +171,7 @@ class HEALPixPaddingv2(th.nn.Module):
         torch.cuda.nvtx.range_push("HEALPixPaddingv2:forward")
 
         x = self.unfold(x)
-        xp = self.padding(x)
+        xp = hpx_pad(x, self.padding)
         xp = self.fold(xp)
 
         torch.cuda.nvtx.range_pop()

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
@@ -46,7 +46,9 @@ have_healpixpad = True
 try:
     from earth2grid.healpix._padding import pad as hpx_pad
 except ImportError:
-    warnings.warn("Cannot find earth2grid HEALPix padding op, falling back to slower implementation. Install earth2grid to use faster implementation: https://github.com/NVlabs/earth2grid.git")
+    warnings.warn(
+        "Cannot find earth2grid HEALPix padding op, falling back to slower implementation. Install earth2grid to use faster implementation: https://github.com/NVlabs/earth2grid.git"
+    )
     have_healpixpad = False
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Adjusts `HEALPixLayer` to use the earth2grid padding kernels, if they are available, rather than a proprietary path that is not generally available. Will raise a warning if earth2grid is not found.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->