### PR TITLE
Use no_grad for healpix tests

### DIFF
--- a/test/models/dlwp_healpix/test_healpix_recunet_model.py
+++ b/test/models/dlwp_healpix/test_healpix_recunet_model.py
@@ -304,6 +304,7 @@ def test_HEALPixRecUNet_integration_steps(
 
 @import_or_fail("omegaconf")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@torch.no_grad()
 def test_HEALPixRecUNet_reset(
     device,
     encoder_dict,
@@ -356,6 +357,7 @@ def test_HEALPixRecUNet_reset(
 
 @import_or_fail("omegaconf")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@torch.no_grad()
 def test_HEALPixRecUNet_forward(
     device,
     encoder_dict,


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Adds no_grad to reduce memory usage in `HEALPixRecUNet` tests

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->