### PR TITLE
Small CorrDiff fixes

### DIFF
--- a/examples/weather/corrdiff/conf/base/generation/base_all.yaml
+++ b/examples/weather/corrdiff/conf/base/generation/base_all.yaml
@@ -46,6 +46,6 @@ perf:
     # Use Apex GroupNorm (optimized normalization for performance with channelslast layout)
   profile_mode: false
     # Enable NVTX annotations for performance profiling
-  io_syncronous: true
+  io_synchronous: true
     # Synchronize I/O operations for writing inference results
 

--- a/examples/weather/corrdiff/helpers/generate_helpers.py
+++ b/examples/weather/corrdiff/helpers/generate_helpers.py
@@ -51,8 +51,7 @@ def save_images(
     image_tar,
     image_lr,
     time_index,
-    t_index,
-    has_lead_time,
+    dataset_index,
 ):
     """
     Saves inferencing result along with the baseline
@@ -71,7 +70,7 @@ def save_images(
     image_tar (torch.Tensor): Ground truth data
     image_lr (torch.Tensor): Low resolution input data
     time_index (int): Epoch number
-    t_index (int): index where times are located
+    dataset_index (int): index where times are located
     """
     # weather sub-plot
     image_lr2 = image_lr[0].unsqueeze(0)
@@ -95,7 +94,7 @@ def save_images(
         image_out2 = image_out2.cpu().numpy()
         image_out2 = dataset.denormalize_output(image_out2)
 
-        time = times[t_index]
+        time = times[dataset_index]
         writer.write_time(time_index, time)
         for channel_idx in range(image_out2.shape[1]):
             info = dataset.output_channels()[channel_idx]

--- a/examples/weather/corrdiff/train.py
+++ b/examples/weather/corrdiff/train.py
@@ -831,7 +831,7 @@ def main(cfg: DictConfig) -> None:
                     )
 
             # Retain only the recent n checkpoints, if desired
-            if cfg.training.io.save_n_recent_checkpoints > 0:
+            if dist.rank == 0 and cfg.training.io.save_n_recent_checkpoints > 0:
                 for suffix in [".mdlus", ".pt"]:
                     ckpts = checkpoint_list(checkpoint_dir, suffix=suffix)
                     while len(ckpts) > cfg.training.io.save_n_recent_checkpoints:

--- a/examples/weather/corrdiff/train.py
+++ b/examples/weather/corrdiff/train.py
@@ -830,13 +830,13 @@ def main(cfg: DictConfig) -> None:
                         epoch=cur_nimg,
                     )
 
-            # Retain only the recent n checkpoints, if desired
-            if dist.rank == 0 and cfg.training.io.save_n_recent_checkpoints > 0:
-                for suffix in [".mdlus", ".pt"]:
-                    ckpts = checkpoint_list(checkpoint_dir, suffix=suffix)
-                    while len(ckpts) > cfg.training.io.save_n_recent_checkpoints:
-                        os.remove(os.path.join(checkpoint_dir, ckpts[0]))
-                        ckpts = ckpts[1:]
+                    # Retain only the recent n checkpoints, if desired
+                    if cfg.training.io.save_n_recent_checkpoints > 0:
+                        for suffix in [".mdlus", ".pt"]:
+                            ckpts = checkpoint_list(checkpoint_dir, suffix=suffix)
+                            while len(ckpts) > cfg.training.io.save_n_recent_checkpoints:
+                                os.remove(os.path.join(checkpoint_dir, ckpts[0]))
+                                ckpts = ckpts[1:]
 
     # Done.
     logger0.info("Training Completed.")


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Two small fixes:
* For n output timestamps, generate.py always wrote the first n timestamps of the dataset to the output file. It now uses the sample indices for indexing the list of times instead.
* The checkpoint cleanup procedure was potentially called on multiple ranks, which can cause race conditions. It is now only called after saving a checkpoint (on rank 0).

I also changed io_syncronous to io_synchronous.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->