### PR TITLE
Allow 0/1 values for use_fp16 in cordiff model wrappers (#1059)

### DIFF
--- a/physicsnemo/models/diffusion/preconditioning.py
+++ b/physicsnemo/models/diffusion/preconditioning.py
@@ -852,7 +852,8 @@ class EDMPrecondSuperResolution(Module):
         ValueError
             If `value` is not a boolean.
         """
-        if not isinstance(value, bool):
+        # NOTE: allow 0/1 values for older checkpoints
+        if not (isinstance(value, bool) or value in [0, 1]):
             raise ValueError(
                 f"`use_fp16` must be a boolean, but got {type(value).__name__}."
             )

--- a/physicsnemo/models/diffusion/unet.py
+++ b/physicsnemo/models/diffusion/unet.py
@@ -240,7 +240,8 @@ class UNet(Module):  # TODO a lot of redundancy, need to clean up
         ValueError
             If `value` is not a boolean.
         """
-        if not isinstance(value, bool):
+        # NOTE: allow 0/1 values for older checkpoints
+        if not (isinstance(value, bool) or value in [0, 1]):
             raise ValueError(
                 f"`use_fp16` must be a boolean, but got {type(value).__name__}."
             )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->