### PR TITLE
Bumps Ruff from v0.0.290 to 0.12.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,9 +20,7 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix]
-        exclude: ^docs/
       - id: ruff-format
-        exclude: ^docs/|^physicsnemo/experimental/
 
 -   repo: https://github.com/econchick/interrogate
     rev: 1.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,14 @@
 # limitations under the License.
 
 repos:
--   repo: https://github.com/psf/black
-    rev: 22.10.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.5
     hooks:
-    - id: black
-      exclude: "(docs|physicsnemo/experimental)"
+      - id: ruff-check
+        args: [--fix]
+        exclude: ^docs/
+      - id: ruff-format
+        exclude: ^docs/|^physicsnemo/experimental/
 
 -   repo: https://github.com/econchick/interrogate
     rev: 1.7.0
@@ -31,7 +34,7 @@ repos:
           "--ignore-magic", "--fail-under=99", "--exclude=['setup.py', 'test', 'build', 'docs']",  
           "--ignore-regex=['forward', 'backward', 'reset_parameters', 'extra_repr', 'MetaData', 'apply_activation','exec_activation']", 
           "--color", "--"]
-      exclude: ^physicsnemo/internal/|^physicsnemo/experimental/|^docs/
+      exclude: ^docs/|^physicsnemo/experimental/
 
 -   repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.35.0
@@ -45,13 +48,6 @@ repos:
       entry: python test/ci_tests/header_check.py
       language: python
       pass_filenames: false
-
--   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.290
-    hooks:
-    - id: ruff
-      args: [--fix]
-      exclude: ^docs/
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   :warning: This is an experimental feature that can be accessed through the
   `physicsnemo.experimental` module; it might also be subjected to API changes
   without notice.
+- Bumped Ruff version from 0.0.290 to 0.12.5. Replaced Black with `ruff-format`.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,17 +148,16 @@ the commits will be checked for appropriate formatting.
 
 ### CI
 
-To ensure quality of the code, your merge request will pass through several CI checks.
+To ensure quality of the code, your merge request (MR) will pass through several CI checks.
 It is mandatory for your MRs to pass these pipelines to ensure a successful merge.
 Please keep checking this document for the latest guidelines on pushing code. Currently,
 The pipeline has following stages:
 
-1. `format`
-    *Pre-commit will check this for you!*
-    Checks for formatting of your python code.
-    Refer [black](https://black.readthedocs.io/en/stable/) for more information.
-    If your MR fails this test, run `black <script-name>.py` on problematic scripts and
-    black will take care of the rest.
+1. `format` 
+    *Pre-commit will check this for you!* Checks for formatting of your
+    Python code, using `ruff format` via [Ruff](https://docs.astral.sh/ruff/).
+    If your MR fails this test, run `ruff format <script-name>.py` on
+    problematic scripts and Ruff will take care of the rest.
 
 2. `interrogate`
    *Pre-commit will check this for you!*
@@ -194,13 +193,15 @@ The pipeline has following stages:
     ```
 
 3. `lint`
-    *Pre-commit will check this for you!*
-    Linters will perform static analysis to check the style, complexity, errors and more.
-    For markdown files `markdownlint` is used, its suggested to use the vscode,
-    neovim or sublime [extensions](https://github.com/DavidAnson/markdownlint#related).
-    PhysicsNeMo uses [Ruff](https://docs.astral.sh/ruff/) for linting of various types.
-    Currently we use flake8/pycodestyle (`E`), Pyflakes (`F`), flake8-bandit (`S`),
-    isort (`I`), and performance 'PERF' rules with the isort rules being fixable.
+    *Pre-commit will check this for you!* 
+    Linters will perform static analysis to check the style, complexity, errors
+    and more. For markdown files `markdownlint` is used, its suggested to use
+    the vscode, neovim or sublime
+    [extensions](https://github.com/DavidAnson/markdownlint#related).
+    PhysicsNeMo uses `ruff check` via[Ruff](https://docs.astral.sh/ruff/) for
+    linting of various types. Currently we use flake8/pycodestyle (`E`),
+    Pyflakes (`F`), flake8-bandit (`S`), isort (`I`), and performance 'PERF'
+    rules with the isort rules being fixable.
 
 4. `license`
     *Pre-commit will check this for you!*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ It is mandatory for your MRs to pass these pipelines to ensure a successful merg
 Please keep checking this document for the latest guidelines on pushing code. Currently,
 The pipeline has following stages:
 
-1. `format` 
+1. `format`
     *Pre-commit will check this for you!* Checks for formatting of your
     Python code, using `ruff format` via [Ruff](https://docs.astral.sh/ruff/).
     If your MR fails this test, run `ruff format <script-name>.py` on
@@ -193,7 +193,7 @@ The pipeline has following stages:
     ```
 
 3. `lint`
-    *Pre-commit will check this for you!* 
+    *Pre-commit will check this for you!*
     Linters will perform static analysis to check the style, complexity, errors
     and more. For markdown files `markdownlint` is used, its suggested to use
     the vscode, neovim or sublime

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,8 @@ The pipeline has following stages:
     PhysicsNeMo uses `ruff check` via[Ruff](https://docs.astral.sh/ruff/) for
     linting of various types. Currently we use flake8/pycodestyle (`E`),
     Pyflakes (`F`), flake8-bandit (`S`), isort (`I`), and performance 'PERF'
-    rules with the isort rules being fixable.
+    rules. Many rule violations will be automatically fixed by Ruff; others may
+    require manual changes.
 
 4. `license`
     *Pre-commit will check this for you!*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ pre-commit install
 Once the above commands are executed, the pre-commit hooks will be activated and all
 the commits will be checked for appropriate formatting.
 
-### CI
+### Continuous Integration (CI)
 
 To ensure quality of the code, your merge request (MR) will pass through several CI checks.
 It is mandatory for your MRs to pass these pipelines to ensure a successful merge.

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ setup-ci:
 	pre-commit install
 
 black:
-	pre-commit run black -a
+	pre-commit run ruff-format -a
 
 interrogate:
 	pre-commit run interrogate -a
 
 lint:
+	pre-commit run ruff-check -a && \
 	pre-commit run markdownlint -a && \
-	pre-commit run ruff -a && \
 	pre-commit run check-added-large-files -a
 
 license: 

--- a/physicsnemo/datapipes/cae/domino_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_datapipe.py
@@ -16,14 +16,14 @@
 
 """
 This code provides the datapipe for reading the processed npy files,
-generating multi-res grids, calculating signed distance fields, 
-positional encodings, sampling random points in the volume and on surface, 
+generating multi-res grids, calculating signed distance fields,
+positional encodings, sampling random points in the volume and on surface,
 normalizing fields and returning the output tensors as a dictionary.
 
-This datapipe also non-dimensionalizes the fields, so the order in which the variables should 
-be fixed: velocity, pressure, turbulent viscosity for volume variables and 
-pressure, wall-shear-stress for surface variables. The different parameters such as 
-variable names, domain resolution, sampling size etc. are configurable in config.yaml. 
+This datapipe also non-dimensionalizes the fields, so the order in which the variables should
+be fixed: velocity, pressure, turbulent viscosity for volume variables and
+pressure, wall-shear-stress for surface variables. The different parameters such as
+variable names, domain resolution, sampling size etc. are configurable in config.yaml.
 """
 
 import os
@@ -346,7 +346,6 @@ class DoMINODataPipe(Dataset):
 
     @profile
     def read_data_zarr(self, filepath):
-
         # def create_pinned_streaming_space(shape, dtype):
         #     # TODO - this function could boost performance a little, but
         #     # the pinned memory pool seems too small.
@@ -386,7 +385,6 @@ class DoMINODataPipe(Dataset):
             return result
 
         with zarr.open_group(filepath, mode="r") as z:
-
             data = {}
             futures = []
             if "volume_fields" in z.keys():
@@ -458,7 +456,6 @@ class DoMINODataPipe(Dataset):
         filepath,
         max_workers=None,
     ):
-
         if max_workers is not None:
             self.max_workers = max_workers
 
@@ -500,7 +497,6 @@ class DoMINODataPipe(Dataset):
 
     @profile
     def preprocess_combined(self, data_dict):
-
         # Pull these out and force to fp32:
         with self.device_context:
             global_params_values = data_dict["global_params_values"].astype(
@@ -538,7 +534,6 @@ class DoMINODataPipe(Dataset):
 
         # SDF calculation on the grid using WARP
         if not self.config.compute_scaling_factors:
-
             nx, ny, nz = self.config.grid_resolution
             surf_grid = create_grid(s_max, s_min, [nx, ny, nz])
             surf_grid_reshaped = surf_grid.reshape(nx * ny * nz, 3)
@@ -598,7 +593,6 @@ class DoMINODataPipe(Dataset):
 
     @profile
     def preprocess_surface(self, data_dict, core_dict, center_of_mass, s_min, s_max):
-
         nx, ny, nz = self.config.grid_resolution
 
         return_dict = {}
@@ -629,7 +623,6 @@ class DoMINODataPipe(Dataset):
             surface_fields = surface_fields[idx_s]
 
         if not self.config.compute_scaling_factors:
-
             c_max = self.config.bounding_box_dims[0]
             c_min = self.config.bounding_box_dims[1]
 
@@ -797,7 +790,6 @@ class DoMINODataPipe(Dataset):
         stl_vertices,
         center_of_mass,
     ):
-
         return_dict = {}
 
         nx, ny, nz = self.config.grid_resolution
@@ -892,7 +884,6 @@ class DoMINODataPipe(Dataset):
                 pos_normals_com_vol = volume_coordinates - center_of_mass
 
             if self.config.normalize_coordinates:
-
                 volume_coordinates = normalize(volume_coordinates, c_max, c_min)
                 grid = normalize(grid, c_max, c_min)
 
@@ -934,7 +925,6 @@ class DoMINODataPipe(Dataset):
 
     @profile
     def preprocess_data(self, data_dict):
-
         (
             return_dict,
             s_min,
@@ -1022,7 +1012,6 @@ class DoMINODataPipe(Dataset):
 
 @profile
 def compute_scaling_factors(cfg: DictConfig, input_path: str, use_cache: bool) -> None:
-
     model_type = cfg.model.model_type
     max_scaling_factor_files = 20
 

--- a/physicsnemo/datapipes/cae/domino_sharded_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_sharded_datapipe.py
@@ -66,7 +66,6 @@ class ShardedDoMINODataPipe(DoMINODataPipe):
         shard_grid,
         **config_overrides,
     ):
-
         # if 'gpu_output' not in config_overrides:
         config_overrides["gpu_output"] = True
 
@@ -118,7 +117,6 @@ class ShardedDoMINODataPipe(DoMINODataPipe):
         ]
 
     def __getitem__(self, idx):
-
         single_dict = super().__getitem__(idx)
 
         # Here, we're assuming that the data is already replicated.
@@ -159,7 +157,6 @@ def create_sharded_domino_dataset(
     shard_point_cloud,
     shard_grid,
 ):
-
     # Pull off the data path, model type, and config_dict:
     data_path = base_dataset.config.data_path
     model_type = base_dataset.model_type

--- a/physicsnemo/datapipes/cae/mesh_datapipe.py
+++ b/physicsnemo/datapipes/cae/mesh_datapipe.py
@@ -345,7 +345,6 @@ class MeshDaliExternalSource:
 
         # Shuffle before the next epoch starts.
         if self.shuffle and sample_info.epoch_idx != self.last_epoch:
-
             # All workers use the same rng seed so the resulting
             # indices are the same across workers.
             np.random.default_rng(seed=sample_info.epoch_idx).shuffle(self.indices)

--- a/physicsnemo/datapipes/climate/climate.py
+++ b/physicsnemo/datapipes/climate/climate.py
@@ -441,7 +441,7 @@ class ClimateDatapipe(Datapipe):
 
         # Determine outputs of pipeline
         self.pipe_outputs = []
-        for (i, spec) in enumerate(self.sources):
+        for i, spec in enumerate(self.sources):
             name = spec.name if spec.name is not None else i
             self.pipe_outputs += [f"state_seq-{name}", f"timestamps-{name}"]
             self.pipe_outputs.extend(
@@ -463,7 +463,7 @@ class ClimateDatapipe(Datapipe):
         # Load all data files and statistics
         for spec in sources:
             spec.parse_dataset_files(num_samples_per_year=num_samples_per_year)
-        for (i, spec_i) in enumerate(sources):
+        for i, spec_i in enumerate(sources):
             for spec_j in sources[i + 1 :]:
                 if not spec_i.dimensions_compatible(spec_j):
                     raise ValueError("Incompatible data sources")
@@ -801,7 +801,7 @@ class ClimateNetCDF4DaliExternalSource(ClimateDaliExternalSource):
         shape = (self.num_steps, len(self.variables)) + shape[1:]
         # TODO: this can be optimized to do the NetCDF scale/offset on GPU
         output = np.empty(shape, dtype=np.float32)
-        for (i, var) in enumerate(self.variables):
+        for i, var in enumerate(self.variables):
             v = data_file.variables[var]
             output[:, i] = v[
                 idx : idx + self.num_steps * self.stride : self.stride

--- a/physicsnemo/datapipes/gnn/ahmed_body_dataset.py
+++ b/physicsnemo/datapipes/gnn/ahmed_body_dataset.py
@@ -216,7 +216,7 @@ class AhmedBodyDataset(DGLDataset, Datapipe):
             max_workers=num_workers,
             mp_context=torch.multiprocessing.get_context("spawn"),
         ) as executor:
-            for (i, graph, coeff, normal, area) in executor.map(
+            for i, graph, coeff, normal, area in executor.map(
                 self.create_graph,
                 range(self.length),
                 case_files[: self.length],

--- a/physicsnemo/datapipes/gnn/bsms.py
+++ b/physicsnemo/datapipes/gnn/bsms.py
@@ -2,6 +2,7 @@
 # ruff: noqa: E402
 
 """"""
+
 """
 BSMS-GNN model. This code was modified from,
 https://github.com/Eydcao/BSMS-GNN

--- a/physicsnemo/datapipes/gnn/hydrographnet_dataset.py
+++ b/physicsnemo/datapipes/gnn/hydrographnet_dataset.py
@@ -178,13 +178,29 @@ def download_from_url(
         if fpath.suffix in [".tar", ".gz", ".tgz"]:
             logger.info(f"Extracting tar archive {fpath}...")
             with tarfile.open(fpath, "r:*") as archive:
-                archive.extractall(path=root)
+                # Safely extract while supporting Python versions < 3.12 that lack the
+                # ``filter`` keyword.  Starting with 3.12, ``filter="data"`` is the
+                # recommended way to avoid unsafe members;
+                extract_kwargs = dict(
+                    path=root,
+                )
+                if "filter" in archive.extractall.__code__.co_varnames:
+                    extract_kwargs["filter"] = "data"
+                archive.extractall(**extract_kwargs)  # noqa: S202
                 names = ", ".join(archive.getnames())
             logger.info(f"Extracted files: {names}")
         elif fpath.suffix == ".zip":
             logger.info(f"Extracting zip archive {fpath}...")
             with zipfile.ZipFile(fpath, "r") as z:
-                z.extractall(path=root)
+                # Safely extract while supporting Python versions < 3.12 that lack the
+                # ``filter`` keyword.  Starting with 3.12, ``filter="data"`` is the
+                # recommended way to avoid unsafe members;
+                extract_kwargs = dict(
+                    path=root,
+                )
+                if "filter" in z.extractall.__code__.co_varnames:
+                    extract_kwargs["filter"] = "data"
+                z.extractall(**extract_kwargs)  # noqa: S202
                 names = ", ".join(z.namelist())
             logger.info(f"Extracted files: {names}")
 

--- a/physicsnemo/datapipes/gnn/hydrographnet_dataset.py
+++ b/physicsnemo/datapipes/gnn/hydrographnet_dataset.py
@@ -152,13 +152,16 @@ def download_from_url(
         with requests.get(url, stream=True, timeout=120) as r:
             r.raise_for_status()
             total_size = int(r.headers.get("content-length", 0))
-            with open(fpath, "wb") as f, tqdm(
-                desc=str(fpath),
-                total=total_size,
-                unit="iB",
-                unit_scale=True,
-                unit_divisor=1024,
-            ) as bar:
+            with (
+                open(fpath, "wb") as f,
+                tqdm(
+                    desc=str(fpath),
+                    total=total_size,
+                    unit="iB",
+                    unit_scale=True,
+                    unit_divisor=1024,
+                ) as bar,
+            ):
                 for chunk in r.iter_content(chunk_size=chunk_size):
                     if chunk:
                         f.write(chunk)
@@ -291,7 +294,6 @@ class HydroGraphDataset(DGLDataset):
         verbose: bool = False,
         return_physics: bool = False,
     ):
-
         if split not in {"train", "test"}:
             raise ValueError(f"Invalid split '{split}'. Expected 'train' or 'test'.")
 

--- a/physicsnemo/datapipes/gnn/vortex_shedding_re300_1000_dataset_dgl.py
+++ b/physicsnemo/datapipes/gnn/vortex_shedding_re300_1000_dataset_dgl.py
@@ -157,7 +157,6 @@ class VortexSheddingRe300To1000Dataset(DGLDataset):
     def __init__(
         self, name="dataset", data_dir="dataset", split="train", verbose=False
     ):
-
         super().__init__(
             name=name,
             verbose=verbose,

--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -107,15 +107,12 @@ class ConstantCoupler:
         raise NotImplementedError("Data preparation not yet implemented")
 
     def _compute_coupled_integration_dim(self):
-
         return self.presteps + max(self.output_time_dim // self.input_time_dim, 1)
 
     def _compute_timevar_dim(self):
-
         return len(self.input_times) * len(self.variables)
 
     def compute_coupled_indices(self, interval, data_time_step):
-
         """
         Called by CoupledDataset to compute static indices for training
         samples
@@ -133,7 +130,6 @@ class ConstantCoupler:
         )
         for b in range(self.batch_size):
             for i in range(self.coupled_integration_dim):
-
                 self._coupled_offsets[b, i, :] = b + np.array(
                     [ts / data_time_step for ts in self.input_times]
                 )
@@ -141,7 +137,6 @@ class ConstantCoupler:
         self._coupled_offsets = self._coupled_offsets.astype(int)
 
     def set_scaling(self, scaling_da):
-
         """
         Called by CoupledDataset to compute static indices for training
         samples
@@ -179,7 +174,6 @@ class ConstantCoupler:
         self.coupled_channel_indices = channel_indices
 
     def reset_coupler(self):
-
         self.coupled_mode = False
         self.integrated_couplings = None
         self.preset_coupled_fields = None
@@ -265,10 +259,10 @@ class ConstantCoupler:
                     coupling_temp = ds_index_range.isel(
                         time=self._coupled_offsets[b, i, :]
                     )
-                    self.integrated_couplings[
-                        b, i, :, :, :
-                    ] = coupling_temp.to_numpy().reshape(
-                        (self.timevar_dim,) + coupling_temp.shape[2:]
+                    self.integrated_couplings[b, i, :, :, :] = (
+                        coupling_temp.to_numpy().reshape(
+                            (self.timevar_dim,) + coupling_temp.shape[2:]
+                        )
                     )
 
             return self.integrated_couplings.transpose((1, 0, 2, 3, 4, 5)).astype(
@@ -360,7 +354,6 @@ class TrailingAverageCoupler:
             )
 
     def compute_coupled_indices(self, interval, data_time_step):
-
         """
         Called by CoupledDataset to compute static indices for training
         samples
@@ -375,7 +368,6 @@ class TrailingAverageCoupler:
         )
         for b in range(self.batch_size):
             for i in range(self.coupled_integration_dim):
-
                 self._coupled_offsets[b, i, :] = (
                     b
                     + (self.input_time_dim * i + 1) * interval
@@ -385,12 +377,10 @@ class TrailingAverageCoupler:
         self._coupled_offsets = self._coupled_offsets.astype(int)
 
     def _prepare_coupled_data(self):
-
         # TODO: write function to lazily compute average as spcified in time scheme
         raise NotImplementedError("Data preparation not yet implemented")
 
     def set_scaling(self, scaling_da):
-
         coupled_scaling = scaling_da.sel(index=self.variables).rename(
             {"index": "channel_in"}
         )
@@ -400,7 +390,6 @@ class TrailingAverageCoupler:
         }
 
     def _set_time_increments(self):
-
         # get the dt of the dataset
         dt = pd.Timedelta(
             self.ds.time[1].values - self.ds.time[0].values
@@ -414,15 +403,12 @@ class TrailingAverageCoupler:
         self.time_increments = [t.total_seconds() / dt for t in self.input_times]
 
     def _compute_timevar_dim(self):
-
         return len(self.input_times) * len(self.variables)
 
     def _compute_coupled_integration_dim(self):
-
         return self.presteps + max(self.output_time_dim // self.input_time_dim, 1)
 
     def setup_coupling(self, coupled_module):
-
         # To expediate the coupling process the coupled_forecast
         # get proper channels from coupled component output
         output_channels = coupled_module.output_variables
@@ -460,7 +446,6 @@ class TrailingAverageCoupler:
         self.averaging_slices = averaging_slices
 
     def reset_coupler(self):
-
         self.coupled_mode = False
         self.integrated_couplings = None
         self.preset_coupled_fields = None
@@ -503,7 +488,6 @@ class TrailingAverageCoupler:
         batch=None,
         bsize=None,
     ):
-
         """
         Construct array of coupled inputs that includes values required for
         model integration steps.
@@ -548,10 +532,10 @@ class TrailingAverageCoupler:
                     coupling_temp = ds_index_range.isel(
                         time=self._coupled_offsets[b, i, :]
                     )
-                    self.integrated_couplings[
-                        b, i, :, :, :
-                    ] = coupling_temp.to_numpy().reshape(
-                        (self.timevar_dim,) + coupling_temp.shape[2:]
+                    self.integrated_couplings[b, i, :, :, :] = (
+                        coupling_temp.to_numpy().reshape(
+                            (self.timevar_dim,) + coupling_temp.shape[2:]
+                        )
                     )
 
             return self.integrated_couplings.transpose((1, 0, 2, 3, 4, 5)).astype(

--- a/physicsnemo/datapipes/healpix/data_modules.py
+++ b/physicsnemo/datapipes/healpix/data_modules.py
@@ -950,7 +950,6 @@ class CoupledTimeSeriesDataModule(TimeSeriesDataModule):
         )
 
     def _get_coupled_vars(self):
-
         coupled_variables = []
         for d in self.couplings:
             coupled_variables = coupled_variables + d["params"]["variables"]

--- a/physicsnemo/distributed/_shard_redistribute.py
+++ b/physicsnemo/distributed/_shard_redistribute.py
@@ -163,7 +163,6 @@ def _to_new_shard_dim(
     current_dim: int,  # currently sharded on this tensor dimension
     target_dim: int,  # Want to be sharded on this tensor dimension
 ) -> torch.Tensor:
-
     # We're essentially transposing the tensor here.
     # We could implement this as an all_gather_v / scatter_v, but
     # it's more efficient to do an all_to_all.
@@ -484,7 +483,6 @@ class ShardRedistribute(torch.autograd.Function):
         ctx.async_op = async_op
 
         if current_spec.placements != placements:
-
             # We have to assume, here, that the current spec has correct sharding_shapes.
             # Therefore, we can use the target placement + current sharding_shapes
             # to get the target sharding sizes correctly.

--- a/physicsnemo/distributed/_shard_tensor_spec.py
+++ b/physicsnemo/distributed/_shard_tensor_spec.py
@@ -215,11 +215,7 @@ class ShardTensorSpec(DTensorSpec):
         return tuple(offsets)  # Fixed: Return tuple instead of list
 
 
-def _stride_from_contiguous_shape_C_style(
-    shape: Tuple[
-        int,
-    ]
-) -> Tuple[int]:
+def _stride_from_contiguous_shape_C_style(shape: Tuple[int,]) -> Tuple[int]:
     """
     Compute and return the stride from a tensor shape, assuming it is
     both contiguous and laid out in C-style
@@ -324,9 +320,7 @@ def _all_gather_shard_shapes(
     global_shape = [s for s in local_shape]
     # We start by assuming the global shape is the local shape and fix it on sharded axes
     for mesh_axis, placement in enumerate(placements):
-
         if isinstance(placement, Shard):
-
             tensor_dim = placement.dim
             local_group = target_mesh.get_group(mesh_axis)
 
@@ -405,7 +399,6 @@ def compute_sharding_shapes_from_chunking_global_shape(
     # Finally, update the sharded shape with the right chunk size:
     for shape_list in sharding_shapes.values():
         for inner_mesh_dim, chunk_size in temp_sharding_shapes.items():
-
             tensor_dim = placements[inner_mesh_dim].dim
             for shape in shape_list:
                 shape[tensor_dim] = chunk_size

--- a/physicsnemo/distributed/config.py
+++ b/physicsnemo/distributed/config.py
@@ -58,7 +58,7 @@ class ProcessGroupNode:
         str
             String representation of the process group node
         """
-        return "ProcessGroupNode(" f"name={self.name}, " f"size={self.size}, "
+        return f"ProcessGroupNode(name={self.name}, size={self.size}, "
 
     def __repr__(self):
         """

--- a/physicsnemo/distributed/custom_ops/_reductions.py
+++ b/physicsnemo/distributed/custom_ops/_reductions.py
@@ -547,7 +547,7 @@ def unpack_args(
     dim: DimT = None,
     keepdim: bool = False,
     *args: Any,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> Tuple[ShardTensor, DimT, bool, Tuple[Any, ...], Dict[str, Any]]:
     """
     Unpack arguments for reduction functions.  Maps default args from torch.

--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -540,7 +540,6 @@ class DistributedManager(object):
         if key in self._mesh_groups.keys():
             return self._mesh_groups[key]
         else:
-
             if mesh.ndim != 1:
                 # We need to get all ranks in this mesh and spawn a group.
                 # The mesh.mesh object is a GPU tensor and using it will block.
@@ -763,7 +762,6 @@ class DistributedManager(object):
     def create_groups_from_config(
         config: ProcessGroupConfig, verbose: bool = False
     ):  # pragma: no cover
-
         if torch.__version__ > "2.4":
             warnings.warn(
                 "DistributedManager.create_groups_from_config is no longer the most simple "

--- a/physicsnemo/distributed/shard_tensor.py
+++ b/physicsnemo/distributed/shard_tensor.py
@@ -597,7 +597,6 @@ class ShardTensor(DTensor):
         return _ToTorchTensor.apply(redist_res, grad_placements)
 
     def backward(self, *args, **kwargs):
-
         # Before calling backward, we need to resolve any partial placements.
         new_placements = []
         # grad_placements = []

--- a/physicsnemo/distributed/shard_utils/attention_patches.py
+++ b/physicsnemo/distributed/shard_utils/attention_patches.py
@@ -187,10 +187,8 @@ class RingSDPA(torch.autograd.Function):
             # Launch communication for the next iteration early
             with record_function(f"sdpa_send_data_{i}_{dist.get_rank()}"):
                 if i < ring_config.mesh_size - 1:
-
                     # Use a dedicated stream for communication
                     with torch.cuda.stream(comm_stream):
-
                         send_tensors = [
                             torch.empty((), device=q.device, dtype=q.dtype)
                             for _ in range(local_size)
@@ -339,7 +337,6 @@ class RingSDPA(torch.autograd.Function):
         # 4. If iteration != 0, send grad_k, grad_v to the next GPU after combining them into one tensor.
 
         for i in range(ctx.ring_config.mesh_size):
-
             (
                 block_grad_q,
                 block_grad_k,
@@ -422,7 +419,6 @@ class RingSDPABlocking(torch.autograd.Function):
         current_k, current_v = k, v
 
         for i in range(ring_config.mesh_size):
-
             # Perform computation on current k,v while communication happens
             (
                 output,
@@ -533,7 +529,6 @@ class RingSDPABlocking(torch.autograd.Function):
         # 4. If iteration != 0, send grad_k, grad_v to the next GPU after combining them into one tensor.
 
         for i in range(ctx.ring_config.mesh_size):
-
             (
                 block_grad_q,
                 block_grad_k,

--- a/physicsnemo/distributed/shard_utils/conv_patches.py
+++ b/physicsnemo/distributed/shard_utils/conv_patches.py
@@ -222,7 +222,6 @@ def compute_halo_configs_from_conv_args(
         )
 
         if halo_size > 0:
-
             # Create a halo config for this dimension
 
             halo_configs.append(

--- a/physicsnemo/distributed/shard_utils/conv_patches.py
+++ b/physicsnemo/distributed/shard_utils/conv_patches.py
@@ -528,14 +528,14 @@ def generic_conv_nd_wrapper(func: callable, types: tuple, args: tuple, kwargs: d
 
     # Handle regular torch tensor inputs
     if (
-        type(input) == torch.Tensor
-        and type(weight) == torch.nn.parameter.Parameter
-        and (bias is None or type(bias) == torch.nn.parameter.Parameter)
+        isinstance(input, torch.Tensor)
+        and isinstance(weight, torch.nn.parameter.Parameter)
+        and (bias is None or isinstance(bias, torch.nn.parameter.Parameter))
     ):
         return func(*args, **kwargs)
 
     # Handle distributed ShardTensor inputs
-    elif type(input) == ShardTensor:
+    elif isinstance(input, ShardTensor):
         # Gather any distributed weights/bias
         if isinstance(weight, (ShardTensor, DTensor)):
             weight = weight.full_tensor()

--- a/physicsnemo/distributed/shard_utils/index_ops.py
+++ b/physicsnemo/distributed/shard_utils/index_ops.py
@@ -291,7 +291,6 @@ def sharded_select_helper(tensor: ShardTensor, dim: int, index: int) -> ShardTen
         )
 
     else:
-
         # We are reducing tensor rank:
         original_shape.pop(dim)
         output_stride = _stride_from_contiguous_shape_C_style(original_shape)
@@ -426,7 +425,6 @@ def sharded_select_backward_helper(
 
 
 def select_wrapper(tensor, dim, index):
-
     if not isinstance(dim, int):
         raise TypeError(f"Dim must be an int, got {type(dim)}")
     if not isinstance(index, int):

--- a/physicsnemo/distributed/shard_utils/natten_patches.py
+++ b/physicsnemo/distributed/shard_utils/natten_patches.py
@@ -229,9 +229,9 @@ if natten_spec is not None:
         dilation = kwargs.get("dilation", 1)
         kernel_size = kwargs["kernel_size"]
 
-        if all([type(_t) == torch.Tensor for _t in (q, k, v)]):
+        if all([isinstance(_t, torch.Tensor) for _t in (q, k, v)]):
             return wrapped(*args, **kwargs)
-        elif all([type(_t) == ShardTensor for _t in (q, k, v)]):
+        elif all([isinstance(_t, ShardTensor) for _t in (q, k, v)]):
             return partial_na2d(q, k, v, kernel_size, dilation, base_func=wrapped)
 
         else:

--- a/physicsnemo/distributed/shard_utils/natten_patches.py
+++ b/physicsnemo/distributed/shard_utils/natten_patches.py
@@ -232,7 +232,6 @@ if natten_spec is not None:
         if all([type(_t) == torch.Tensor for _t in (q, k, v)]):
             return wrapped(*args, **kwargs)
         elif all([type(_t) == ShardTensor for _t in (q, k, v)]):
-
             return partial_na2d(q, k, v, kernel_size, dilation, base_func=wrapped)
 
         else:

--- a/physicsnemo/distributed/shard_utils/point_cloud_ops.py
+++ b/physicsnemo/distributed/shard_utils/point_cloud_ops.py
@@ -104,11 +104,11 @@ def ring_ball_query(
 
     # For the output shapes, we can compute the output sharding if needed.  If the placement
     # is Replicate, just infer since there aren't shardings.
-    if type(points1._spec.placements[0]) == Replicate:
+    if isinstance(points1._spec.placements[0], Replicate):
         map_shard_shapes = "infer"
         neighbors_shard_shapes = "infer"
         outputs_shard_shapes = "infer"
-    elif type(points1._spec.placements[0]) == Shard:
+    elif isinstance(points1._spec.placements[0], Shard):
         p1_shard_sizes = points1._spec.sharding_shapes()[0]
 
         # This conversion to shard tensor can be done explicitly computing the output shapes.

--- a/physicsnemo/distributed/shard_utils/point_cloud_ops.py
+++ b/physicsnemo/distributed/shard_utils/point_cloud_ops.py
@@ -109,7 +109,6 @@ def ring_ball_query(
         neighbors_shard_shapes = "infer"
         outputs_shard_shapes = "infer"
     elif type(points1._spec.placements[0]) == Shard:
-
         p1_shard_sizes = points1._spec.sharding_shapes()[0]
 
         # This conversion to shard tensor can be done explicitly computing the output shapes.
@@ -273,7 +272,6 @@ def merge_outputs(
 
         # Now, copy the incoming neighbors to offset locations in the current tensor:
         for i in range(neighbors_to_add):
-
             # incoming has no offset
             # current has offset of num_neighbors
             current_m[0, tid, num_neighbors + i] = incoming_m[0, tid, i]
@@ -385,7 +383,6 @@ class RingBallQuery(torch.autograd.Function):
         ctx.hash_grid = bq_kwargs["hash_grid"]
 
         for i in range(world_size):
-
             source_rank = (mesh_rank - i) % world_size
 
             (
@@ -516,7 +513,6 @@ class GradReducer(torch.autograd.Function):
         ctx: torch.autograd.function.FunctionCtx,
         grad_output: torch.Tensor,
     ) -> torch.Tensor:
-
         spec = ctx.spec
         placement = spec.placements[0]
         # Perform an allreduce on the gradient

--- a/physicsnemo/distributed/shard_utils/ring.py
+++ b/physicsnemo/distributed/shard_utils/ring.py
@@ -116,7 +116,6 @@ def perform_ring_iteration(
         tensor_recv = torch.empty(recv_shape, dtype=dtype, device=device)
 
     if ring_config.communication_method == "p2p":
-
         p2p_op_list = []
         torch.cuda.set_device(tensor.device)
 

--- a/physicsnemo/launch/utils/checkpoint.py
+++ b/physicsnemo/launch/utils/checkpoint.py
@@ -128,7 +128,7 @@ def _get_checkpoint_filename(
             file_idx.sort()
             # If we are saving index by 1 to get the next free file name
             if saving:
-                checkpoint_filename = checkpoint_filename + f".{file_idx[-1]+1}"
+                checkpoint_filename = checkpoint_filename + f".{file_idx[-1] + 1}"
             else:
                 checkpoint_filename = checkpoint_filename + f".{file_idx[-1]}"
             checkpoint_filename += file_extension
@@ -236,7 +236,7 @@ def save_checkpoint(
     # Only applicable to Posix filesystems ("file" protocol), not object stores.
     if protocol == "file" and not Path(path).is_dir():
         checkpoint_logging.warning(
-            f"Output directory {path} does not exist, will " "attempt to create"
+            f"Output directory {path} does not exist, will attempt to create"
         )
         Path(path).mkdir(parents=True, exist_ok=True)
 

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -76,7 +76,6 @@ class BaseMSE(th.nn.MSELoss):
 
 
 class WeightedMSE(th.nn.MSELoss):
-
     """
     Loss object that allows for user defined weighting of variables when calculating MSE
     """
@@ -175,7 +174,6 @@ class OceanMSE(th.nn.MSELoss):
         ).to(trainer.device)
 
     def forward(self, prediction, target, average_channels=True):
-
         if not self.lsm_sum_calculated:
             self.lsm_sum = th.broadcast_to(self.lsm_tensor, target.shape).sum()
             self.lsm_var_sum = th.broadcast_to(self.lsm_tensor, target.shape).sum(
@@ -240,7 +238,6 @@ class WeightedOceanMSE(th.nn.MSELoss):
         self.loss_weights = self.loss_weights.to(device=trainer.device)
 
     def forward(self, prediction, target, average_channels=True):
-
         if not self.lsm_sum_calculated:
             self.lsm_sum = th.broadcast_to(self.lsm_tensor, target.shape).sum()
             self.lsm_var_sum = th.broadcast_to(self.lsm_tensor, target.shape).sum(

--- a/physicsnemo/models/afno/afno.py
+++ b/physicsnemo/models/afno/afno.py
@@ -173,44 +173,52 @@ class AFNO2DLayer(nn.Module):
         total_modes = H // 2 + 1
         kept_modes = int(total_modes * self.hard_thresholding_fraction)
 
-        o1_real[
-            :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes
-        ] = F.relu(
-            torch.einsum(
-                "nyxbi,bio->nyxbo",
-                x_real[
-                    :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes
-                ],
-                self.w1[0],
+        o1_real[:, total_modes - kept_modes : total_modes + kept_modes, :kept_modes] = (
+            F.relu(
+                torch.einsum(
+                    "nyxbi,bio->nyxbo",
+                    x_real[
+                        :,
+                        total_modes - kept_modes : total_modes + kept_modes,
+                        :kept_modes,
+                    ],
+                    self.w1[0],
+                )
+                - torch.einsum(
+                    "nyxbi,bio->nyxbo",
+                    x_imag[
+                        :,
+                        total_modes - kept_modes : total_modes + kept_modes,
+                        :kept_modes,
+                    ],
+                    self.w1[1],
+                )
+                + self.b1[0]
             )
-            - torch.einsum(
-                "nyxbi,bio->nyxbo",
-                x_imag[
-                    :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes
-                ],
-                self.w1[1],
-            )
-            + self.b1[0]
         )
 
-        o1_imag[
-            :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes
-        ] = F.relu(
-            torch.einsum(
-                "nyxbi,bio->nyxbo",
-                x_imag[
-                    :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes
-                ],
-                self.w1[0],
+        o1_imag[:, total_modes - kept_modes : total_modes + kept_modes, :kept_modes] = (
+            F.relu(
+                torch.einsum(
+                    "nyxbi,bio->nyxbo",
+                    x_imag[
+                        :,
+                        total_modes - kept_modes : total_modes + kept_modes,
+                        :kept_modes,
+                    ],
+                    self.w1[0],
+                )
+                + torch.einsum(
+                    "nyxbi,bio->nyxbo",
+                    x_real[
+                        :,
+                        total_modes - kept_modes : total_modes + kept_modes,
+                        :kept_modes,
+                    ],
+                    self.w1[1],
+                )
+                + self.b1[1]
             )
-            + torch.einsum(
-                "nyxbi,bio->nyxbo",
-                x_real[
-                    :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes
-                ],
-                self.w1[1],
-            )
-            + self.b1[1]
         )
 
         o2[

--- a/physicsnemo/models/afno/modafno.py
+++ b/physicsnemo/models/afno/modafno.py
@@ -267,13 +267,13 @@ class ModAFNO2DLayer(AFNO2DLayer):
                 o1_im * scale_re + o1_re * scale_im + shift_im,
             )
 
-        o1_real[
-            :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes
-        ] = F.relu(o1_re)
+        o1_real[:, total_modes - kept_modes : total_modes + kept_modes, :kept_modes] = (
+            F.relu(o1_re)
+        )
 
-        o1_imag[
-            :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes
-        ] = F.relu(o1_im)
+        o1_imag[:, total_modes - kept_modes : total_modes + kept_modes, :kept_modes] = (
+            F.relu(o1_im)
+        )
 
         o2[
             :, total_modes - kept_modes : total_modes + kept_modes, :kept_modes, ..., 0

--- a/physicsnemo/models/diffusion/preconditioning.py
+++ b/physicsnemo/models/diffusion/preconditioning.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-Preconditioning schemes used in the paper"Elucidating the Design Space of 
+Preconditioning schemes used in the paper"Elucidating the Design Space of
 Diffusion-Based Generative Models".
 """
 

--- a/physicsnemo/models/diffusion/unet.py
+++ b/physicsnemo/models/diffusion/unet.py
@@ -257,7 +257,6 @@ class UNet(Module):  # TODO a lot of redundancy, need to clean up
         force_fp32: bool = False,
         **model_kwargs: dict,
     ) -> torch.Tensor:
-
         # SR: concatenate input channels
         if img_lr is not None:
             x = torch.cat((x, img_lr), dim=1)
@@ -277,7 +276,7 @@ class UNet(Module):  # TODO a lot of redundancy, need to clean up
 
         if (F_x.dtype != dtype) and not torch.is_autocast_enabled():
             raise ValueError(
-                f"Expected the dtype to be {dtype}, " f"but got {F_x.dtype} instead."
+                f"Expected the dtype to be {dtype}, but got {F_x.dtype} instead."
             )
 
         # skip connection

--- a/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
@@ -161,7 +161,6 @@ class HEALPixUNet(Module):
         )
 
     def _compute_coupled_channels(self, couplings):
-
         c_channels = 0
         for c in couplings:
             c_channels += len(c["params"]["variables"]) * len(
@@ -228,9 +227,7 @@ class HEALPixUNet(Module):
                             step * self.input_time_dim, (step + 1) * self.input_time_dim
                         ),
                         ...,
-                    ].flatten(
-                        self.channel_dim, self.channel_dim + 1
-                    ),  # DI
+                    ].flatten(self.channel_dim, self.channel_dim + 1),  # DI
                 ]
                 res = th.cat(result, dim=self.channel_dim)
 
@@ -263,9 +260,7 @@ class HEALPixUNet(Module):
                     :,
                     slice(step * self.input_time_dim, (step + 1) * self.input_time_dim),
                     ...,
-                ].flatten(
-                    self.channel_dim, self.channel_dim + 1
-                ),  # DI
+                ].flatten(self.channel_dim, self.channel_dim + 1),  # DI
                 inputs[2].expand(
                     *tuple([inputs[0].shape[0]] + len(inputs[2].shape) * [-1])
                 ),  # constants

--- a/physicsnemo/models/domino/model.py
+++ b/physicsnemo/models/domino/model.py
@@ -1175,7 +1175,6 @@ class DoMINO(nn.Module):
             ]
 
             for f in range(num_variables):
-
                 one_loop_centers_expanded = surface_mesh_centers.unsqueeze(2)
 
                 one_loop_noise = one_loop_centers_expanded - (
@@ -1301,7 +1300,6 @@ class DoMINO(nn.Module):
             param_encoding = self.parameter_model(processed_parameters)
 
         if self.solution_calculation_mode == "one-loop":
-
             # Stretch these out to num_sample_points
             one_loop_encoding_node = encoding_node.unsqueeze(0).expand(
                 num_sample_points, -1, -1, -1
@@ -1320,7 +1318,6 @@ class DoMINO(nn.Module):
                 one_loop_other_terms = (one_loop_encoding_node, one_loop_encoding_g)
 
             for f in range(num_variables):
-
                 one_loop_volume_mesh_centers_expanded = volume_mesh_centers.unsqueeze(
                     0
                 ).expand(num_sample_points, -1, -1, -1)
@@ -1391,7 +1388,6 @@ class DoMINO(nn.Module):
             return one_loop_output_all
 
         if self.solution_calculation_mode == "two-loop":
-
             for f in range(num_variables):
                 for p in range(num_sample_points):
                     if p == 0:

--- a/physicsnemo/models/fcn_mip_plugin.py
+++ b/physicsnemo/models/fcn_mip_plugin.py
@@ -194,9 +194,7 @@ class _DLWPWrapper(torch.nn.Module):
                     self.latgrid,
                 ),
                 0,
-            ) - (
-                1 / np.pi
-            )  # subtract mean value
+            ) - (1 / np.pi)  # subtract mean value
             tisr = (
                 torch.tensor(tisr, dtype=dtype)
                 .to(device)

--- a/physicsnemo/models/figconvnet/components/encodings.py
+++ b/physicsnemo/models/figconvnet/components/encodings.py
@@ -25,9 +25,9 @@ class SinusoidalEncoding(nn.Module):
 
     def __init__(self, num_channels: int, data_range: float = 2.0):
         super().__init__()
-        assert (
-            num_channels % 2 == 0
-        ), f"num_channels must be even for sin/cos, got {num_channels}"
+        assert num_channels % 2 == 0, (
+            f"num_channels must be even for sin/cos, got {num_channels}"
+        )
         self.num_channels = num_channels
         self.data_range = data_range
 

--- a/physicsnemo/models/figconvnet/components/reductions.py
+++ b/physicsnemo/models/figconvnet/components/reductions.py
@@ -28,7 +28,7 @@ REDUCTION_TYPES = Literal["min", "max", "mean", "sum", "var", "std"]
 
 def _var(
     features: Float[Tensor, "N F"],  # noqa: F722
-    neighbors_row_splits: Int[Tensor, "M"],  # noqa: F722
+    neighbors_row_splits: Int[Tensor, "M"],  # noqa: F821
 ) -> Tuple[Float[Tensor, "M F"], Float[Tensor, "M F"]]:  # noqa: F722
     out_mean = segment_csr(features, neighbors_row_splits, reduce="mean")
     out_var = (

--- a/physicsnemo/models/figconvnet/components/reductions.py
+++ b/physicsnemo/models/figconvnet/components/reductions.py
@@ -27,8 +27,9 @@ REDUCTION_TYPES = Literal["min", "max", "mean", "sum", "var", "std"]
 
 
 def _var(
-    features: Float[Tensor, "N F"], neighbors_row_splits: Int[Tensor, "M"]  # noqa
-) -> Tuple[Float[Tensor, "M F"], Float[Tensor, "M F"]]:  # noqa
+    features: Float[Tensor, "N F"],  # noqa: F722
+    neighbors_row_splits: Int[Tensor, "M"],  # noqa: F722
+) -> Tuple[Float[Tensor, "M F"], Float[Tensor, "M F"]]:  # noqa: F722
     out_mean = segment_csr(features, neighbors_row_splits, reduce="mean")
     out_var = (
         segment_csr(features**2, neighbors_row_splits, reduce="mean") - out_mean**2

--- a/physicsnemo/models/figconvnet/figconvunet.py
+++ b/physicsnemo/models/figconvnet/figconvunet.py
@@ -85,9 +85,9 @@ class VerticesToPointFeatures(nn.Module):
             self.mlp = MLP(3 * embed_dim, out_features, [])
 
     def forward(self, vertices: Float[Tensor, "B N 3"]) -> PointFeatures:
-        assert (
-            vertices.ndim == 3
-        ), f"Expected 3D vertices of shape BxNx3, got {vertices.shape}"
+        assert vertices.ndim == 3, (
+            f"Expected 3D vertices of shape BxNx3, got {vertices.shape}"
+        )
         vert_embed = self.pos_embed(vertices)
         if self.use_mlp:
             vert_embed = self.mlp(vert_embed)
@@ -256,13 +256,13 @@ class FIGConvUNet(BaseModel):
         if pooling_layers is None:
             pooling_layers = [num_levels]
         else:
-            assert isinstance(
-                pooling_layers, list
-            ), f"pooling_layers must be a list, got {type(pooling_layers)}."
+            assert isinstance(pooling_layers, list), (
+                f"pooling_layers must be a list, got {type(pooling_layers)}."
+            )
             for layer in pooling_layers:
-                assert (
-                    layer <= num_levels
-                ), f"pooling_layer {layer} is greater than num_levels {num_levels}."
+                assert layer <= num_levels, (
+                    f"pooling_layer {layer} is greater than num_levels {num_levels}."
+                )
         self.pooling_layers = pooling_layers
         grid_pools = [
             GridFeatureGroupPool(

--- a/physicsnemo/models/figconvnet/grid_feature_group.py
+++ b/physicsnemo/models/figconvnet/grid_feature_group.py
@@ -129,9 +129,9 @@ class GridFeaturesGroupIntraCommunication(nn.Module):
         # Assert the channel size of all grid_features are the same
         channel_size = grid_features_group[0].features.shape[0]
         for grid_features in grid_features_group:
-            assert (
-                grid_features.features.shape[0] == channel_size
-            ), f"Channel size of grid_features are not the same: {grid_features.features.shape[1]} != {channel_size}"
+            assert grid_features.features.shape[0] == channel_size, (
+                f"Channel size of grid_features are not the same: {grid_features.features.shape[1]} != {channel_size}"
+            )
 
         # broadcast the features between all pairs of grid_features
         # Copy the features of format B_C_H_W_D to avoid in-place operation

--- a/physicsnemo/models/figconvnet/neighbor_ops.py
+++ b/physicsnemo/models/figconvnet/neighbor_ops.py
@@ -104,9 +104,9 @@ def batched_neighbor_radius_search(
     radius: float
     search_method: Literal["warp", "open3d"]
     """
-    assert (
-        inp_positions.shape[0] == out_positions.shape[0]
-    ), f"Batch size mismatch, {inp_positions.shape[0]} != {out_positions.shape[0]}"
+    assert inp_positions.shape[0] == out_positions.shape[0], (
+        f"Batch size mismatch, {inp_positions.shape[0]} != {out_positions.shape[0]}"
+    )
 
     if search_method == "warp":
         neighbor_index, neighbor_dist, neighbor_offset = batched_radius_search_warp(
@@ -200,9 +200,9 @@ def batched_neighbor_knn_search(
     query_positions: [B,M,3]
     k: int
     """
-    assert (
-        ref_positions.shape[0] == query_positions.shape[0]
-    ), f"Batch size mismatch, {ref_positions.shape[0]} != {query_positions.shape[0]}"
+    assert ref_positions.shape[0] == query_positions.shape[0], (
+        f"Batch size mismatch, {ref_positions.shape[0]} != {query_positions.shape[0]}"
+    )
     neighbors = []
     index_offset = 0
     for i in range(ref_positions.shape[0]):

--- a/physicsnemo/models/figconvnet/point_feature_conv.py
+++ b/physicsnemo/models/figconvnet/point_feature_conv.py
@@ -128,30 +128,30 @@ class PointFeatureConv(nn.Module):
         ellipsoidal neighborhood.
         """
         super().__init__()
-        assert (
-            isinstance(reductions, (tuple, list)) and len(reductions) > 0
-        ), f"reductions must be a list or tuple of length > 0, got {reductions}"
+        assert isinstance(reductions, (tuple, list)) and len(reductions) > 0, (
+            f"reductions must be a list or tuple of length > 0, got {reductions}"
+        )
         if out_point_feature_type == "provided":
-            assert (
-                downsample_voxel_size is None
-            ), "downsample_voxel_size is only used for downsample"
-            assert (
-                provided_in_channels is not None
-            ), "provided_in_channels must be provided for provided type"
+            assert downsample_voxel_size is None, (
+                "downsample_voxel_size is only used for downsample"
+            )
+            assert provided_in_channels is not None, (
+                "provided_in_channels must be provided for provided type"
+            )
         elif out_point_feature_type == "downsample":
-            assert (
-                downsample_voxel_size is not None
-            ), "downsample_voxel_size must be provided for downsample"
-            assert (
-                provided_in_channels is None
-            ), "provided_in_channels must be None for downsample type"
+            assert downsample_voxel_size is not None, (
+                "downsample_voxel_size must be provided for downsample"
+            )
+            assert provided_in_channels is None, (
+                "provided_in_channels must be None for downsample type"
+            )
         elif out_point_feature_type == "same":
-            assert (
-                downsample_voxel_size is None
-            ), "downsample_voxel_size is only used for downsample"
-            assert (
-                provided_in_channels is None
-            ), "provided_in_channels must be None for same type"
+            assert downsample_voxel_size is None, (
+                "downsample_voxel_size is only used for downsample"
+            )
+            assert provided_in_channels is None, (
+                "provided_in_channels must be None for same type"
+            )
         if downsample_voxel_size is not None and downsample_voxel_size > radius:
             raise ValueError(
                 f"downsample_voxel_size {downsample_voxel_size} must be <= radius {radius}"
@@ -222,9 +222,9 @@ class PointFeatureConv(nn.Module):
         """When out_point_features is None, the output will be generated on the
         in_point_features.vertices."""
         if self.out_point_feature_type == "provided":
-            assert (
-                out_point_features is not None
-            ), "out_point_features must be provided for the provided type"
+            assert out_point_features is not None, (
+                "out_point_features must be provided for the provided type"
+            )
         elif self.out_point_feature_type == "downsample":
             assert out_point_features is None
             out_point_features = in_point_features.voxel_down_sample(
@@ -242,7 +242,9 @@ class PointFeatureConv(nn.Module):
             + self.use_rel_pos_encode * self.positional_encoding.num_channels * 3
             + (not self.use_rel_pos_encode) * self.use_rel_pos * 3
             == self.edge_transform_mlp.in_channels
-        ), f"input features shape {in_point_features.features.shape} and {out_point_features.features.shape} does not match the edge_transform_mlp input features {self.edge_transform_mlp.in_channels}"
+        ), (
+            f"input features shape {in_point_features.features.shape} and {out_point_features.features.shape} does not match the edge_transform_mlp input features {self.edge_transform_mlp.in_channels}"
+        )
         # Get the neighbors
         in_vertices = in_point_features.vertices
         out_vertices = out_point_features.vertices
@@ -398,9 +400,9 @@ class PointFeatureConvBlock(nn.Module):
         out_point_features: Optional[PointFeatures["B M C2"]] = None,
     ) -> PointFeatures["B N C2"]:
         if self.out_point_feature_type == "provided":
-            assert (
-                out_point_features is not None
-            ), "out_point_features must be provided for the provided type"
+            assert out_point_features is not None, (
+                "out_point_features must be provided for the provided type"
+            )
             out = self.conv1(in_point_features, out_point_features)
         elif self.out_point_feature_type == "downsample":
             assert out_point_features is None

--- a/physicsnemo/models/figconvnet/warp_neighbor_search.py
+++ b/physicsnemo/models/figconvnet/warp_neighbor_search.py
@@ -112,9 +112,9 @@ def _radius_search_warp(
     result_count_torch = wp.to_torch(result_count)
     torch.cumsum(result_count_torch, dim=0, out=torch_offset[1:])
     total_count = torch_offset[-1].item()
-    assert (
-        total_count < 2**31 - 1
-    ), f"Total result count is too large: {total_count} > 2**31 - 1"
+    assert total_count < 2**31 - 1, (
+        f"Total result count is too large: {total_count} > 2**31 - 1"
+    )
 
     result_point_idx = wp.zeros(shape=(total_count,), dtype=wp.int32)
     result_point_dist = wp.zeros(shape=(total_count,), dtype=wp.float32)
@@ -143,9 +143,7 @@ def radius_search_warp(
     radius: float,
     grid_dim: Union[int, Tuple[int, int, int]] = (128, 128, 128),
     device: str = "cuda",
-) -> Tuple[
-    Float[Tensor, "Q"], Float[Tensor, "Q"], Float[Tensor, "M + 1"]
-]:  # noqa: F821
+) -> Tuple[Float[Tensor, "Q"], Float[Tensor, "Q"], Float[Tensor, "M + 1"]]:  # noqa: F821
     """
     Args:
         points: [N, 3]
@@ -187,9 +185,7 @@ def batched_radius_search_warp(
     radius: float,
     grid_dim: Union[int, Tuple[int, int, int]] = (128, 128, 128),
     device: str = "cuda",
-) -> Tuple[
-    Float[Tensor, "Q"], Float[Tensor, "Q"], Float[Tensor, "B*M + 1"]
-]:  # noqa: F821
+) -> Tuple[Float[Tensor, "Q"], Float[Tensor, "Q"], Float[Tensor, "B*M + 1"]]:  # noqa: F821
     """
     Args:
         points: [B, N, 3]

--- a/physicsnemo/models/gnn_layers/bsms.py
+++ b/physicsnemo/models/gnn_layers/bsms.py
@@ -2,6 +2,7 @@
 # ruff: noqa: E402
 
 """"""
+
 """
 BSMS-GNN model. This code was modified from,
 https://github.com/Eydcao/BSMS-GNN

--- a/physicsnemo/models/gnn_layers/distributed_graph.py
+++ b/physicsnemo/models/gnn_layers/distributed_graph.py
@@ -495,15 +495,15 @@ def partition_graph_with_matrix_decomposition(
             global_src_node_at_partition[src_node_indices] - node_offset
         )
         # fill the numbers of indices (edges), dst nodes and src nodes for each partition
-        graph_partition.num_indices_in_each_partition[
-            to_partition
-        ] = local_indices.size(0)
+        graph_partition.num_indices_in_each_partition[to_partition] = (
+            local_indices.size(0)
+        )
         graph_partition.num_dst_nodes_in_each_partition[to_partition] = (
             partition_book[to_partition + 1] - partition_book[to_partition]
         )
-        graph_partition.num_src_nodes_in_each_partition[
-            to_partition
-        ] = global_src_node_at_partition.size(0)
+        graph_partition.num_src_nodes_in_each_partition[to_partition] = (
+            global_src_node_at_partition.size(0)
+        )
 
         if to_partition == partition_rank:
             graph_partition.local_indices = inverse_indices

--- a/physicsnemo/models/gnn_layers/mesh_graph_mlp.py
+++ b/physicsnemo/models/gnn_layers/mesh_graph_mlp.py
@@ -56,7 +56,11 @@ class CustomSiLuLinearAutogradFunction(torch.autograd.Function):
     @once_differentiable
     def backward(
         ctx, grad_output: torch.Tensor
-    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor],]:
+    ) -> Tuple[
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+    ]:
         """backward pass of the SiLU + Linear function"""
 
         from nvfuser import FusionDefinition

--- a/physicsnemo/models/layers/ball_query.py
+++ b/physicsnemo/models/layers/ball_query.py
@@ -115,7 +115,6 @@ def _ball_query_forward_primitive_(
     radius: float,
     hash_grid: wp.HashGrid,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-
     # Create output tensors:
     mapping = torch.zeros(
         (1, points1.shape[0], k),
@@ -195,7 +194,6 @@ def _ball_query_backward_primitive_(
     grad_num_neighbors,
     grad_outputs,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-
     p2_grad = torch.zeros_like(points2)
 
     # Run the kernel in adjoint mode
@@ -280,7 +278,6 @@ class BallQuery(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_mapping, grad_num_neighbors, grad_outputs):
-
         points1, points2, mapping, num_neighbors, outputs = ctx.saved_tensors
         # Apply the primitive
         p2_grad = _ball_query_backward_primitive_(

--- a/physicsnemo/models/layers/drop.py
+++ b/physicsnemo/models/layers/drop.py
@@ -56,4 +56,4 @@ class DropPath(nn.Module):
         return drop_path(x, self.drop_prob, self.training, self.scale_by_keep)
 
     def extra_repr(self):
-        return f"drop_prob={round(self.drop_prob,3):0.3f}"
+        return f"drop_prob={round(self.drop_prob, 3):0.3f}"

--- a/physicsnemo/models/layers/spectral_layers.py
+++ b/physicsnemo/models/layers/spectral_layers.py
@@ -474,53 +474,61 @@ class SpectralConv4d(nn.Module):
         # print(f'mod: size x: {x_ft.size()}, out: {out_ft.size()}')
         # print(f'mod: x_ft[weight4]: {x_ft[:, :, self.modes1 :, self.modes2 :, : -self.modes3, :self.modes4].size()} weight4: {self.weights4.size()}')
 
-        out_ft[
-            :, :, : self.modes1, : self.modes2, : self.modes3, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, : self.modes1, : self.modes2, : self.modes3, : self.modes4],
-            self.weights1,
+        out_ft[:, :, : self.modes1, : self.modes2, : self.modes3, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[:, :, : self.modes1, : self.modes2, : self.modes3, : self.modes4],
+                self.weights1,
+            )
         )
-        out_ft[
-            :, :, -self.modes1 :, : self.modes2, : self.modes3, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, -self.modes1 :, : self.modes2, : self.modes3, : self.modes4],
-            self.weights2,
+        out_ft[:, :, -self.modes1 :, : self.modes2, : self.modes3, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[:, :, -self.modes1 :, : self.modes2, : self.modes3, : self.modes4],
+                self.weights2,
+            )
         )
-        out_ft[
-            :, :, : self.modes1, -self.modes2 :, : self.modes3, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, : self.modes1, -self.modes2 :, : self.modes3, : self.modes4],
-            self.weights3,
+        out_ft[:, :, : self.modes1, -self.modes2 :, : self.modes3, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[:, :, : self.modes1, -self.modes2 :, : self.modes3, : self.modes4],
+                self.weights3,
+            )
         )
-        out_ft[
-            :, :, : self.modes1, : self.modes2, -self.modes3 :, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, : self.modes1, : self.modes2, -self.modes3 :, : self.modes4],
-            self.weights4,
+        out_ft[:, :, : self.modes1, : self.modes2, -self.modes3 :, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[:, :, : self.modes1, : self.modes2, -self.modes3 :, : self.modes4],
+                self.weights4,
+            )
         )
-        out_ft[
-            :, :, -self.modes1 :, -self.modes2 :, : self.modes3, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, -self.modes1 :, -self.modes2 :, : self.modes3, : self.modes4],
-            self.weights5,
+        out_ft[:, :, -self.modes1 :, -self.modes2 :, : self.modes3, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[
+                    :, :, -self.modes1 :, -self.modes2 :, : self.modes3, : self.modes4
+                ],
+                self.weights5,
+            )
         )
-        out_ft[
-            :, :, -self.modes1 :, : self.modes2, -self.modes3 :, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, -self.modes1 :, : self.modes2, -self.modes3 :, : self.modes4],
-            self.weights6,
+        out_ft[:, :, -self.modes1 :, : self.modes2, -self.modes3 :, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[
+                    :, :, -self.modes1 :, : self.modes2, -self.modes3 :, : self.modes4
+                ],
+                self.weights6,
+            )
         )
-        out_ft[
-            :, :, : self.modes1, -self.modes2 :, -self.modes3 :, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, : self.modes1, -self.modes2 :, -self.modes3 :, : self.modes4],
-            self.weights7,
+        out_ft[:, :, : self.modes1, -self.modes2 :, -self.modes3 :, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[
+                    :, :, : self.modes1, -self.modes2 :, -self.modes3 :, : self.modes4
+                ],
+                self.weights7,
+            )
         )
-        out_ft[
-            :, :, -self.modes1 :, -self.modes2 :, -self.modes3 :, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, -self.modes1 :, -self.modes2 :, -self.modes3 :, : self.modes4],
-            self.weights8,
+        out_ft[:, :, -self.modes1 :, -self.modes2 :, -self.modes3 :, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[
+                    :, :, -self.modes1 :, -self.modes2 :, -self.modes3 :, : self.modes4
+                ],
+                self.weights8,
+            )
         )
 
         # Return to physical space

--- a/physicsnemo/models/layers/transformer_decoder.py
+++ b/physicsnemo/models/layers/transformer_decoder.py
@@ -35,6 +35,7 @@ class TransformerDecoder(Module):
         norm: str
             Layer normalization component.
     """
+
     __constants__ = ["norm"]
 
     def __init__(self, decoder_layer, num_layers, norm=None):
@@ -98,6 +99,7 @@ class DecoderOnlyLayer(Module):
             bias. Default: ``True``.
 
     """
+
     __constants__ = ["norm_first"]
 
     def __init__(
@@ -272,7 +274,6 @@ def _detect_is_causal_mask(
 
 
 def _get_seq_len(src: Tensor, batch_first: bool) -> Optional[int]:
-
     if src.is_nested:
         return None
     else:

--- a/physicsnemo/models/mesh_reduced/mesh_reduced.py
+++ b/physicsnemo/models/mesh_reduced/mesh_reduced.py
@@ -200,7 +200,6 @@ class Mesh_Reduced(torch.nn.Module):
         return x
 
     def decode(self, x, edge_features, graph, position_mesh, position_pivotal):
-
         nodes_index = torch.arange(graph.batch_size).to(x.device)
         if isinstance(graph, DGLGraph):
             batch_mesh = nodes_index.repeat_interleave(graph.batch_num_nodes())

--- a/physicsnemo/models/module.py
+++ b/physicsnemo/models/module.py
@@ -57,9 +57,7 @@ class Module(torch.nn.Module):
     __model_checkpoint_version__ = (
         "0.1.0"  # Used for file versioning and is not the same as physicsnemo version
     )
-    __supported_model_checkpoint_version__ = (
-        {}
-    )  # Dict of supported model checkpoints and corresponding warnings messages
+    __supported_model_checkpoint_version__ = {}  # Dict of supported model checkpoints and corresponding warnings messages
 
     # __init__ arguments that can be overridden. By default all arguments are
     # protected. Subclasses can override this to allow for overriding of specific
@@ -175,7 +173,7 @@ class Module(torch.nn.Module):
         for key, value in override_args.items():
             if key not in cls._overridable_args:
                 raise ValueError(
-                    f"Argument '{key}' cannot be overridden for " f"{cls.__name__}."
+                    f"Argument '{key}' cannot be overridden for {cls.__name__}."
                 )
             # In this case we are not overriding, but we are adding a new arg
             if key not in args:

--- a/physicsnemo/models/module.py
+++ b/physicsnemo/models/module.py
@@ -405,8 +405,7 @@ class Module(torch.nn.Module):
                 )
                 if "filter" in tar.extractall.__code__.co_varnames:
                     extract_kwargs["filter"] = "data"
-
-                tar.extractall(**extract_kwargs)
+                tar.extractall(**extract_kwargs)  # noqa: S202
 
             # Check if the checkpoint is valid
             Module._check_checkpoint(local_path)
@@ -475,7 +474,7 @@ class Module(torch.nn.Module):
                 )
                 if "filter" in tar.extractall.__code__.co_varnames:
                     extract_kwargs["filter"] = "data"
-                tar.extractall(**extract_kwargs)
+                tar.extractall(**extract_kwargs)  # noqa: S202
 
             # Check if the checkpoint is valid
             Module._check_checkpoint(local_path)

--- a/physicsnemo/models/module.py
+++ b/physicsnemo/models/module.py
@@ -357,18 +357,12 @@ class Module(torch.nn.Module):
             fs.put(str(local_path / "model.tar"), file_name)
 
     @staticmethod
-    def _check_checkpoint(local_path: str) -> bool:
-        if not local_path.joinpath("args.json").exists():
-            raise IOError("File 'args.json' not found in checkpoint")
-
-        if not local_path.joinpath("metadata.json").exists():
-            raise IOError("File 'metadata.json' not found in checkpoint")
-
-        if not local_path.joinpath("model.pt").exists():
-            raise IOError("Model weights 'model.pt' not found in checkpoint")
-
-        if not local_path.joinpath("metadata.json").exists():
-            raise IOError("Metadata 'metadata.json' not found in checkpoint")
+    def _check_checkpoint(local_path: Path | str) -> None:
+        local_path = Path(local_path)
+        expected_files = ["args.json", "metadata.json", "model.pt"]
+        for file in expected_files:
+            if not (local_path / file).exists():
+                raise IOError(f"File '{file}' not found in checkpoint")
 
     def load(
         self,

--- a/physicsnemo/models/pix2pix/pix2pix.py
+++ b/physicsnemo/models/pix2pix/pix2pix.py
@@ -1,6 +1,7 @@
 # ignore_header_test
 # ruff: noqa: E402
 """"""
+
 """
 Pix2Pix model. This code was modified from, https://github.com/NVIDIA/pix2pixHD
 

--- a/physicsnemo/models/pix2pix/pix2pixunet.py
+++ b/physicsnemo/models/pix2pix/pix2pixunet.py
@@ -365,7 +365,7 @@ class UnetSkipConnectionBlock(nn.Module):
     ):
         super().__init__()
         self.outermost = outermost
-        if type(norm_layer) == functools.partial:
+        if isinstance(norm_layer, functools.partial):
             use_bias = norm_layer.func == nn.InstanceNorm2d
         else:
             use_bias = norm_layer == nn.InstanceNorm2d

--- a/physicsnemo/models/rnn/layers.py
+++ b/physicsnemo/models/rnn/layers.py
@@ -114,9 +114,10 @@ class _ConvLayer(nn.Module):
             x = F.pad(x, [pad_w // 2, pad_w - pad_w // 2], mode="constant", value=0.0)
         elif input_length == 2:
             ih, iw = x.size()[-2:]
-            pad_h, pad_w = _get_same_padding(
-                ih, self.kernel_size, self.stride
-            ), _get_same_padding(iw, self.kernel_size, self.stride)
+            pad_h, pad_w = (
+                _get_same_padding(ih, self.kernel_size, self.stride),
+                _get_same_padding(iw, self.kernel_size, self.stride),
+            )
             x = F.pad(
                 x,
                 [pad_h // 2, pad_h - pad_h // 2, pad_w // 2, pad_w - pad_w // 2],
@@ -244,11 +245,14 @@ class _TransposeConvLayer(nn.Module):
             ]
         elif input_length == 2:
             ih, iw = orig_x.size()[-2:]
-            pad_h, pad_w = _get_same_padding(
-                ih,
-                self.kernel_size,
-                self.stride,
-            ), _get_same_padding(iw, self.kernel_size, self.stride)
+            pad_h, pad_w = (
+                _get_same_padding(
+                    ih,
+                    self.kernel_size,
+                    self.stride,
+                ),
+                _get_same_padding(iw, self.kernel_size, self.stride),
+            )
             x = x[
                 :,
                 :,
@@ -459,11 +463,14 @@ class _ConvResidualBlock(nn.Module):
                 )
             elif len(orig_x.size()) - 2 == 2:
                 ih, iw = orig_x.size()[-2:]
-                pad_h, pad_w = _get_same_padding(
-                    ih,
-                    2,
-                    2,
-                ), _get_same_padding(iw, 2, 2)
+                pad_h, pad_w = (
+                    _get_same_padding(
+                        ih,
+                        2,
+                        2,
+                    ),
+                    _get_same_padding(iw, 2, 2),
+                )
                 pool = torch.nn.AvgPool2d(
                     2, 2, padding=(pad_h // 2, pad_w // 2), count_include_pad=False
                 )

--- a/physicsnemo/models/srrn/super_res_net.py
+++ b/physicsnemo/models/srrn/super_res_net.py
@@ -2,6 +2,7 @@
 # ruff: noqa: E402
 
 """"""
+
 """
 SRResNet model. This code was modified from, 
 https://github.com/sgrvinod/a-PyTorch-Tutorial-to-Super-Resolution

--- a/physicsnemo/models/topodiff/diffusion.py
+++ b/physicsnemo/models/topodiff/diffusion.py
@@ -25,7 +25,6 @@ class Diffusion:
     """
 
     def __init__(self, n_steps=1000, min_beta=10**-4, max_beta=0.02, device="cpu"):
-
         self.n_steps = n_steps
         self.device = device
 
@@ -44,7 +43,6 @@ class Diffusion:
         self.loss = nn.MSELoss()
 
     def q_sample(self, x0, t, noise=None):
-
         """
         Diffuse the input data.
         """
@@ -62,7 +60,6 @@ class Diffusion:
         return x
 
     def p_sample(self, model, xt, t, cons):
-
         """
         Sample from the posterior distribution.
         """
@@ -70,7 +67,6 @@ class Diffusion:
         return model(xt, cons, t)
 
     def train_loss(self, model, x0, cons):
-
         """
         Compute the training loss.
         """

--- a/physicsnemo/models/topodiff/topodiff.py
+++ b/physicsnemo/models/topodiff/topodiff.py
@@ -18,7 +18,6 @@
 Model architectures used in the paper Diffusion models beat gans on image synthesis".
 """
 
-
 from dataclasses import dataclass
 from typing import List
 
@@ -260,7 +259,6 @@ class UNetEncoder(Module):
         dropout=0,
         output_prob=False,
     ):
-
         super().__init__()
 
         self.in_channels = in_channels
@@ -284,7 +282,6 @@ class UNetEncoder(Module):
         for level, mult in enumerate(channel_mult):
             attention = ds in attention_resolutions
             for i in range(num_res_blocks):
-
                 down = i == num_res_blocks - 1 and level != len(channel_mult) - 1
 
                 layer = UNetBlock(

--- a/physicsnemo/models/topodiff/utils.py
+++ b/physicsnemo/models/topodiff/utils.py
@@ -20,7 +20,6 @@ from torch.utils.data import DataLoader, Dataset
 
 class DatasetTopoDiff(Dataset):
     def __init__(self, topologies, stress, strain, load_im, constraints):
-
         self.topologies = topologies
         self.constraints = constraints
         self.image_size = topologies.shape[1]
@@ -33,7 +32,6 @@ class DatasetTopoDiff(Dataset):
         return self.topologies.shape[0]
 
     def __getitem__(self, idx):
-
         cons = self.constraints[idx]
 
         vol_frac = cons["VOL_FRAC"]

--- a/physicsnemo/models/transolver/Embedding.py
+++ b/physicsnemo/models/transolver/Embedding.py
@@ -1,6 +1,7 @@
 # ignore_header_test
 # ruff: noqa: E402
 """"""
+
 """
 Transolver model. This code was modified from, https://github.com/thuml/Transolver
 

--- a/physicsnemo/models/transolver/Physics_Attention.py
+++ b/physicsnemo/models/transolver/Physics_Attention.py
@@ -1,6 +1,7 @@
 # ignore_header_test
 # ruff: noqa: E402
 """"""
+
 """
 Transolver model. This code was modified from, https://github.com/thuml/Transolver
 

--- a/physicsnemo/models/transolver/__init__.py
+++ b/physicsnemo/models/transolver/__init__.py
@@ -1,6 +1,7 @@
 # ignore_header_test
 # ruff: noqa: E402
 """"""
+
 """
 Transolver model. This code was modified from, https://github.com/thuml/Transolver
 

--- a/physicsnemo/models/transolver/transolver.py
+++ b/physicsnemo/models/transolver/transolver.py
@@ -1,6 +1,7 @@
 # ignore_header_test
 # ruff: noqa: E402
 """"""
+
 """
 Transolver model. This code was modified from, https://github.com/thuml/Transolver
 

--- a/physicsnemo/models/util_compatibility.py
+++ b/physicsnemo/models/util_compatibility.py
@@ -21,7 +21,6 @@ def convert_ckp_apex(
     model_args: Dict[str, Any],
     model_dict: Dict[str, Any],
 ) -> Dict[str, Any]:
-
     """Utility for converting Apex GroupNorm-related keys in a checkpoint.
 
     This function modifies the checkpoint arguments and model dictionary

--- a/physicsnemo/models/utils/patch_embed.py
+++ b/physicsnemo/models/utils/patch_embed.py
@@ -89,9 +89,9 @@ class PatchEmbed3D(nn.Module):
         self.img_size = img_size
         level, height, width = img_size
         l_patch_size, h_patch_size, w_patch_size = patch_size
-        padding_left = (
-            padding_right
-        ) = padding_top = padding_bottom = padding_front = padding_back = 0
+        padding_left = padding_right = padding_top = padding_bottom = padding_front = (
+            padding_back
+        ) = 0
 
         l_remainder = level % l_patch_size
         h_remainder = height % l_patch_size

--- a/physicsnemo/models/utils/utils.py
+++ b/physicsnemo/models/utils/utils.py
@@ -88,9 +88,9 @@ def get_pad3d(input_resolution, window_size):
     Pl, Lat, Lon = input_resolution
     win_pl, win_lat, win_lon = window_size
 
-    padding_left = (
-        padding_right
-    ) = padding_top = padding_bottom = padding_front = padding_back = 0
+    padding_left = padding_right = padding_top = padding_bottom = padding_front = (
+        padding_back
+    ) = 0
     pl_remainder = Pl % win_pl
     lat_remainder = Lat % win_lat
     lon_remainder = Lon % win_lon

--- a/physicsnemo/models/vfgn/graph_network_modules.py
+++ b/physicsnemo/models/vfgn/graph_network_modules.py
@@ -760,9 +760,7 @@ class LearnedSimulator(Module):
         num_velocities = velocity_sequence.shape[1]
         velocity_sequence_noise = torch.empty(
             velocity_sequence.shape, dtype=velocity_sequence.dtype
-        ).normal_(
-            mean=0, std=noise_std_last_step / num_velocities**0.5
-        )  # float
+        ).normal_(mean=0, std=noise_std_last_step / num_velocities**0.5)  # float
 
         # Apply the random walk
         velocity_sequence_noise = torch.cumsum(velocity_sequence_noise, dim=1)

--- a/physicsnemo/utils/capture.py
+++ b/physicsnemo/utils/capture.py
@@ -437,7 +437,6 @@ class StaticCaptureTraining(_StaticCapture):
 
 
 class StaticCaptureEvaluateNoGrad(_StaticCapture):
-
     """An performance optimization decorator for PyTorch no grad evaluation.
 
     This class should be initialized as a decorator on a function that computes run the

--- a/physicsnemo/utils/corrdiff/utils.py
+++ b/physicsnemo/utils/corrdiff/utils.py
@@ -74,8 +74,7 @@ def regression_step(
     # Safety check: avoid silently ignoring batch elements in img_lr
     if img_lr.shape[0] > 1:
         raise ValueError(
-            f"Expected img_lr to have a batch size of 1, "
-            f"but found {img_lr.shape[0]}."
+            f"Expected img_lr to have a batch size of 1, but found {img_lr.shape[0]}."
         )
 
     # Perform regression on a single batch element
@@ -106,7 +105,6 @@ def diffusion_step(
     distribution: Literal["normal", "student_t"] = "normal",
     nu: Optional[int] = None,
 ) -> torch.Tensor:
-
     """
     Generate images using diffusion techniques as described in the relevant paper.
 

--- a/physicsnemo/utils/diffusion/utils.py
+++ b/physicsnemo/utils/diffusion/utils.py
@@ -512,7 +512,7 @@ def list_dir_recursively_with_ignore(
 
 
 def copy_files_and_create_dirs(
-    files: List[Tuple[str, str]]
+    files: List[Tuple[str, str]],
 ) -> None:  # pragma: no cover
     """
     Takes in a list of tuples of (src, dst) paths and copies files.
@@ -575,9 +575,7 @@ try:
     nan_to_num = torch.nan_to_num  # 1.8.0a0
 except AttributeError:
 
-    def nan_to_num(
-        input, nan=0.0, posinf=None, neginf=None, *, out=None
-    ):  # pylint: disable=redefined-builtin  # pragma: no cover
+    def nan_to_num(input, nan=0.0, posinf=None, neginf=None, *, out=None):  # pylint: disable=redefined-builtin  # pragma: no cover
         """Replace NaN/Inf with specified numerical values"""
         if not isinstance(input, torch.Tensor):
             raise TypeError("input should be a Tensor")
@@ -637,13 +635,17 @@ def assert_shape(tensor, ref_shape):  # pragma: no cover
         if ref_size is None:
             pass
         elif isinstance(ref_size, torch.Tensor):
-            with suppress_tracer_warnings():  # as_tensor results are registered as constants
+            with (
+                suppress_tracer_warnings()
+            ):  # as_tensor results are registered as constants
                 symbolic_assert(
                     torch.equal(torch.as_tensor(size), ref_size),
                     f"Wrong size for dimension {idx}",
                 )
         elif isinstance(size, torch.Tensor):
-            with suppress_tracer_warnings():  # as_tensor results are registered as constants
+            with (
+                suppress_tracer_warnings()
+            ):  # as_tensor results are registered as constants
                 symbolic_assert(
                     torch.equal(size, torch.as_tensor(ref_size)),
                     f"Wrong size for dimension {idx}: expected {ref_size}",

--- a/physicsnemo/utils/graphcast/icosahedral_mesh.py
+++ b/physicsnemo/utils/graphcast/icosahedral_mesh.py
@@ -226,7 +226,6 @@ class _ChildVerticesBuilder(object):
     """Bookkeeping of new child vertices added to an existing set of vertices."""
 
     def __init__(self, parent_vertices):
-
         # Because the same new vertex will be required when splitting adjacent
         # triangles (which share an edge) we keep them in a hash table indexed by
         # sorted indices of the vertices adjacent to the edge, to avoid creating

--- a/physicsnemo/utils/patching.py
+++ b/physicsnemo/utils/patching.py
@@ -183,7 +183,6 @@ class RandomPatching2D(BasePatching2D):
     def __init__(
         self, img_shape: Tuple[int, int], patch_shape: Tuple[int, int], patch_num: int
     ) -> None:
-
         super().__init__(img_shape, patch_shape)
         self._patch_num = patch_num
         # Generate the indices of the patches to extract

--- a/physicsnemo/utils/profiling/interface.py
+++ b/physicsnemo/utils/profiling/interface.py
@@ -278,7 +278,6 @@ class Profiler(metaclass=_Profiler_Singleton):
         return self._deferred_or_immediate_decoration(fn)
 
     def _deferred_or_immediate_decoration(self, func):
-
         if self.initialized:
             return self._decorate_function(func)
         else:
@@ -307,7 +306,6 @@ class Profiler(metaclass=_Profiler_Singleton):
         # )
 
         if "." in func.__qualname__:
-
             qualname_parts = func.__qualname__.split(".")
             # If the object is local, it's annoying.
             # Best we can do is update references in the module

--- a/physicsnemo/utils/profiling/torch.py
+++ b/physicsnemo/utils/profiling/torch.py
@@ -132,7 +132,6 @@ class TorchProfileWrapper(PhysicsNeMoProfilerWrapper, metaclass=_Profiler_Single
         # Get the output directory:
         out_top = self.output_dir(output_top)
         if self._profiler is not None and self._profiler.profiler is not None:
-
             try:
                 averages = self._profiler.key_averages()
             except AssertionError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,17 +115,17 @@ include = ["physicsnemo", "physicsnemo.*"]
 [tool.ruff]
 # Enable flake8/pycodestyle (`E`), Pyflakes (`F`), flake8-bandit (`S`),
 # isort (`I`), and performance 'PERF' rules.
-select = ["E", "F", "S", "I", "PERF"]
-fixable = ["I"]
+lint.select = ["E", "F", "S", "I", "PERF"]
+lint.fixable = ["I"]
 
 # Never enforce `E402`, `E501` (line length violations),
 # and `S311` (random number generators)
-ignore = ["E501", "S311"]
+lint.ignore = ["E501", "S311"]
 
 # Exclude the examples and experimental folders
 exclude = ["examples", "physicsnemo/experimental"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Ignore `F401` (import violations) in all `__init__.py` files, and in `docs/*.py`.
 "__init__.py" = ["F401"]
 "docs/*.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ lint.fixable = ["I"]
 lint.ignore = ["E501", "S311"]
 
 # Exclude the examples and experimental folders
-exclude = ["examples", "physicsnemo/experimental"]
+exclude = ["docs", "examples", "physicsnemo/experimental"]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore `F401` (import violations) in all `__init__.py` files, and in `docs/*.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,9 @@ launch = [
 dev = [
     "pytest>=6.0.0",
     "pyyaml>=6.0",
-    "black==22.10.0",
     "interrogate==1.5.0",
     "coverage==6.5.0",
-    "ruff==0.0.290",
+    "ruff==0.12.5",
     "moto[s3]>=5.0.28",
 ]
 

--- a/test/ci_tests/header_check.py
+++ b/test/ci_tests/header_check.py
@@ -108,8 +108,8 @@ def get_committed_files():
     git_executable = shutil.which("git")
     if not git_executable:
         raise RuntimeError("git executable not found in PATH")
-    result = subprocess.run(
-        [git_executable, "diff", "--name-only", "--cached"],  # noqa: S603
+    result = subprocess.run(  # noqa: S603
+        [git_executable, "diff", "--name-only", "--cached"],
         capture_output=True,
         text=True,
     )

--- a/test/datapipes/test_climate.py
+++ b/test/datapipes/test_climate.py
@@ -70,6 +70,7 @@ datapipe_kwargs = dict(
     shuffle=False,
 )
 
+
 # Skip CPU tests because too slow
 @import_or_fail("netCDF4")
 @pytest.mark.parametrize("device", ["cuda:0"])
@@ -82,7 +83,6 @@ def test_climate_hdf5_constructor(
     device,
     pytestconfig,
 ):
-
     from physicsnemo.datapipes.climate import ClimateDatapipe, ClimateDataSourceSpec
     from physicsnemo.datapipes.climate.utils import invariant
 
@@ -91,7 +91,7 @@ def test_climate_hdf5_constructor(
         data_dir=data_dir,
         stats_files=stats_files,
         metadata_path=metadata_path,
-        **spec_kwargs
+        **spec_kwargs,
     )
     invariants = {
         "land_sea_mask": invariant.FileInvariant(lsm_filename, "lsm"),
@@ -113,13 +113,13 @@ def test_climate_hdf5_constructor(
             data_dir="/null_path",
             stats_files=stats_files,
             metadata_path=metadata_path,
-            **spec_kwargs
+            **spec_kwargs,
         )
         datapipe = ClimateDatapipe(
             [spec],
             invariants=invariants,
             device=torch.device(device),
-            **datapipe_kwargs
+            **datapipe_kwargs,
         )
         raise IOError("Failed to raise error given null data path")
     except IOError:
@@ -133,13 +133,13 @@ def test_climate_hdf5_constructor(
             data_dir=data_dir,
             stats_files={"mean": "/null_path", "std": "/null_path"},
             metadata_path=metadata_path,
-            **spec_kwargs
+            **spec_kwargs,
         )
         datapipe = ClimateDatapipe(
             [spec],
             invariants=invariants,
             device=torch.device(device),
-            **datapipe_kwargs
+            **datapipe_kwargs,
         )
         raise IOError("Failed to raise error given null stats path")
     except IOError:
@@ -151,13 +151,13 @@ def test_climate_hdf5_constructor(
             data_dir=data_dir,
             stats_files=stats_files,
             metadata_path=metadata_path,
-            **spec_kwargs
+            **spec_kwargs,
         )
         datapipe = ClimateDatapipe(
             [spec],
             invariants=invariants,
             device=torch.device(device),
-            **{**datapipe_kwargs, **{"num_samples_per_year": 5}}
+            **{**datapipe_kwargs, **{"num_samples_per_year": 5}},
         )
         raise ValueError("Failed to raise error given invalid num_samples_per_year")
     except ValueError:
@@ -169,13 +169,13 @@ def test_climate_hdf5_constructor(
             data_dir=data_dir,
             stats_files=stats_files,
             metadata_path=metadata_path,
-            **{**spec_kwargs, **{"channels": [1]}}
+            **{**spec_kwargs, **{"channels": [1]}},
         )
         datapipe = ClimateDatapipe(
             [spec],
             invariants=invariants,
             device=torch.device(device),
-            **{**datapipe_kwargs, **{"num_samples_per_year": 5}}
+            **{**datapipe_kwargs, **{"num_samples_per_year": 5}},
         )
         raise ValueError("Failed to raise error given invalid channel id")
     except ValueError:
@@ -193,7 +193,6 @@ def test_climate_hdf5_device(
     device,
     pytestconfig,
 ):
-
     from physicsnemo.datapipes.climate import ClimateDatapipe, ClimateDataSourceSpec
     from physicsnemo.datapipes.climate.utils import invariant
 
@@ -202,7 +201,7 @@ def test_climate_hdf5_device(
         data_dir=data_dir,
         stats_files=stats_files,
         metadata_path=metadata_path,
-        **spec_kwargs
+        **spec_kwargs,
     )
     invariants = {
         "land_sea_mask": invariant.FileInvariant(lsm_filename, "lsm"),
@@ -242,7 +241,6 @@ def test_climate_hdf5_shape(
     device,
     pytestconfig,
 ):
-
     from physicsnemo.datapipes.climate import ClimateDatapipe, ClimateDataSourceSpec
     from physicsnemo.datapipes.climate.utils import invariant
 
@@ -332,7 +330,6 @@ def test_era5_hdf5_sequence(
     device,
     pytestconfig,
 ):
-
     from physicsnemo.datapipes.climate import ClimateDatapipe, ClimateDataSourceSpec
     from physicsnemo.datapipes.climate.utils import invariant
 
@@ -385,7 +382,6 @@ def test_era5_hdf5_shuffle(
     device,
     pytestconfig,
 ):
-
     from physicsnemo.datapipes.climate import ClimateDatapipe, ClimateDataSourceSpec
     from physicsnemo.datapipes.climate.utils import invariant
 
@@ -437,7 +433,6 @@ def test_era5_hdf5_cudagraphs(
     metadata_path,
     pytestconfig,
 ):
-
     from physicsnemo.datapipes.climate import ClimateDatapipe, ClimateDataSourceSpec
     from physicsnemo.datapipes.climate.utils import invariant
 
@@ -450,7 +445,7 @@ def test_era5_hdf5_cudagraphs(
         data_dir=data_dir,
         stats_files=stats_files,
         metadata_path=metadata_path,
-        **spec_kwargs
+        **spec_kwargs,
     )
     invariants = {
         "land_sea_mask": invariant.FileInvariant(lsm_filename, "lsm"),

--- a/test/datapipes/test_darcy.py
+++ b/test/datapipes/test_darcy.py
@@ -28,7 +28,6 @@ Tensor = torch.Tensor
 @import_or_fail("warp")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_darcy_2d_constructor(device, pytestconfig):
-
     from physicsnemo.datapipes.benchmarks.darcy import Darcy2D
 
     # construct data pipe
@@ -53,7 +52,6 @@ def test_darcy_2d_constructor(device, pytestconfig):
 @import_or_fail("warp")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_darcy_2d_device(device, pytestconfig):
-
     from physicsnemo.datapipes.benchmarks.darcy import Darcy2D
 
     # construct data pipe
@@ -83,7 +81,6 @@ def test_darcy_2d_device(device, pytestconfig):
 @pytest.mark.parametrize("batch_size", [1, 2, 3])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_darcy_2d_shape(resolution, batch_size, device, pytestconfig):
-
     from physicsnemo.datapipes.benchmarks.darcy import Darcy2D
 
     # construct data pipe
@@ -122,7 +119,6 @@ def test_darcy_2d_shape(resolution, batch_size, device, pytestconfig):
 @import_or_fail("warp")
 @pytest.mark.parametrize("device", ["cuda:0"])
 def test_darcy_cudagraphs(device, pytestconfig):
-
     from physicsnemo.datapipes.benchmarks.darcy import Darcy2D
 
     # Preprocess function to convert dataloader output into Tuple of tensors

--- a/test/datapipes/test_drivaernet.py
+++ b/test/datapipes/test_drivaernet.py
@@ -31,7 +31,6 @@ def data_dir(nfs_data_dir):
 @import_or_fail(["vtk", "pyvista", "dgl"])
 @pytest.mark.parametrize("cache_graph", [True, False])
 def test_drivaernet_init(data_dir, cache_graph, tmp_path, pytestconfig):
-
     from physicsnemo.datapipes.gnn.drivaernet_dataset import DrivAerNetDataset
 
     cache_dir = tmp_path / "cache" if cache_graph else None

--- a/test/datapipes/test_healpix.py
+++ b/test/datapipes/test_healpix.py
@@ -136,7 +136,6 @@ def test_open_time_series(data_dir, dataset_name, pytestconfig):
 @import_or_fail("netCDF4")
 @import_or_fail("numpy")
 def test_create_time_series(data_dir, dataset_name, create_path, pytestconfig):
-
     from physicsnemo.datapipes.healpix.data_modules import (
         create_time_series_dataset_classic,
     )
@@ -202,7 +201,6 @@ def test_create_time_series(data_dir, dataset_name, create_path, pytestconfig):
 def test_TimeSeriesDataset_initialization(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
-
     from physicsnemo.datapipes.healpix.timeseries_dataset import TimeSeriesDataset
 
     # open our test dataset
@@ -643,7 +641,6 @@ def test_TimeSeriesDataModule_get_constants(
 def test_TimeSeriesDataModule_get_dataloaders(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
-
     from physicsnemo.datapipes.healpix.data_modules import (
         TimeSeriesDataModule,
     )

--- a/test/datapipes/test_healpix_couple.py
+++ b/test/datapipes/test_healpix_couple.py
@@ -106,7 +106,6 @@ def scaling_double_dict():
 @import_or_fail("pandas")
 @import_or_fail("xarray")
 def test_ConstantCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
-
     from physicsnemo.datapipes.healpix.couplers import (
         ConstantCoupler,
     )
@@ -420,7 +419,6 @@ def test_TrailingAverageCoupler(data_dir, dataset_name, scaling_dict, pytestconf
 def test_CoupledTimeSeriesDataset_initialization(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
-
     from physicsnemo.datapipes.healpix.coupledtimeseries_dataset import (
         CoupledTimeSeriesDataset,
     )
@@ -531,7 +529,6 @@ def test_CoupledTimeSeriesDataset_initialization(
 def test_CoupledTimeSeriesDataset_get_constants(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
-
     from physicsnemo.datapipes.healpix.coupledtimeseries_dataset import (
         CoupledTimeSeriesDataset,
     )
@@ -843,7 +840,6 @@ def test_CoupledTimeSeriesDataset_get(
 def test_CoupledTimeSeriesDataModule_initialization(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
-
     from physicsnemo.datapipes.healpix.data_modules import (
         CoupledTimeSeriesDataModule,
     )
@@ -952,7 +948,6 @@ def test_CoupledTimeSeriesDataModule_initialization(
 def test_CoupledTimeSeriesDataModule_get_constants(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
-
     from physicsnemo.datapipes.healpix.data_modules import (
         CoupledTimeSeriesDataModule,
     )
@@ -1048,7 +1043,6 @@ def test_CoupledTimeSeriesDataModule_get_constants(
 def test_CoupledTimeSeriesDataModule_get_dataloaders(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
-
     from physicsnemo.datapipes.healpix.data_modules import (
         CoupledTimeSeriesDataModule,
     )

--- a/test/datapipes/test_kelvin_helmholtz.py
+++ b/test/datapipes/test_kelvin_helmholtz.py
@@ -28,7 +28,6 @@ Tensor = torch.Tensor
 @import_or_fail("warp")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_kelvin_helmholtz_2d_constructor(device, pytestconfig):
-
     from physicsnemo.datapipes.benchmarks.kelvin_helmholtz import KelvinHelmholtz2D
 
     # construct data pipe
@@ -52,7 +51,6 @@ def test_kelvin_helmholtz_2d_constructor(device, pytestconfig):
 @import_or_fail("warp")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_kelvin_helmholtz_2d_device(device, pytestconfig):
-
     from physicsnemo.datapipes.benchmarks.kelvin_helmholtz import KelvinHelmholtz2D
 
     # construct data pipe
@@ -85,7 +83,6 @@ def test_kelvin_helmholtz_2d_device(device, pytestconfig):
 def test_kelvin_helmholtz_2d_shape(
     resolution, batch_size, seq_length, device, pytestconfig
 ):
-
     from physicsnemo.datapipes.benchmarks.kelvin_helmholtz import KelvinHelmholtz2D
 
     # construct data pipe
@@ -126,7 +123,6 @@ def test_kelvin_helmholtz_2d_shape(
 @import_or_fail("warp")
 @pytest.mark.parametrize("device", ["cuda:0"])
 def test_kelvin_helmholtz_cudagraphs(device, pytestconfig):
-
     from physicsnemo.datapipes.benchmarks.kelvin_helmholtz import KelvinHelmholtz2D
 
     # Preprocess function to convert dataloader output into Tuple of tensors

--- a/test/distributed/test_autograd.py
+++ b/test/distributed/test_autograd.py
@@ -28,7 +28,6 @@ from physicsnemo.distributed.autograd import (
 
 
 def run_test_scatter_v(rank, world_size):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{world_size}",
@@ -36,7 +35,6 @@ def run_test_scatter_v(rank, world_size):
         MASTER_PORT=str(12355),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         DistributedManager.initialize()
 
         manager = DistributedManager()
@@ -71,7 +69,6 @@ def run_test_scatter_v(rank, world_size):
 
 
 def run_test_gather_v(rank, world_size):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{world_size}",
@@ -79,7 +76,6 @@ def run_test_gather_v(rank, world_size):
         MASTER_PORT=str(12355),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         DistributedManager.initialize()
 
         manager = DistributedManager()
@@ -117,7 +113,6 @@ def run_test_gather_v(rank, world_size):
 
 
 def run_test_all_gather_v(rank, world_size):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{world_size}",
@@ -125,7 +120,6 @@ def run_test_all_gather_v(rank, world_size):
         MASTER_PORT=str(12355),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         DistributedManager.initialize()
 
         manager = DistributedManager()
@@ -162,7 +156,6 @@ def run_test_all_gather_v(rank, world_size):
 
 
 def run_test_indexed_all_to_all_v(rank, world_size):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{world_size}",
@@ -170,7 +163,6 @@ def run_test_indexed_all_to_all_v(rank, world_size):
         MASTER_PORT=str(12355),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         DistributedManager.initialize()
 
         manager = DistributedManager()

--- a/test/distributed/test_config.py
+++ b/test/distributed/test_config.py
@@ -53,9 +53,9 @@ def test_config():
     group_sizes = {"channel_parallel": 3, "spatial_parallel": 2, "data_parallel": 4}
     config.set_leaf_group_sizes(group_sizes)  # Update all parent group sizes too
 
-    assert (
-        config.get_node("model_parallel").size == 6
-    ), "Incorrect size for 'model_parallel' parent node"
+    assert config.get_node("model_parallel").size == 6, (
+        "Incorrect size for 'model_parallel' parent node"
+    )
 
     assert config.get_node("world").size == 24, "Incorrect size for 'world' parent node"
 
@@ -91,7 +91,6 @@ def run_distributed_model_config(rank, model_parallel_size, verbose):
         MASTER_PORT=str(12355),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         DistributedManager._shared_state = {}
 
         DistributedManager.initialize()
@@ -104,13 +103,13 @@ def run_distributed_model_config(rank, model_parallel_size, verbose):
         group_sizes = {"model_parallel": 2, "data_parallel": 1}
         config.set_leaf_group_sizes(group_sizes)  # Updates all parent group sizes too
 
-        assert (
-            config.get_node("model_parallel").size == 2
-        ), "Incorrect size for 'model_parallel' parent node"
+        assert config.get_node("model_parallel").size == 2, (
+            "Incorrect size for 'model_parallel' parent node"
+        )
 
-        assert (
-            config.get_node("world").size == 2
-        ), "Incorrect size for 'world' parent node"
+        assert config.get_node("world").size == 2, (
+            "Incorrect size for 'world' parent node"
+        )
 
         # Create model parallel process group
         DistributedManager.create_groups_from_config(config, verbose=verbose)

--- a/test/distributed/test_distributed_fft.py
+++ b/test/distributed/test_distributed_fft.py
@@ -24,7 +24,6 @@ from physicsnemo.distributed.fft import DistributedRFFT2
 
 
 def distributed_setup(rank, model_parallel_size, verbose):
-
     DistributedManager._shared_state = {}
 
     # Setup distributed process config

--- a/test/distributed/test_manager.py
+++ b/test/distributed/test_manager.py
@@ -39,16 +39,15 @@ def test_manager():
         MASTER_PORT=str(12355),
         LOCAL_RANK="0",
     ):
-
         DistributedManager.initialize()
         print(DistributedManager())
 
         manager = DistributedManager()
 
         assert manager.is_initialized()
-        assert (
-            manager.distributed == torch.distributed.is_available()
-        ), "Manager should be in serial mode"
+        assert manager.distributed == torch.distributed.is_available(), (
+            "Manager should be in serial mode"
+        )
         assert manager.rank == 0
         assert manager.world_size == 1
         assert manager.local_rank == 0
@@ -57,7 +56,6 @@ def test_manager():
 
 
 def test_manager_slurm():
-
     # Test distributed manager with Slurm variables
     with modify_environment(
         MASTER_ADDR="localhost",
@@ -79,7 +77,6 @@ def test_manager_slurm():
 
 
 def test_manager_ompi():
-
     with modify_environment(
         MASTER_ADDR="localhost",
         MASTER_PORT="12345",
@@ -108,7 +105,6 @@ def test_manager_specified_initialization():
         WORLD_SIZE="1",
         LOCAL_RANK="0",
     ):
-
         with modify_environment(
             SLURM_PROCID="0",
             SLURM_NPROCS="1",
@@ -124,9 +120,9 @@ def test_manager_specified_initialization():
             manager = DistributedManager()
             assert manager.is_initialized()
             assert manager._initialization_method == "slurm"
-            assert (
-                manager.distributed == torch.distributed.is_available()
-            ), "Manager should be in serial mode"
+            assert manager.distributed == torch.distributed.is_available(), (
+                "Manager should be in serial mode"
+            )
             assert manager.rank == 0
             assert manager.world_size == 1
             assert manager.local_rank == 0
@@ -144,9 +140,9 @@ def test_manager_specified_initialization():
             manager = DistributedManager()
             assert manager.is_initialized()
             assert manager._initialization_method == "openmpi"
-            assert (
-                manager.distributed == torch.distributed.is_available()
-            ), "Manager should be in serial mode"
+            assert manager.distributed == torch.distributed.is_available(), (
+                "Manager should be in serial mode"
+            )
             assert manager.rank == 0
             assert manager.world_size == 1
             assert manager.local_rank == 0
@@ -162,7 +158,6 @@ def test_manager_singleton():
         WORLD_SIZE="1",
         LOCAL_RANK="0",
     ):
-
         DistributedManager.initialize()
 
         manager_1 = DistributedManager()
@@ -195,7 +190,6 @@ def test_manager_uninitialized_instantiation():
         WORLD_SIZE="1",
         LOCAL_RANK="0",
     ):
-
         assert not DistributedManager.is_initialized()
 
         with pytest.raises(PhysicsNeMoUninitializedDistributedManagerWarning):
@@ -212,7 +206,6 @@ def test_manager_undefined_group_query():
         WORLD_SIZE="1",
         LOCAL_RANK="0",
     ):
-
         DistributedManager.initialize()
 
         manager = DistributedManager()
@@ -238,7 +231,6 @@ def test_manager_single_process_subgroups():
         MASTER_PORT=str(12375),
         LOCAL_RANK="0",
     ):
-
         DistributedManager.initialize()
 
         verbose = False
@@ -269,7 +261,6 @@ def run_process_groups(rank, model_parallel_size, verbose):
         MASTER_PORT=str(12365),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         DistributedManager.initialize()
 
         # Create model parallel process group
@@ -315,7 +306,6 @@ def run_process_groups_from_config(rank, model_parallel_size, verbose):
         MASTER_ADDR="localhost",
         MASTER_PORT="13246",
     ):
-
         DistributedManager.initialize()
         dm = DistributedManager()
         assert dm.is_initialized()
@@ -342,13 +332,13 @@ def run_process_groups_from_config(rank, model_parallel_size, verbose):
         }
         config.set_leaf_group_sizes(group_sizes)  # Updates all parent group sizes too
 
-        assert (
-            config.get_node("model_parallel").size == model_parallel_size
-        ), "Incorrect size for 'model_parallel' parent node"
+        assert config.get_node("model_parallel").size == model_parallel_size, (
+            "Incorrect size for 'model_parallel' parent node"
+        )
 
-        assert (
-            config.get_node("world").size == model_parallel_size
-        ), "Incorrect size for 'world' parent node"
+        assert config.get_node("world").size == model_parallel_size, (
+            "Incorrect size for 'world' parent node"
+        )
 
         # Create model parallel process group
         DistributedManager.create_groups_from_config(config, verbose=verbose)

--- a/test/distributed/test_mesh.py
+++ b/test/distributed/test_mesh.py
@@ -39,7 +39,6 @@ distributed_test = pytest.mark.skipif(
 
 
 def run_mesh_creation(rank, num_gpus, mesh_names, mesh_sizes, verbose):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{num_gpus}",
@@ -47,7 +46,6 @@ def run_mesh_creation(rank, num_gpus, mesh_names, mesh_sizes, verbose):
         MASTER_PORT=str(12355),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         DistributedManager.initialize()
         dm = DistributedManager()
         assert dm.is_initialized()
@@ -68,7 +66,6 @@ def run_mesh_creation(rank, num_gpus, mesh_names, mesh_sizes, verbose):
         if len(mesh_names) > 1:
             for i, i_name in enumerate(mesh_names):
                 for j, j_name in enumerate(mesh_names[i + 1 :]):
-
                     mesh_i = global_mesh[i_name].mesh.tolist()
                     mesh_j = global_mesh[j_name].mesh.tolist()
                     intersection = list(set(mesh_i) & set(mesh_j))

--- a/test/distributed/test_shard_tensor_function_registration.py
+++ b/test/distributed/test_shard_tensor_function_registration.py
@@ -102,7 +102,6 @@ def setup_registry():
 
 @pytest.fixture(scope="module")
 def device_mesh():
-
     with modify_environment(
         RANK="0",
         WORLD_SIZE="1",
@@ -131,12 +130,12 @@ def test_function_registration_with_tensors(setup_registry):
 
     # Verify result and execution path
     assert torch.all(result == 2)
-    assert (
-        len(torch_function_paths) == 0
-    ), "Regular tensors should not trigger our wrapper"
-    assert (
-        len(torch_dispatch_paths) == 0
-    ), "Regular tensors should not trigger our wrapper"
+    assert len(torch_function_paths) == 0, (
+        "Regular tensors should not trigger our wrapper"
+    )
+    assert len(torch_dispatch_paths) == 0, (
+        "Regular tensors should not trigger our wrapper"
+    )
 
 
 def test_function_registration_with_shard_tensors(setup_registry, device_mesh):
@@ -150,12 +149,12 @@ def test_function_registration_with_shard_tensors(setup_registry, device_mesh):
     # Verify result and execution path
     assert isinstance(result, ShardTensor)
     assert torch.all(result.to_local() == 2)
-    assert torch_function_paths == [
-        "mul_wrapper"
-    ], "ShardTensors should trigger our wrapper"
-    assert (
-        len(torch_dispatch_paths) == 0
-    ), "torch_function intercepts should not trigger dispatch intercepts"
+    assert torch_function_paths == ["mul_wrapper"], (
+        "ShardTensors should trigger our wrapper"
+    )
+    assert len(torch_dispatch_paths) == 0, (
+        "torch_function intercepts should not trigger dispatch intercepts"
+    )
 
 
 def test_dispatch_registration_with_tensors(setup_registry):
@@ -168,12 +167,12 @@ def test_dispatch_registration_with_tensors(setup_registry):
 
     # Verify result
     assert torch.all(result == 3)
-    assert (
-        len(torch_dispatch_paths) == 0
-    ), "Regular tensors should not trigger our wrapper"
-    assert (
-        len(torch_function_paths) == 0
-    ), "Regular tensors should not trigger our wrapper"
+    assert len(torch_dispatch_paths) == 0, (
+        "Regular tensors should not trigger our wrapper"
+    )
+    assert len(torch_function_paths) == 0, (
+        "Regular tensors should not trigger our wrapper"
+    )
 
 
 def test_dispatch_registration_with_shard_tensors(setup_registry, device_mesh):
@@ -187,9 +186,9 @@ def test_dispatch_registration_with_shard_tensors(setup_registry, device_mesh):
     # Verify result and execution path
     assert isinstance(result, ShardTensor)
     assert torch.all(result.to_local() == 3)
-    assert torch_dispatch_paths == [
-        "add_wrapper"
-    ], "ShardTensors should trigger our wrapper"
-    assert (
-        len(torch_function_paths) == 0
-    ), "torch_dispatch intercepts should not trigger torch_function intercepts"
+    assert torch_dispatch_paths == ["add_wrapper"], (
+        "ShardTensors should trigger our wrapper"
+    )
+    assert len(torch_function_paths) == 0, (
+        "torch_dispatch intercepts should not trigger torch_function intercepts"
+    )

--- a/test/distributed/test_shard_tensor_grad_sharding.py
+++ b/test/distributed/test_shard_tensor_grad_sharding.py
@@ -114,7 +114,6 @@ def test_shard_tensor_detach(data_parallel_size, domain_H, domain_W, uneven):
 def run_shard_tensor_input_gradient_full_loss(
     rank, num_gpus, mesh_names, mesh_sizes, uneven, verbose
 ):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{num_gpus}",
@@ -220,7 +219,6 @@ def test_shard_tensor_input_gradient_full_loss(
 def run_shard_tensor_input_gradient_local_loss(
     rank, num_gpus, mesh_names, mesh_sizes, uneven, verbose
 ):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{num_gpus}",
@@ -228,7 +226,6 @@ def run_shard_tensor_input_gradient_local_loss(
         MASTER_PORT=str(13245),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         init_dist(rank, num_gpus)
         shard_tensor = shard_tensor_factory(
             mesh_names, mesh_sizes, requires_grad=True, uneven=uneven

--- a/test/distributed/test_shard_tensor_initialization.py
+++ b/test/distributed/test_shard_tensor_initialization.py
@@ -41,14 +41,12 @@ from physicsnemo.distributed import DistributedManager
 
 
 def init_dist(rank, num_gpus):
-
     DistributedManager.initialize()
     dm = DistributedManager()
     assert dm.is_initialized()
 
 
 def init_global_shape_and_placements(mesh_names):
-
     dm = DistributedManager()
 
     global_mesh = dm.global_mesh
@@ -179,7 +177,6 @@ def run_shard_tensor_initialization_from_all_dtensor(
 def run_shard_tensor_initialization_from_local_chunks(
     rank, num_gpus, mesh_names, mesh_sizes, verbose
 ):
-
     # Here, we create local shards and combine into a shard tensor.
     # This test is allowed to go a little wild: the shapes for the local tensors
     # are allowed to be randomly generated along the first shard axis.

--- a/test/distributed/test_shard_tensor_redistribute.py
+++ b/test/distributed/test_shard_tensor_redistribute.py
@@ -94,7 +94,6 @@ def shard_tensor_factory(mesh_names, mesh_sizes, requires_grad=False, uneven=Tru
 
 
 def run_shard_tensor_reduction(rank, num_gpus, mesh_names, mesh_sizes, op, verbose):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{num_gpus}",

--- a/test/distributed/test_shard_tensor_reductions.py
+++ b/test/distributed/test_shard_tensor_reductions.py
@@ -58,7 +58,6 @@ def run_consecutive_reductions(
     ):
 
         def two_reduction_operation(output, target):
-
             mask = target > 0.0
 
             num = torch.sum(mask * (output - target) ** 2.0, (1,))
@@ -107,7 +106,6 @@ def run_consecutive_reductions(
 def run_shard_tensor_reduction(
     rank, num_gpus, mesh_names, mesh_sizes, op, backward, dim, in_place, verbose
 ):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{num_gpus}",
@@ -256,7 +254,6 @@ def test_shard_tensor_reduction(op, backward, dim, in_place):
 
 @pytest.mark.multigpu
 def test_consecutive_reductions():
-
     num_gpus = torch.cuda.device_count()
     assert num_gpus >= 2, "Not enough GPUs available for test"
 

--- a/test/distributed/test_utils.py
+++ b/test/distributed/test_utils.py
@@ -31,7 +31,6 @@ from physicsnemo.distributed.utils import _reduce
 
 
 def test_modify_environment():
-
     keys = ["RANK", "WORLD_SIZE", "MASTER_ADDR", "MASTER_PORT", "LOCAL_RANK"]
     # Set the values to nonsense for testing:
     values = [f"{i}" for i in range(len(keys))]
@@ -56,7 +55,6 @@ def test_modify_environment():
 
 
 def run_test_reduce_loss(rank, world_size):
-
     with modify_environment(
         RANK=f"{rank}",
         WORLD_SIZE=f"{world_size}",
@@ -97,7 +95,6 @@ def run_test_mark_shared(rank, world_size):
         MASTER_PORT=str(12355),
         LOCAL_RANK=f"{rank % torch.cuda.device_count()}",
     ):
-
         DistributedManager._shared_state = {}
         DistributedManager.initialize()
         DistributedManager.create_process_subgroup(

--- a/test/metrics/diffusion/test_losses.py
+++ b/test/metrics/diffusion/test_losses.py
@@ -165,7 +165,6 @@ def test_call_method_edm():
 
 
 def test_call_method_regressionloss():
-
     # With a fake network
 
     def fake_net(input, y_lr, augment_labels=None, force_fp32=False):
@@ -193,7 +192,6 @@ def test_call_method_regressionloss():
 # More realistic test with a UNet model
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_call_method_regressionloss_with_unet(device):
-
     res, inc, outc = 64, 2, 3
     model = UNet(
         img_resolution=res,
@@ -422,7 +420,6 @@ def test_residualloss_call_method():
 # More realistic test with a UNet model
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_call_method_residualloss_with_unet(device):
-
     res, inc, outc = 64, 2, 3
     N_pos = 2
     regression_model = UNet(

--- a/test/metrics/diffusion/test_t_edm_residual_loss.py
+++ b/test/metrics/diffusion/test_t_edm_residual_loss.py
@@ -23,7 +23,6 @@ from physicsnemo.utils.patching import RandomPatching2D
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_residualloss_initialization(device):
-
     from physicsnemo.experimental.metrics.diffusion import tEDMResidualLoss
 
     # Mock regression network
@@ -139,7 +138,6 @@ def test_residualloss_call_method(device):
 # More realistic test with a UNet model
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_call_method_residualloss_with_unet(device):
-
     from physicsnemo.experimental.metrics.diffusion import tEDMResidualLoss
     from physicsnemo.experimental.models.diffusion.preconditioning import (
         tEDMPrecondSuperRes,
@@ -180,7 +178,6 @@ def test_call_method_residualloss_with_unet(device):
 # Test with UNets and hr_mean_conditioning
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_call_method_residualloss_with_unet_hr_mean_conditioning(device):
-
     from physicsnemo.experimental.metrics.diffusion import tEDMResidualLoss
     from physicsnemo.experimental.models.diffusion.preconditioning import (
         tEDMPrecondSuperRes,
@@ -223,7 +220,6 @@ def test_call_method_residualloss_with_unet_hr_mean_conditioning(device):
 # Test with UNets, hr_mean_conditioning, and lead-time aware embedding
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_call_method_residualloss_with_lt_unet_hr_mean_conditioning(device):
-
     from physicsnemo.experimental.metrics.diffusion import tEDMResidualLoss
     from physicsnemo.experimental.models.diffusion.preconditioning import (
         tEDMPrecondSuperRes,

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -207,9 +207,7 @@ def test_WeightedMSE(device, test_data, rtol: float = 1e-3, atol: float = 1e-3):
     )
 
     # test for individual channel loss
-    error = weighted_mse_func(
-        pred_tensor**2, targ_tensor**2, average_channels=False
-    )
+    error = weighted_mse_func(pred_tensor**2, targ_tensor**2, average_channels=False)
     assert torch.allclose(
         error,
         channel_weighted_mse,

--- a/test/metrics/test_metrics_climate.py
+++ b/test/metrics/test_metrics_climate.py
@@ -250,7 +250,6 @@ def test_climate_reductions(test_data, device, rtol: float = 1e-3, atol: float =
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_climate_efi(test_data, device, rtol: float = 1e-1, atol: float = 1e-1):
-
     one = torch.ones((1, 1), dtype=torch.float32, device=device)
     bin_edges = hist.linspace(-10 * one, 10 * one, 30)
     bin_mids = 0.5 * bin_edges[1:] + 0.5 * bin_edges[:-1]

--- a/test/metrics/test_metrics_general.py
+++ b/test/metrics/test_metrics_general.py
@@ -295,7 +295,6 @@ def test_fair_crps_dim_arg_works(device):
 @pytest.mark.parametrize("num", [10, 23, 59])
 @pytest.mark.parametrize("biased", [True, False])
 def test_crps_finite(device, num, biased):
-
     # Test biased and unbiased on uniform data with analytic result
     pred = torch.linspace(0, 1, num + 1).unsqueeze(-1).to(device)
     obs = torch.zeros([1], device=device)
@@ -716,7 +715,6 @@ def test_means_var(device, rtol: float = 1e-3, atol: float = 1e-3):
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_calibration(device, rtol: float = 1e-2, atol: float = 1e-2):
-
     x = torch.randn((10_000, 30, 30), device=device, dtype=torch.float32)
     y = torch.randn((30, 30), device=device, dtype=torch.float32)
 

--- a/test/models/common/checkpoints.py
+++ b/test/models/common/checkpoints.py
@@ -80,9 +80,9 @@ def validate_checkpoint(
         output_2 = model_2.forward(*in_args)
 
     # Model outputs should initially be different
-    assert not compare_output(
-        output_1, output_2, rtol, atol
-    ), "Model outputs should initially be different"
+    assert not compare_output(output_1, output_2, rtol, atol), (
+        "Model outputs should initially be different"
+    )
 
     # Save checkpoint from model 1 and load it into model 2
     model_1.save("checkpoint.mdlus")

--- a/test/models/common/optimization.py
+++ b/test/models/common/optimization.py
@@ -321,18 +321,20 @@ def validate_combo_optims(
         """Mini-forward function to capture in cuda graph if needed"""
         # Test AMP
         # This is a conditional context statement: https://stackoverflow.com/a/34798330
-        with torch.autocast(
-            amp_device, enabled=True, dtype=amp_dtype
-        ) if model.meta.amp else nullcontext():
+        with (
+            torch.autocast(amp_device, enabled=True, dtype=amp_dtype)
+            if model.meta.amp
+            else nullcontext()
+        ):
             optimizer.zero_grad()
             output = fwd_model(*in_args)
             loss = dummy_loss_fn(output)
             scaler.scale(loss).backward()
 
     # Warmup stream (if cuda graphs)
-    with torch.cuda.stream(
-        torch.cuda.Stream()
-    ) if cuda_graphs_enabled else nullcontext():
+    with (
+        torch.cuda.stream(torch.cuda.Stream()) if cuda_graphs_enabled else nullcontext()
+    ):
         for i in range(warmup_length):
             foward(in_args)
             scaler.step(optimizer)

--- a/test/models/diffusion/test_preconditioning.py
+++ b/test/models/diffusion/test_preconditioning.py
@@ -98,14 +98,13 @@ def test_EDMPrecondSuperResolution_fp16_forward():
     assert output_fp16.shape == (b, c_target, x, y)
 
     # Assert the fp16 output and fp32 output are close
-    assert torch.allclose(
-        output_fp16, output_fp32, rtol=1e-3, atol=1e-3
-    ), "FP16 and FP32 outputs differ more than allowed"
+    assert torch.allclose(output_fp16, output_fp32, rtol=1e-3, atol=1e-3), (
+        "FP16 and FP32 outputs differ more than allowed"
+    )
 
 
 @import_or_fail("termcolor")
 def test_EDMPrecondSuperResolution_serialization(tmp_path, pytestconfig):
-
     from physicsnemo.launch.utils import load_checkpoint, save_checkpoint
 
     module = EDMPrecondSuperResolution(8, 1, 1)
@@ -156,7 +155,6 @@ def test_EDMPrecond_forward(channels):
 
 
 def test_VEPrecond_dfsr():
-
     b, c, x, y = 1, 3, 256, 256
     img_resolution = 256
     img_channels = 3
@@ -181,7 +179,7 @@ def test_VEPrecond_dfsr():
         dataset_mean=5.85e-05,
         dataset_scale=4.79,
         model_type="SongUNet",
-        **model_kwargs
+        **model_kwargs,
     )
 
     xt = torch.randn(b, c, x, y)
@@ -191,7 +189,6 @@ def test_VEPrecond_dfsr():
 
 
 def test_voriticity_residual_method():
-
     b, c, x, y = 1, 3, 256, 256
     img_resolution = 256
     img_channels = 3
@@ -218,7 +215,7 @@ def test_voriticity_residual_method():
         dataset_mean=dataset_mean,
         dataset_scale=dataset_scale,
         model_type="SongUNet",
-        **model_kwargs
+        **model_kwargs,
     )
 
     xt = torch.randn(b, c, x, y)

--- a/test/models/diffusion/test_song_unet.py
+++ b/test/models/diffusion/test_song_unet.py
@@ -338,12 +338,13 @@ def test_song_unet_grad_checkpointing(device):
         computed_grads_checkpointed[name] = param.grad.clone()
 
     # Check that the results are the same
-    assert torch.allclose(
-        y_pred_checkpointed, y_pred
-    ), "Outputs do not match. Checkpointing failed!"
+    assert torch.allclose(y_pred_checkpointed, y_pred), (
+        "Outputs do not match. Checkpointing failed!"
+    )
 
     # Compare the gradients
     for name in computed_grads:
-        torch.allclose(
-            computed_grads_checkpointed[name], computed_grads[name]
-        ), "Gradient do not match. Checkpointing failed!"
+        (
+            torch.allclose(computed_grads_checkpointed[name], computed_grads[name]),
+            "Gradient do not match. Checkpointing failed!",
+        )

--- a/test/models/diffusion/test_t_edm_preconditioning.py
+++ b/test/models/diffusion/test_t_edm_preconditioning.py
@@ -58,7 +58,6 @@ def test_EDMPrecondSuperResolution_forward(device):
 @import_or_fail("termcolor")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_EDMPrecondSuperResolution_serialization(tmp_path, pytestconfig, device):
-
     from physicsnemo.experimental.models.diffusion.preconditioning import (
         tEDMPrecondSuperRes,
     )

--- a/test/models/diffusion/test_unet_wrappers.py
+++ b/test/models/diffusion/test_unet_wrappers.py
@@ -84,9 +84,9 @@ def test_unet_fp16_forwards(device):
     output_fp32 = model_fp32(x=input_image, img_lr=lr_image)
 
     assert output_fp16.shape == (1, outc, res, res)
-    assert torch.allclose(
-        output_fp16, output_fp32, rtol=1e-3, atol=1e-3
-    ), "FP16 and FP32 outputs differ more than allowed"
+    assert torch.allclose(output_fp16, output_fp32, rtol=1e-3, atol=1e-3), (
+        "FP16 and FP32 outputs differ more than allowed"
+    )
 
     # Construct the StormCastUNet model
     model = StormCastUNet(

--- a/test/models/dlwp_healpix/test_healpix_blocks.py
+++ b/test/models/dlwp_healpix/test_healpix_blocks.py
@@ -42,7 +42,6 @@ def test_data():
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_ConvGRUBlock_initialization(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         ConvGRUBlock,
     )
@@ -55,7 +54,6 @@ def test_ConvGRUBlock_initialization(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_ConvGRUBlock_forward(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         ConvGRUBlock,
     )
@@ -79,7 +77,6 @@ def test_ConvGRUBlock_forward(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_ConvNeXtBlock_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         ConvNeXtBlock,
     )
@@ -101,7 +98,6 @@ def test_ConvNeXtBlock_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_ConvNeXtBlock_forward(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         ConvNeXtBlock,
     )
@@ -130,7 +126,6 @@ def test_ConvNeXtBlock_forward(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_DoubleConvNeXtBlock_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         DoubleConvNeXtBlock,
     )
@@ -158,7 +153,6 @@ def test_DoubleConvNeXtBlock_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_DoubleConvNeXtBlock_forward(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         DoubleConvNeXtBlock,
     )
@@ -194,7 +188,6 @@ def test_DoubleConvNeXtBlock_forward(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_SymmetricConvNeXtBlock_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         SymmetricConvNeXtBlock,
     )
@@ -219,7 +212,6 @@ def test_SymmetricConvNeXtBlock_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_SymmetricConvNeXtBlock_forward(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         SymmetricConvNeXtBlock,
     )
@@ -243,7 +235,6 @@ def test_SymmetricConvNeXtBlock_forward(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_Multi_SymmetricConvNeXtBlock_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         Multi_SymmetricConvNeXtBlock,
     )
@@ -261,7 +252,6 @@ def test_Multi_SymmetricConvNeXtBlock_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_Multi_SymmetricConvNeXtBlock_forward(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         Multi_SymmetricConvNeXtBlock,
     )
@@ -287,7 +277,6 @@ def test_Multi_SymmetricConvNeXtBlock_forward(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_BasicConvBlock_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         BasicConvBlock,
     )
@@ -314,7 +303,6 @@ def test_BasicConvBlock_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_BasicConvBlock_forward(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         BasicConvBlock,
     )
@@ -340,7 +328,6 @@ def test_BasicConvBlock_forward(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_MaxPool_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         MaxPool,
     )
@@ -373,7 +360,6 @@ def test_MaxPool_forward(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_AvgPool_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         AvgPool,
     )
@@ -386,7 +372,6 @@ def test_AvgPool_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_AvgPool_forward(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         AvgPool,
     )
@@ -426,7 +411,6 @@ def test_TransposedConvUpsample_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_TransposedConvUpsample_forward(device, test_data, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         TransposedConvUpsample,
     )
@@ -458,7 +442,6 @@ def test_TransposedConvUpsample_forward(device, test_data, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_Interpolate_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         Interpolate,
     )

--- a/test/models/dlwp_healpix/test_healpix_encoder_decoder.py
+++ b/test/models/dlwp_healpix/test_healpix_encoder_decoder.py
@@ -29,7 +29,6 @@ from pytest_utils import import_or_fail
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_UNetEncoder_initialize(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         ConvNeXtBlock,  # for convolutional layer
         MaxPool,  # for downsampling
@@ -74,7 +73,6 @@ def test_UNetEncoder_initialize(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_UNetEncoder_forward(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         ConvNeXtBlock,  # for convolutional layer
         MaxPool,  # for downsampling
@@ -124,7 +122,6 @@ def test_UNetEncoder_forward(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_UNetEncoder_reset(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         ConvNeXtBlock,  # for convolutional layer
         MaxPool,  # for downsampling
@@ -162,7 +159,6 @@ def test_UNetEncoder_reset(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_UNetDecoder_initilization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         BasicConvBlock,  # for the output layer
         ConvGRUBlock,  # for the recurrent layer
@@ -231,7 +227,6 @@ def test_UNetDecoder_initilization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_UNetDecoder_forward(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         BasicConvBlock,  # for the output layer
         ConvGRUBlock,  # for the recurrent layer
@@ -319,7 +314,6 @@ def test_UNetDecoder_forward(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_UNetDecoder_reset(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         BasicConvBlock,  # for the output layer
         ConvGRUBlock,  # for the recurrent layer

--- a/test/models/dlwp_healpix/test_healpix_layers.py
+++ b/test/models/dlwp_healpix/test_healpix_layers.py
@@ -41,7 +41,6 @@ class MulX(torch.nn.Module):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_HEALPixFoldFaces_initialization(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         HEALPixFoldFaces,
     )
@@ -53,7 +52,6 @@ def test_HEALPixFoldFaces_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_HEALPixFoldFaces_forward(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         HEALPixFoldFaces,
     )
@@ -86,7 +84,6 @@ def test_HEALPixUnfoldFaces_initialization(device, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_HEALPixUnfoldFaces_forward(device, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         HEALPixUnfoldFaces,
     )
@@ -118,7 +115,6 @@ HEALPixPadding_testdata = [
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device,padding", HEALPixPadding_testdata)
 def test_HEALPixPadding_initialization(device, padding, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         HEALPixPadding,
     )
@@ -130,7 +126,6 @@ def test_HEALPixPadding_initialization(device, padding, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device,padding", HEALPixPadding_testdata)
 def test_HEALPixPadding_forward(device, padding, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         HEALPixPadding,
     )
@@ -187,7 +182,6 @@ def test_HEALPixLayer_initialization(device, multiplier, pytestconfig):
 @import_or_fail("hydra")
 @pytest.mark.parametrize("device,multiplier", HEALPixLayer_testdata)
 def test_HEALPixLayer_forward(device, multiplier, pytestconfig):
-
     from physicsnemo.models.dlwp_healpix_layers import (
         HEALPixLayer,
     )

--- a/test/models/graphcast/test_cugraphops.py
+++ b/test/models/graphcast/test_cugraphops.py
@@ -99,10 +99,10 @@ def test_cugraphops(
     x_grad_dgl = x_dgl.grad
 
     # Check that the results are the same
-    assert torch.allclose(
-        y_pred_dgl, y_pred, atol=1.0e-6
-    ), "testing DGL against cugraph-ops: outputs do not match!"
+    assert torch.allclose(y_pred_dgl, y_pred, atol=1.0e-6), (
+        "testing DGL against cugraph-ops: outputs do not match!"
+    )
 
-    assert torch.allclose(
-        x_grad_dgl, x_grad, atol=1.0e-4, rtol=1.0e-3
-    ), "testing DGL against cugraph-ops: gradients do not match!"
+    assert torch.allclose(x_grad_dgl, x_grad, atol=1.0e-4, rtol=1.0e-3), (
+        "testing DGL against cugraph-ops: gradients do not match!"
+    )

--- a/test/models/graphcast/test_grad_checkpointing.py
+++ b/test/models/graphcast/test_grad_checkpointing.py
@@ -105,11 +105,12 @@ def test_grad_checkpointing(device, pytestconfig, num_channels=2, res_h=15, res_
 
     # Compare the gradients
     for name in computed_grads:
-        torch.allclose(
-            computed_grads_checkpointed[name], computed_grads[name]
-        ), "Gradient do not match. Checkpointing failed!"
+        (
+            torch.allclose(computed_grads_checkpointed[name], computed_grads[name]),
+            "Gradient do not match. Checkpointing failed!",
+        )
 
     # Check that the results are the same
-    assert torch.allclose(
-        y_pred_checkpointed, y_pred
-    ), "Outputs do not match. Checkpointing failed!"
+    assert torch.allclose(y_pred_checkpointed, y_pred), (
+        "Outputs do not match. Checkpointing failed!"
+    )

--- a/test/models/graphcast/test_graphcast_snmg.py
+++ b/test/models/graphcast/test_graphcast_snmg.py
@@ -136,9 +136,9 @@ def run_test_distributed_graphcast(
     diff = out_single_gpu - out_multi_gpu
     diff = torch.abs(diff)
     mask = diff > atol
-    assert torch.allclose(
-        out_single_gpu, out_multi_gpu, atol=atol, rtol=rtol
-    ), f"{mask.sum()} elements have diff > {atol} \n {out_single_gpu[mask]} \n {out_multi_gpu[mask]}"
+    assert torch.allclose(out_single_gpu, out_multi_gpu, atol=atol, rtol=rtol), (
+        f"{mask.sum()} elements have diff > {atol} \n {out_single_gpu[mask]} \n {out_multi_gpu[mask]}"
+    )
 
     # compare model gradients (ensure correctness of backward)
     model_multi_gpu_parameters = list(model_multi_gpu.parameters())
@@ -151,7 +151,9 @@ def run_test_distributed_graphcast(
             model_multi_gpu_parameters[param_idx].grad,
             atol=atol_w,
             rtol=rtol_w,
-        ), f"{mask.sum()} elements have diff > {atol_w} \n {param.grad[mask]} \n {model_multi_gpu_parameters[param_idx].grad[mask]}"
+        ), (
+            f"{mask.sum()} elements have diff > {atol_w} \n {param.grad[mask]} \n {model_multi_gpu_parameters[param_idx].grad[mask]}"
+        )
 
     # cleanup distributed
     DistributedManager.cleanup()

--- a/test/models/meshgraphnet/test_meshgraphnet_dgl2pyg.py
+++ b/test/models/meshgraphnet/test_meshgraphnet_dgl2pyg.py
@@ -203,9 +203,9 @@ def test_mesh_node_block_gradient_equivalence(device, pytestconfig):
     for (name_dgl, param_dgl), (name_pyg, param_pyg) in zip(
         node_block_dgl.named_parameters(), node_block_pyg.named_parameters()
     ):
-        assert (
-            name_dgl == name_pyg
-        ), f"Parameter names should match: {name_dgl} vs {name_pyg}"
+        assert name_dgl == name_pyg, (
+            f"Parameter names should match: {name_dgl} vs {name_pyg}"
+        )
         assert_close(
             param_dgl.grad,
             param_pyg.grad,
@@ -441,9 +441,9 @@ def test_mesh_edge_block_gradient_equivalence(device, pytestconfig):
     for (name_dgl, param_dgl), (name_pyg, param_pyg) in zip(
         edge_block_dgl.named_parameters(), edge_block_pyg.named_parameters()
     ):
-        assert (
-            name_dgl == name_pyg
-        ), f"Parameter names should match: {name_dgl} vs {name_pyg}"
+        assert name_dgl == name_pyg, (
+            f"Parameter names should match: {name_dgl} vs {name_pyg}"
+        )
         assert_close(
             param_dgl.grad,
             param_pyg.grad,
@@ -766,9 +766,9 @@ def test_meshgraphnet_gradient_equivalence(device, pytestconfig):
     for (name_dgl, param_dgl), (name_pyg, param_pyg) in zip(
         model_dgl.named_parameters(), model_pyg.named_parameters()
     ):
-        assert (
-            name_dgl == name_pyg
-        ), f"Parameter names should match: {name_dgl} vs {name_pyg}"
+        assert name_dgl == name_pyg, (
+            f"Parameter names should match: {name_dgl} vs {name_pyg}"
+        )
         assert_close(param_dgl.grad, param_pyg.grad)
 
 

--- a/test/models/meshgraphnet/test_meshgraphnet_snmg.py
+++ b/test/models/meshgraphnet/test_meshgraphnet_snmg.py
@@ -219,9 +219,9 @@ def run_test_distributed_meshgraphnet(rank, world_size, dtype, partition_scheme)
     diff = out_single_gpu_dist - out_multi_gpu
     diff = torch.abs(diff)
     mask = diff > atol
-    assert torch.allclose(
-        out_single_gpu_dist, out_multi_gpu, atol=atol, rtol=rtol
-    ), f"{mask.sum()} elements have diff > {atol} \n {out_single_gpu_dist[mask]} \n {out_multi_gpu[mask]}"
+    assert torch.allclose(out_single_gpu_dist, out_multi_gpu, atol=atol, rtol=rtol), (
+        f"{mask.sum()} elements have diff > {atol} \n {out_single_gpu_dist[mask]} \n {out_multi_gpu[mask]}"
+    )
 
     # compare data gradient
     nfeat_grad_single_gpu_dist = graph_multi_gpu.get_src_node_features_in_partition(
@@ -232,7 +232,9 @@ def run_test_distributed_meshgraphnet(rank, world_size, dtype, partition_scheme)
     mask = diff > atol
     assert torch.allclose(
         nfeat_multi_gpu.grad, nfeat_grad_single_gpu_dist, atol=atol_w, rtol=rtol_w
-    ), f"{mask.sum()} elements have diff > {atol} \n {nfeat_grad_single_gpu_dist[mask]} \n {nfeat_multi_gpu.grad[mask]}"
+    ), (
+        f"{mask.sum()} elements have diff > {atol} \n {nfeat_grad_single_gpu_dist[mask]} \n {nfeat_multi_gpu.grad[mask]}"
+    )
 
     # compare model gradients (ensure correctness of backward)
     model_multi_gpu_parameters = list(model_multi_gpu.parameters())
@@ -245,7 +247,9 @@ def run_test_distributed_meshgraphnet(rank, world_size, dtype, partition_scheme)
             model_multi_gpu_parameters[param_idx].grad,
             atol=atol_w,
             rtol=rtol_w,
-        ), f"{mask.sum()} for param[{param_idx}].grad elements have diff > {atol_w} with a avg. diff of {diff[mask].mean().item()} ({diff.mean().item()} overall)"
+        ), (
+            f"{mask.sum()} for param[{param_idx}].grad elements have diff > {atol_w} with a avg. diff of {diff[mask].mean().item()} ({diff.mean().item()} overall)"
+        )
 
     # cleanup distributed
     del os.environ["RANK"]

--- a/test/models/test_distributed_graph.py
+++ b/test/models/test_distributed_graph.py
@@ -127,7 +127,6 @@ def run_test_distributed_graph(
     partition_scheme: str,
     use_torchrun: bool = False,
 ):
-
     from physicsnemo.models.gnn_layers import (
         DistributedGraph,
         partition_graph_by_coordinate_bbox,
@@ -347,7 +346,6 @@ def run_test_distributed_graph(
 @pytest.mark.multigpu
 @pytest.mark.parametrize("partition_scheme", ["lat_lon_bbox", "default"])
 def test_distributed_graph(partition_scheme, pytestconfig):
-
     num_gpus = torch.cuda.device_count()
     assert num_gpus >= 2, "Not enough GPUs available for test"
     world_size = 2  # num_gpus
@@ -367,7 +365,6 @@ def test_distributed_graph(partition_scheme, pytestconfig):
 
 
 if __name__ == "__main__":
-
     # to be launched with torchrun
     DistributedManager.initialize()
     run_test_distributed_graph(-1, -1, "lat_lon_bbox", True)

--- a/test/models/test_fcn_mip_plugin.py
+++ b/test/models/test_fcn_mip_plugin.py
@@ -149,7 +149,6 @@ def save_untrained_dlwp(path):
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 def test_dlwp(tmp_path, batch_size, device, dlwp_data_dir, pytestconfig):
-
     from physicsnemo.models.fcn_mip_plugin import dlwp
 
     package = save_untrained_dlwp(tmp_path)

--- a/test/models/test_graph_partition.py
+++ b/test/models/test_graph_partition.py
@@ -85,7 +85,6 @@ def assert_partitions_are_equal(a, b):
 @import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_gp_mapping(global_graph, device, pytestconfig):
-
     from physicsnemo.models.gnn_layers import (
         GraphPartition,
         partition_graph_with_id_mapping,
@@ -138,7 +137,6 @@ def test_gp_mapping(global_graph, device, pytestconfig):
 @import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_gp_nodewise(global_graph, device, pytestconfig):
-
     from physicsnemo.models.gnn_layers import (
         GraphPartition,
         partition_graph_nodewise,
@@ -186,7 +184,6 @@ def test_gp_nodewise(global_graph, device, pytestconfig):
 @import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_gp_matrixdecomp(global_graph_square, device, pytestconfig):
-
     from physicsnemo.models.gnn_layers import (
         GraphPartition,
         partition_graph_nodewise,
@@ -230,7 +227,6 @@ def test_gp_matrixdecomp(global_graph_square, device, pytestconfig):
 @import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_gp_coordinate_bbox(global_graph, device, pytestconfig):
-
     from physicsnemo.models.gnn_layers import (
         GraphPartition,
         partition_graph_by_coordinate_bbox,
@@ -304,7 +300,6 @@ def test_gp_coordinate_bbox(global_graph, device, pytestconfig):
 @import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_gp_coordinate_bbox_lat_long(global_graph, device, pytestconfig):
-
     from physicsnemo.models.gnn_layers import (
         GraphPartition,
         partition_graph_by_coordinate_bbox,

--- a/test/models/test_layers_activations.py
+++ b/test/models/test_layers_activations.py
@@ -145,9 +145,9 @@ def test_activation_fused_silu(device):
     )
 
     input = torch.randn(20, 20, dtype=torch.double, requires_grad=True, device=device)
-    assert torch.autograd.gradcheck(
-        FusedSiLU.apply, input, eps=1e-6, atol=1e-4
-    ), "Failed FusedSiLU autograd check"
+    assert torch.autograd.gradcheck(FusedSiLU.apply, input, eps=1e-6, atol=1e-4), (
+        "Failed FusedSiLU autograd check"
+    )
 
     assert torch.autograd.gradcheck(
         FusedSiLU_deriv_1.apply, input, eps=1e-6, atol=1e-4

--- a/test/models/test_nd_conv_layers.py
+++ b/test/models/test_nd_conv_layers.py
@@ -162,53 +162,61 @@ class SpectralConv4d(nn.Module):
             device=x.device,
         )
 
-        out_ft[
-            :, :, : self.modes1, : self.modes2, : self.modes3, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, : self.modes1, : self.modes2, : self.modes3, : self.modes4],
-            self.weights1,
+        out_ft[:, :, : self.modes1, : self.modes2, : self.modes3, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[:, :, : self.modes1, : self.modes2, : self.modes3, : self.modes4],
+                self.weights1,
+            )
         )
-        out_ft[
-            :, :, -self.modes1 :, : self.modes2, : self.modes3, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, -self.modes1 :, : self.modes2, : self.modes3, : self.modes4],
-            self.weights2,
+        out_ft[:, :, -self.modes1 :, : self.modes2, : self.modes3, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[:, :, -self.modes1 :, : self.modes2, : self.modes3, : self.modes4],
+                self.weights2,
+            )
         )
-        out_ft[
-            :, :, : self.modes1, -self.modes2 :, : self.modes3, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, : self.modes1, -self.modes2 :, : self.modes3, : self.modes4],
-            self.weights3,
+        out_ft[:, :, : self.modes1, -self.modes2 :, : self.modes3, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[:, :, : self.modes1, -self.modes2 :, : self.modes3, : self.modes4],
+                self.weights3,
+            )
         )
-        out_ft[
-            :, :, : self.modes1, : self.modes2, -self.modes3 :, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, : self.modes1, : self.modes2, -self.modes3 :, : self.modes4],
-            self.weights4,
+        out_ft[:, :, : self.modes1, : self.modes2, -self.modes3 :, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[:, :, : self.modes1, : self.modes2, -self.modes3 :, : self.modes4],
+                self.weights4,
+            )
         )
-        out_ft[
-            :, :, -self.modes1 :, -self.modes2 :, : self.modes3, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, -self.modes1 :, -self.modes2 :, : self.modes3, : self.modes4],
-            self.weights5,
+        out_ft[:, :, -self.modes1 :, -self.modes2 :, : self.modes3, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[
+                    :, :, -self.modes1 :, -self.modes2 :, : self.modes3, : self.modes4
+                ],
+                self.weights5,
+            )
         )
-        out_ft[
-            :, :, -self.modes1 :, : self.modes2, -self.modes3 :, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, -self.modes1 :, : self.modes2, -self.modes3 :, : self.modes4],
-            self.weights6,
+        out_ft[:, :, -self.modes1 :, : self.modes2, -self.modes3 :, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[
+                    :, :, -self.modes1 :, : self.modes2, -self.modes3 :, : self.modes4
+                ],
+                self.weights6,
+            )
         )
-        out_ft[
-            :, :, : self.modes1, -self.modes2 :, -self.modes3 :, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, : self.modes1, -self.modes2 :, -self.modes3 :, : self.modes4],
-            self.weights7,
+        out_ft[:, :, : self.modes1, -self.modes2 :, -self.modes3 :, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[
+                    :, :, : self.modes1, -self.modes2 :, -self.modes3 :, : self.modes4
+                ],
+                self.weights7,
+            )
         )
-        out_ft[
-            :, :, -self.modes1 :, -self.modes2 :, -self.modes3 :, : self.modes4
-        ] = self.compl_mul4d(
-            x_ft[:, :, -self.modes1 :, -self.modes2 :, -self.modes3 :, : self.modes4],
-            self.weights8,
+        out_ft[:, :, -self.modes1 :, -self.modes2 :, -self.modes3 :, : self.modes4] = (
+            self.compl_mul4d(
+                x_ft[
+                    :, :, -self.modes1 :, -self.modes2 :, -self.modes3 :, : self.modes4
+                ],
+                self.weights8,
+            )
         )
 
         # Return to physical space
@@ -252,9 +260,9 @@ def test_conv_nd(device, dimension):
     nn.init.constant_(comp_nn.bias, ini_b)
     nn.init.constant_(comp_nn.weight, ini_w)
     with torch.no_grad():
-        assert torch.allclose(
-            conv_nd(invar), comp_nn(invar), rtol=1e-05, atol=1e-03
-        ), f"ConvNdKernel1Layer output not identical to that of layer specific for {dimension}d fields :("
+        assert torch.allclose(conv_nd(invar), comp_nn(invar), rtol=1e-05, atol=1e-03), (
+            f"ConvNdKernel1Layer output not identical to that of layer specific for {dimension}d fields :("
+        )
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
@@ -286,9 +294,9 @@ def test_conv_ndfc(device, dimension):
     torch.manual_seed(0)
     comp_nn.reset_parameters()
     with torch.no_grad():
-        assert torch.allclose(
-            conv_nd(invar), comp_nn(invar), rtol=1e-05, atol=1e-03
-        ), f"ConvNdFCLayer output not identical to that of layer specific for {dimension}d fields :("
+        assert torch.allclose(conv_nd(invar), comp_nn(invar), rtol=1e-05, atol=1e-03), (
+            f"ConvNdFCLayer output not identical to that of layer specific for {dimension}d fields :("
+        )
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])

--- a/test/utils/corrdiff/test_generation_steps.py
+++ b/test/utils/corrdiff/test_generation_steps.py
@@ -47,7 +47,6 @@ class MockNet:
 @import_or_fail("cftime")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_regression_step(device, pytestconfig):
-
     from physicsnemo.models.diffusion import UNet
     from physicsnemo.utils.corrdiff import regression_step
 

--- a/test/utils/corrdiff/test_netcdf_writer.py
+++ b/test/utils/corrdiff/test_netcdf_writer.py
@@ -44,7 +44,6 @@ def mock_ncfile():
 
 @import_or_fail("cftime")
 def test_init(mock_ncfile, pytestconfig):
-
     from physicsnemo.utils.corrdiff import NetCDFWriter
 
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -91,7 +90,6 @@ def test_init(mock_ncfile, pytestconfig):
 
 @import_or_fail("cftime")
 def test_write_input(mock_ncfile, pytestconfig):
-
     from physicsnemo.utils.corrdiff import NetCDFWriter
 
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -115,7 +113,6 @@ def test_write_input(mock_ncfile, pytestconfig):
 
 @import_or_fail("cftime")
 def test_write_truth(mock_ncfile, pytestconfig):
-
     from physicsnemo.utils.corrdiff import NetCDFWriter
 
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -139,7 +136,6 @@ def test_write_truth(mock_ncfile, pytestconfig):
 
 @import_or_fail("cftime")
 def test_write_prediction(mock_ncfile, pytestconfig):
-
     from physicsnemo.utils.corrdiff import NetCDFWriter
 
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -166,7 +162,6 @@ def test_write_prediction(mock_ncfile, pytestconfig):
 
 @import_or_fail("cftime")
 def test_write_time(mock_ncfile, pytestconfig):
-
     from physicsnemo.utils.corrdiff import NetCDFWriter
 
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])

--- a/test/utils/corrdiff/test_time_range.py
+++ b/test/utils/corrdiff/test_time_range.py
@@ -19,7 +19,6 @@ from pytest_utils import import_or_fail
 
 @import_or_fail("cftime")
 def test_default_interval(pytestconfig):
-
     from physicsnemo.utils.corrdiff import get_time_from_range
 
     times_range = ["2024-01-01T00:00:00", "2024-01-01T01:00:00"]
@@ -30,7 +29,6 @@ def test_default_interval(pytestconfig):
 
 @import_or_fail("cftime")
 def test_hourly_interval(pytestconfig):
-
     from physicsnemo.utils.corrdiff import get_time_from_range
 
     times_range = ["2024-01-01T00:00:00", "2024-01-01T03:00:00", 1]
@@ -46,7 +44,6 @@ def test_hourly_interval(pytestconfig):
 
 @import_or_fail("cftime")
 def test_custom_interval(pytestconfig):
-
     from physicsnemo.utils.corrdiff import get_time_from_range
 
     times_range = ["2024-01-01T00:00:00", "2024-01-01T03:00:00", 2]
@@ -57,7 +54,6 @@ def test_custom_interval(pytestconfig):
 
 @import_or_fail("cftime")
 def test_no_interval_provided(pytestconfig):
-
     from physicsnemo.utils.corrdiff import get_time_from_range
 
     times_range = ["2024-01-01T00:00:00", "2024-01-01T02:00:00"]
@@ -68,7 +64,6 @@ def test_no_interval_provided(pytestconfig):
 
 @import_or_fail("cftime")
 def test_same_start_end_time(pytestconfig):
-
     from physicsnemo.utils.corrdiff import get_time_from_range
 
     times_range = ["2024-01-01T00:00:00", "2024-01-01T00:00:00"]

--- a/test/utils/generative/test_deterministic_sampler.py
+++ b/test/utils/generative/test_deterministic_sampler.py
@@ -42,7 +42,6 @@ def mock_net():
 # Basic functionality test
 @import_or_fail("cftime")
 def test_deterministic_sampler_output_type_and_shape(mock_net, pytestconfig):
-
     from physicsnemo.utils.diffusion import deterministic_sampler
 
     latents = torch.randn(1, 3, 64, 64)
@@ -56,7 +55,6 @@ def test_deterministic_sampler_output_type_and_shape(mock_net, pytestconfig):
 @import_or_fail("cftime")
 @pytest.mark.parametrize("solver", ["invalid_solver", "euler", "heun"])
 def test_deterministic_sampler_solver_validation(mock_net, solver, pytestconfig):
-
     from physicsnemo.utils.diffusion import deterministic_sampler
 
     if solver == "invalid_solver":
@@ -80,7 +78,6 @@ def test_deterministic_sampler_solver_validation(mock_net, solver, pytestconfig)
 # Test for edge cases
 @import_or_fail("cftime")
 def test_deterministic_sampler_edge_cases(mock_net, pytestconfig):
-
     from physicsnemo.utils.diffusion import deterministic_sampler
 
     latents = torch.randn(1, 3, 64, 64)
@@ -96,7 +93,6 @@ def test_deterministic_sampler_edge_cases(mock_net, pytestconfig):
 @import_or_fail("cftime")
 @pytest.mark.parametrize("discretization", ["vp", "ve", "iddpm", "edm"])
 def test_deterministic_sampler_discretization(mock_net, discretization, pytestconfig):
-
     from physicsnemo.utils.diffusion import deterministic_sampler
 
     latents = torch.randn(1, 3, 64, 64)
@@ -111,7 +107,6 @@ def test_deterministic_sampler_discretization(mock_net, discretization, pytestco
 @import_or_fail("cftime")
 @pytest.mark.parametrize("schedule", ["vp", "ve", "linear"])
 def test_deterministic_sampler_schedule(mock_net, schedule, pytestconfig):
-
     from physicsnemo.utils.diffusion import deterministic_sampler
 
     latents = torch.randn(1, 3, 64, 64)
@@ -126,7 +121,6 @@ def test_deterministic_sampler_schedule(mock_net, schedule, pytestconfig):
 @import_or_fail("cftime")
 @pytest.mark.parametrize("num_steps", [1, 5, 18])
 def test_deterministic_sampler_num_steps(mock_net, num_steps, pytestconfig):
-
     from physicsnemo.utils.diffusion import deterministic_sampler
 
     latents = torch.randn(1, 3, 64, 64)
@@ -143,7 +137,6 @@ def test_deterministic_sampler_num_steps(mock_net, num_steps, pytestconfig):
 def test_deterministic_sampler_sigma_boundaries(
     mock_net, sigma_min, sigma_max, pytestconfig
 ):
-
     from physicsnemo.utils.diffusion import deterministic_sampler
 
     latents = torch.randn(1, 3, 64, 64)
@@ -162,7 +155,6 @@ def test_deterministic_sampler_sigma_boundaries(
 @import_or_fail("cftime")
 @pytest.mark.parametrize("scaling", ["invalid_scaling", "vp", "none"])
 def test_deterministic_sampler_scaling_validation(mock_net, scaling, pytestconfig):
-
     from physicsnemo.utils.diffusion import deterministic_sampler
 
     latents = torch.randn(1, 3, 64, 64)
@@ -182,7 +174,6 @@ def test_deterministic_sampler_scaling_validation(mock_net, scaling, pytestconfi
 # Test correctness with known ODE solution
 @import_or_fail("cftime")
 def test_deterministic_sampler_correctness(pytestconfig):
-
     from physicsnemo.utils.generative import deterministic_sampler
 
     # Create a simple network that implements our ODE: dx/dt = -x ==> x(t) = exp(-t)
@@ -221,6 +212,6 @@ def test_deterministic_sampler_correctness(pytestconfig):
     analytical_solution = torch.ones_like(x_final)
 
     # Check with loose tolerance since we're using numerical integration
-    assert torch.allclose(
-        x_final, analytical_solution, rtol=1e-2, atol=1e-2
-    ), f"Numerical solution {x_final.item():.6f} does not match analytical solution {analytical_solution.item():.6f}"
+    assert torch.allclose(x_final, analytical_solution, rtol=1e-2, atol=1e-2), (
+        f"Numerical solution {x_final.item():.6f} does not match analytical solution {analytical_solution.item():.6f}"
+    )

--- a/test/utils/generative/test_format_time.py
+++ b/test/utils/generative/test_format_time.py
@@ -21,7 +21,6 @@ from pytest_utils import import_or_fail
 # Test format_time function
 @import_or_fail("cftime")
 def test_format_time(pytestconfig):
-
     from physicsnemo.utils.diffusion import format_time
 
     assert format_time(59) == "59s"
@@ -37,7 +36,6 @@ def test_format_time(pytestconfig):
 # Test format_time_brief function
 @import_or_fail("cftime")
 def test_format_time_brief(pytestconfig):
-
     from physicsnemo.utils.diffusion import format_time_brief
 
     assert format_time_brief(59) == "59s"

--- a/test/utils/generative/test_parse_int_list.py
+++ b/test/utils/generative/test_parse_int_list.py
@@ -19,7 +19,6 @@ from pytest_utils import import_or_fail
 
 @import_or_fail("cftime")
 def test_parse_int_list(pytestconfig):
-
     from physicsnemo.utils.diffusion import parse_int_list
 
     # Test parsing a simple comma-separated list

--- a/test/utils/generative/test_stochastic_sampler.py
+++ b/test/utils/generative/test_stochastic_sampler.py
@@ -47,7 +47,6 @@ class MockNet:
 # The test function for edm_sampler
 @import_or_fail("cftime")
 def test_stochastic_sampler(pytestconfig):
-
     from physicsnemo.utils.diffusion import stochastic_sampler
 
     torch._dynamo.reset()
@@ -93,9 +92,9 @@ def test_stochastic_sampler(pytestconfig):
         S_noise=1,
     )
 
-    assert (
-        result_mean_hr.shape == latents.shape
-    ), "Mean HR conditioned output shape does not match expected shape"
+    assert result_mean_hr.shape == latents.shape, (
+        "Mean HR conditioned output shape does not match expected shape"
+    )
 
     # Test with different S_churn value
     result_churn = stochastic_sampler(
@@ -114,9 +113,9 @@ def test_stochastic_sampler(pytestconfig):
         S_noise=1,
     )
 
-    assert (
-        result_churn.shape == latents.shape
-    ), "Churn output shape does not match expected shape"
+    assert result_churn.shape == latents.shape, (
+        "Churn output shape does not match expected shape"
+    )
 
 
 # The test function for edm_sampler with rectangular domain and patching
@@ -164,9 +163,9 @@ def test_stochastic_sampler_rectangle_patching(device, pytestconfig):
         S_noise=1,
     )
 
-    assert (
-        result_mean_hr.shape == latents.shape
-    ), "Mean HR conditioned output shape does not match expected shape"
+    assert result_mean_hr.shape == latents.shape, (
+        "Mean HR conditioned output shape does not match expected shape"
+    )
 
 
 # Test that the stochastic sampler is differentiable with rectangular patching
@@ -244,9 +243,9 @@ def test_stochastic_sampler_patching_differentiable(device, pytestconfig):
         S_noise=1,
     )
 
-    assert (
-        result_mean_hr.shape == latents.shape
-    ), "Mean HR conditioned output shape does not match expected shape"
+    assert result_mean_hr.shape == latents.shape, (
+        "Mean HR conditioned output shape does not match expected shape"
+    )
 
     loss = result_mean_hr.sum()
     loss.backward()

--- a/test/utils/generative/test_tuple_product.py
+++ b/test/utils/generative/test_tuple_product.py
@@ -20,7 +20,6 @@ from pytest_utils import import_or_fail
 # Test tuple_product function
 @import_or_fail("cftime")
 def test_tuple_product(pytestconfig):
-
     from physicsnemo.utils.diffusion import tuple_product
 
     # Test with an empty tuple

--- a/test/utils/graphcast/test_coordinate_transform.py
+++ b/test/utils/graphcast/test_coordinate_transform.py
@@ -30,6 +30,6 @@ def test_coordinate_transform(latlon, pytestconfig):
     latlon = torch.tensor([latlon], dtype=torch.float)
     xyz = latlon2xyz(latlon)
     latlon_recovered = xyz2latlon(xyz)
-    assert torch.allclose(
-        latlon, latlon_recovered
-    ), f"coordinate transformation failed, {latlon} != {latlon_recovered}"
+    assert torch.allclose(latlon, latlon_recovered), (
+        f"coordinate transformation failed, {latlon} != {latlon_recovered}"
+    )

--- a/test/utils/test_capture.py
+++ b/test/utils/test_capture.py
@@ -29,7 +29,7 @@ from physicsnemo.utils.capture import _StaticCapture
 optimizers = pytest.importorskip("apex.optimizers")
 
 Tensor = torch.Tensor
-logger = logging.getLogger("__name__")
+module_logger = logging.getLogger("__name__")
 
 
 @pytest.fixture

--- a/test/utils/test_mesh_utils.py
+++ b/test/utils/test_mesh_utils.py
@@ -179,7 +179,6 @@ def test_mesh_utils(tmp_path, pytestconfig):
 @import_or_fail(["warp", "skimage", "stl"])
 @pytest.mark.parametrize("backend", ["warp", "skimage"])
 def test_stl_gen(pytestconfig, backend, download_stl, tmp_path):
-
     from stl import mesh
 
     from physicsnemo.utils.mesh import (

--- a/test/utils/test_msc_public_read.py
+++ b/test/utils/test_msc_public_read.py
@@ -26,7 +26,6 @@ from pytest_utils import import_or_fail
 # See the [Multi-Storage Client README](/examples/multi_storage_client/README.md) for further information.
 @import_or_fail(["multistorageclient"])
 def test_msc_read(pytestconfig):
-
     # Point at the MSC config file which specifies access information for the S3 bucket
     current_file = Path(__file__).resolve()
     current_dir = current_file.parent

--- a/test/utils/test_patching.py
+++ b/test/utils/test_patching.py
@@ -38,7 +38,6 @@ def test_grid_patching_2d(pytestconfig, device):
     ]
 
     for i, (H, W, H_p, W_p, overlap_pix, boundary_pix, P) in enumerate(test_cases):
-
         error_msg = f"Failed on {device} with test case {i}"
 
         patching = GridPatching2D(
@@ -106,9 +105,9 @@ def test_image_fuse_basic(pytestconfig, device):
         )
         assert fused_image.shape == (batch_size, 1, img_shape_y, img_shape_x)
         expected_output = input_tensor
-        assert torch.allclose(
-            fused_image, expected_output, atol=1e-5
-        ), "Output does not match expected output."
+        assert torch.allclose(fused_image, expected_output, atol=1e-5), (
+            "Output does not match expected output."
+        )
 
         # Make sure that image_fuse is differentiable
         loss = fused_image.sum()
@@ -138,9 +137,9 @@ def test_image_fuse_with_boundary(pytestconfig, device):
     expected_output = input_tensor[
         :, :, boundary_pix:-boundary_pix, boundary_pix:-boundary_pix
     ]
-    assert torch.allclose(
-        fused_image, expected_output, atol=1e-5
-    ), "Output with boundary does not match expected output."
+    assert torch.allclose(fused_image, expected_output, atol=1e-5), (
+        "Output with boundary does not match expected output."
+    )
 
     # Make sure that image_fuse is differentiable
     loss = fused_image.sum()
@@ -229,9 +228,9 @@ def test_image_batching_basic(pytestconfig, device):
     )
     assert batched_images.shape == (batch_size, 1, patch_shape_y, patch_shape_x)
     expected_output = input_tensor
-    assert torch.allclose(
-        batched_images, expected_output, atol=1e-5
-    ), "Batched images do not match expected output."
+    assert torch.allclose(batched_images, expected_output, atol=1e-5), (
+        "Batched images do not match expected output."
+    )
 
     # Make sure that image_batching is differentiable
     loss = batched_images.sum()
@@ -266,9 +265,9 @@ def test_image_batching_with_boundary(pytestconfig, device):
     )
 
     assert batched_images.shape == (1, 1, patch_shape_y, patch_shape_x)
-    assert torch.allclose(
-        batched_images, expected_output, atol=1e-5
-    ), "Batched images with boundary do not match expected output."
+    assert torch.allclose(batched_images, expected_output, atol=1e-5), (
+        "Batched images with boundary do not match expected output."
+    )
 
     # Make sure that image_batching is differentiable
     loss = batched_images.sum()
@@ -330,9 +329,9 @@ def test_image_batching_with_input_interp(device, pytestconfig):
             dim=1,
         )
 
-        assert torch.allclose(
-            batched_images, expected_output, atol=1e-5
-        ), "Batched images with input_interp do not match expected output."
+        assert torch.allclose(batched_images, expected_output, atol=1e-5), (
+            "Batched images with input_interp do not match expected output."
+        )
 
         # Make sure that image_batching is differentiable
         loss = batched_images.sum()

--- a/test/utils/test_profiler.py
+++ b/test/utils/test_profiler.py
@@ -45,12 +45,10 @@ class MockProfilerConfig:
 
 # Mock profiler class for testing
 class MockProfiler(PhysicsNeMoProfilerWrapper, metaclass=_Profiler_Singleton):
-
     _is_context = True
     _is_decorator = True
 
     def __init__(self, config: Optional[MockProfilerConfig] = None, **config_overrides):
-
         default_config = MockProfilerConfig()
 
         # Replace any overrides right into the config:

--- a/test/utils/test_sdf.py
+++ b/test/utils/test_sdf.py
@@ -68,7 +68,6 @@ def tet_verts(flip_x=1):
 
 @import_or_fail("warp")
 def test_sdf(pytestconfig):
-
     from physicsnemo.utils.sdf import signed_distance_field
 
     tet = tet_verts()


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

Makes the following changes:
- Bumps Ruff from v0.0.290 to 0.12.5
- Uses Ruff-format, which is essentially a superset of Black (["designed as a drop-in replacement for Black"](https://docs.astral.sh/ruff/formatter/), but much faster. Removes no-longer-needed Black hook.
- Does not make any changes to Ruff configuration options. A few settings are migrated from the pre-commit config to pyproject.toml so they run repo-wide (i.e., even for ruff checks launched outside pre-commit), but this has no functional change in the pre-commit.
- Minor updates to setting names to fix deprecations

Note to reviewers:

I'm submitting this PR for review *before* committing the results of the updated pre-commit hook, so that the diff is readable and reviewable. (After I run it, there will be a flurry of minor formatting-only changes.)

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->