### PR TITLE
Refactor ReshapedLayerNorm to handle missing transformer_engine import gracefully

### DIFF
--- a/physicsnemo/models/unet/unet.py
+++ b/physicsnemo/models/unet/unet.py
@@ -21,14 +21,17 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
-from transformer_engine import pytorch as te
+
+try:
+    from transformer_engine import pytorch as te
+except ImportError:
+    te = None
 
 from physicsnemo.models.meta import ModelMetaData
 from physicsnemo.models.module import Module
 
 
-class ReshapedLayerNorm(te.LayerNorm):
-
+class ReshapedLayerNorm(te.LayerNorm if te else nn.LayerNorm):
     """
     A modified LayerNorm that reshapes and transposes the input tensor before
     applying layer normalization, then restores the original shape after normalization.


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

Fixes: https://github.com/NVIDIA/physicsnemo/issues/899

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->