### PR TITLE
Add a distributed implementation of kNN + testing.

### DIFF
--- a/physicsnemo/distributed/shard_utils/__init__.py
+++ b/physicsnemo/distributed/shard_utils/__init__.py
@@ -21,7 +21,12 @@ from physicsnemo.utils.version_check import check_module_requirements
 # Prevent importing this module if the minimum version of pytorch is not met.
 try:
     check_module_requirements("physicsnemo.distributed.shard_tensor")
+    SHARD_TENSOR_AVAILABLE = True
 
+except ImportError:
+    pass
+
+if SHARD_TENSOR_AVAILABLE:
     from physicsnemo.distributed.shard_tensor import ShardTensor
 
     def register_shard_wrappers():
@@ -32,6 +37,7 @@ try:
             sharded_select_backward_helper,
             sharded_select_helper,
         )
+        from .knn import knn_sharded_wrapper
 
         # Currently disabled until wrapt is removed
         # from .natten_patches import na2d_wrapper
@@ -40,6 +46,3 @@ try:
         from .pooling_patches import generic_avg_pool_nd_wrapper
         from .unary_ops import unsqueeze_wrapper
         from .unpooling_patches import generic_interpolate_wrapper
-
-except ImportError:
-    pass

--- a/physicsnemo/distributed/shard_utils/knn.py
+++ b/physicsnemo/distributed/shard_utils/knn.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Callable
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+from physicsnemo.utils.neighbors.knn._cuml_impl import knn_impl
+from physicsnemo.utils.version_check import check_module_requirements
+
+check_module_requirements("physicsnemo.distributed.shard_tensor")
+
+from physicsnemo.distributed import ShardTensor  # noqa: E402
+from physicsnemo.distributed.shard_utils.patch_core import (  # noqa: E402
+    MissingShardPatch,
+)
+from physicsnemo.distributed.shard_utils.ring import (  # noqa: E402
+    RingPassingConfig,
+    perform_ring_iteration,
+)
+
+
+def ring_knn(
+    points: ShardTensor, queries: ShardTensor, k: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Ring based kNN implementation, where the points travel around a ring and the
+    queries stay local.
+    """
+    # Each tensor has a _spec attribute, which contains information about the tensor's placement
+    # and the devices it lives on:
+    points_spec = points._spec
+    queries_spec = queries._spec
+
+    # ** In general ** you want to do some checking on the placements, since each
+    # point cloud might be sharded differently.  By construction, I know they're both
+    # sharded along the points axis here (and not, say, replicated).
+
+    if not points_spec.mesh == queries_spec.mesh:
+        raise NotImplementedError("Tensors must be sharded on the same mesh")
+
+    mesh = points_spec.mesh
+    local_group = mesh.get_group(0)
+    local_size = dist.get_world_size(group=local_group)
+    mesh_rank = mesh.get_local_rank()
+
+    # points and queries are both sharded - and since we're returning the nearest
+    # neighbors to points, let's make sure the output keeps that sharding too.
+
+    # One memory-efficient way to do this is with with a ring computation.
+    # We'll compute the knn on the local tensors, get the distances and outputs,
+    # then shuffle the queries shards along the mesh.
+
+    # we'll need to sort the results and make sure we have just the top-k,
+    # which is a little extra computation.
+
+    # Physics nemo has a ring passing utility we can use.
+    ring_config = RingPassingConfig(
+        mesh_dim=0,
+        mesh_size=local_size,
+        ring_direction="forward",
+        communication_method="p2p",
+    )
+
+    local_points, local_queries = points.to_local(), queries.to_local()
+    current_dists = None
+    current_topk_idx = None
+
+    points_spec = points._spec
+
+    points_sharding_shapes = points_spec.sharding_shapes()[0]
+
+    sharding_dim = points_spec.placements[0].dim
+
+    # This is to help specify the offset from local to global tensor.
+    points_strides_along_ring = [s[sharding_dim] for s in points_sharding_shapes]
+    points_strides_along_ring = np.cumsum(points_strides_along_ring)
+    points_strides_along_ring = [
+        0,
+    ] + list(points_strides_along_ring[0:-1])
+
+    for i in range(local_size):
+        source_rank = (mesh_rank - i) % local_size
+
+        # For point clouds, we need to pass the size of the incoming shard.
+        next_source_rank = (source_rank - 1) % local_size
+        recv_shape = points_sharding_shapes[next_source_rank]
+        if i != local_size - 1:
+            # Don't do a ring on the last iteration.
+            next_local_points = perform_ring_iteration(
+                local_points,
+                mesh,
+                ring_config,
+                recv_shape=recv_shape,
+            )
+
+        # Compute the knn on the local tensors:
+        local_idx, local_distances = knn_impl(local_points, local_queries, k)
+
+        # The local_idx indexes into the _local_ tensor, but for
+        # Correctness we need it to index into the _global_ tensor.
+        # Make sure to index using the rank the points came from!
+        offset = points_strides_along_ring[source_rank]
+        local_idx = local_idx + offset
+
+        if current_dists is None:
+            current_dists = local_distances
+            current_topk_idx = local_idx
+        else:
+            # Combine with the topk so far:
+            current_dists = torch.cat([current_dists, local_distances], dim=1)
+            current_topk_idx = torch.cat([current_topk_idx, local_idx], dim=1)
+            # And take the topk again:
+            current_dists, running_indexes = torch.topk(
+                current_dists, k=k, dim=1, sorted=True, largest=False
+            )
+
+            # This creates proper indexing to select specific elements along dim 1
+
+            current_topk_idx = torch.gather(current_topk_idx, 1, running_indexes)
+
+        if i != local_size - 1:
+            # Don't do a ring on the last iteration.
+            local_points = next_local_points
+
+    return current_topk_idx, current_dists
+
+
+def extract_knn_args(points, queries, k, *args, **kwargs):
+    return points, queries, k
+
+
+def knn_sharded_wrapper(
+    func: Callable, types: Any, args: tuple, kwargs: dict
+) -> tuple[ShardTensor, ShardTensor]:
+    """
+    Dispatch the proper kNN tools based on the input sharding.
+    """
+
+    points, queries, k = extract_knn_args(*args, **kwargs)
+
+    # kNN will only work with 1D sharding
+    if points._spec.mesh != queries._spec.mesh:
+        raise MissingShardPatch(
+            "sharded knn: All point inputs must be on the same mesh"
+        )
+
+    # make sure all meshes are 1D
+    if points._spec.mesh.ndim != 1:
+        raise MissingShardPatch(
+            "point_cloud_ops.radius_search_wrapper: All point inputs must be on 1D meshes"
+        )
+
+    # Do we need a ring?
+    points_placement = points._spec.placements[0]
+
+    if points_placement.is_shard():
+        # We need a ring
+        idx, distances = ring_knn(points, queries, k)
+    else:
+        # No ring is needed.  Get the local tensors and compute directly:
+        local_points = points.to_local()  # This is replicated, getting all of it
+        local_queries = queries.to_local()  # This sharding doesn't matter!
+        idx, distances = knn_impl(local_points, local_queries, k)
+
+    # The outputs only depend on the local queries shape
+    input_queries_spec = queries._spec
+    # The global output tensor will be (N_q, k)
+
+    output_queries_shard_shapes = {
+        mesh_dim: tuple(
+            torch.Size((s[0], k))
+            for s in input_queries_spec.sharding_shapes()[mesh_dim]
+        )
+        for mesh_dim in input_queries_spec.sharding_shapes().keys()
+    }
+
+    # Convert the selected points and indexes to shards:
+    shard_idx = ShardTensor.from_local(
+        idx,
+        queries._spec.mesh,
+        queries._spec.placements,
+        sharding_shapes=output_queries_shard_shapes,
+    )
+    shard_distances = ShardTensor.from_local(
+        distances,
+        queries._spec.mesh,
+        queries._spec.placements,
+        sharding_shapes=output_queries_shard_shapes,
+    )
+
+    return shard_idx, shard_distances
+
+
+ShardTensor.register_named_function_handler(
+    "physicsnemo.knn_cuml.default", knn_sharded_wrapper
+)

--- a/physicsnemo/distributed/shard_utils/knn.py
+++ b/physicsnemo/distributed/shard_utils/knn.py
@@ -39,8 +39,36 @@ def ring_knn(
     points: ShardTensor, queries: ShardTensor, k: int
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
-    Ring based kNN implementation, where the points travel around a ring and the
-    queries stay local.
+    Ring based kNN implementation where points travel around a ring and queries stay local.
+
+    This function performs k-nearest neighbor search using a distributed ring-based
+    algorithm. The points are passed around different devices in a ring topology while
+    the queries remain local to each device.
+
+    Parameters
+    ----------
+    points : ShardTensor
+        The point cloud data tensor that will be distributed around the ring.
+        Must be sharded on the same mesh as queries.
+    queries : ShardTensor
+        The query points tensor that stays local on each device.
+        Must be sharded on the same mesh as points.
+    k : int
+        Number of nearest neighbors to find for each query point.
+
+    Returns
+    -------
+    tuple[torch.Tensor, torch.Tensor]
+        A tuple containing:
+        - shard_idx : torch.Tensor
+            Indices of the k nearest neighbors for each query point
+        - shard_distances : torch.Tensor
+            Distances to the k nearest neighbors for each query point
+
+    Raises
+    ------
+    NotImplementedError
+        If points and queries tensors are not sharded on the same mesh.
     """
     # Each tensor has a _spec attribute, which contains information about the tensor's placement
     # and the devices it lives on:
@@ -141,7 +169,12 @@ def ring_knn(
     return current_topk_idx, current_dists
 
 
-def extract_knn_args(points, queries, k, *args, **kwargs):
+def extract_knn_args(
+    points: torch.Tensor, queries: torch.Tensor, k: int, *args, **kwargs
+):
+    """
+    Minimal function to use python's argument unpacking to extract the points, queries, and k values.
+    """
     return points, queries, k
 
 
@@ -150,6 +183,30 @@ def knn_sharded_wrapper(
 ) -> tuple[ShardTensor, ShardTensor]:
     """
     Dispatch the proper kNN tools based on the input sharding.
+
+    `args` and `kwargs` are passed to `extract_knn_args` to extract
+    the points, queries, and k values needed for the kNN operation.
+
+    Parameters
+    ----------
+    func : Callable
+        The function to dispatch.
+    types : Any
+        The types of the inputs.
+    args : tuple
+        The positional arguments.
+    kwargs : dict
+        The keyword arguments.
+
+    Returns
+    -------
+    tuple[ShardTensor, ShardTensor]
+        A tuple containing the shard_idx and shard_distances.
+
+    Raises
+    ------
+    MissingShardPatch
+        If the points and queries tensors are not sharded on the same mesh.
     """
 
     points, queries, k = extract_knn_args(*args, **kwargs)
@@ -182,13 +239,13 @@ def knn_sharded_wrapper(
     input_queries_spec = queries._spec
     # The global output tensor will be (N_q, k)
 
-    output_queries_shard_shapes = {
-        mesh_dim: tuple(
+    output_queries_shard_shapes = {}
+    for mesh_dim in input_queries_spec.sharding_shapes().keys():
+        shard_shapes = tuple(
             torch.Size((s[0], k))
             for s in input_queries_spec.sharding_shapes()[mesh_dim]
         )
-        for mesh_dim in input_queries_spec.sharding_shapes().keys()
-    }
+        output_queries_shard_shapes[mesh_dim] = shard_shapes
 
     # Convert the selected points and indexes to shards:
     shard_idx = ShardTensor.from_local(

--- a/test/distributed/shard_tensor/ops/test_knn.py
+++ b/test/distributed/shard_tensor/ops/test_knn.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from physicsnemo.distributed import DistributedManager, scatter_tensor
+from physicsnemo.utils.neighbors import knn
+
+from .utils import numerical_shard_tensor_check
+
+
+class kNNModule(torch.nn.Module):
+    def __init__(
+        self,
+        num_neighbors=4,
+    ):
+        super().__init__()
+
+        self.num_neighbors = num_neighbors
+
+    def forward(self, points, queries):
+        return knn(points, queries, self.num_neighbors)
+
+
+@pytest.mark.multigpu_static
+@pytest.mark.parametrize("scatter_points", [True, False])
+@pytest.mark.parametrize("scatter_queries", [True, False])
+def test_knn_1dmesh(
+    distributed_mesh,
+    scatter_points: bool,
+    scatter_queries: bool,
+):
+    dm = DistributedManager()
+
+    # Generate random points for the points and queries
+    points = torch.randn(1043, 3).to(dm.device)
+    queries = torch.randn(2198, 3).to(dm.device)
+
+    # points = torch.randn(10, 3).to(dm.device)
+    # queries = torch.randn(8, 3).to(dm.device)
+
+    # Distribute the inputs:
+    points_placements = (Shard(0),) if scatter_points else (Replicate(),)
+    queries_placements = (Shard(0),) if scatter_queries else (Replicate(),)
+
+    sharded_points = scatter_tensor(points, 0, distributed_mesh, points_placements)
+    sharded_queries = scatter_tensor(queries, 0, distributed_mesh, queries_placements)
+
+    module = kNNModule()
+
+    numerical_shard_tensor_check(
+        distributed_mesh,
+        module,
+        [sharded_points, sharded_queries],
+        {},
+        check_grads=False,
+    )

--- a/test/distributed/shard_tensor/ops/test_knn.py
+++ b/test/distributed/shard_tensor/ops/test_knn.py
@@ -51,9 +51,6 @@ def test_knn_1dmesh(
     points = torch.randn(1043, 3).to(dm.device)
     queries = torch.randn(2198, 3).to(dm.device)
 
-    # points = torch.randn(10, 3).to(dm.device)
-    # queries = torch.randn(8, 3).to(dm.device)
-
     # Distribute the inputs:
     points_placements = (Shard(0),) if scatter_points else (Replicate(),)
     queries_placements = (Shard(0),) if scatter_queries else (Replicate(),)

--- a/test/distributed/shard_tensor/ops/utils.py
+++ b/test/distributed/shard_tensor/ops/utils.py
@@ -18,6 +18,7 @@ import copy
 from collections.abc import Iterable
 
 import torch
+import torch.distributed as dist
 from torch.distributed.tensor import DTensor, distribute_module
 from torch.distributed.tensor.device_mesh import DeviceMesh
 
@@ -81,9 +82,23 @@ def sharded_to_local(container):
 
 
 def default_tensor_comparison(output, d_output, atol, rtol):
-    # We assume a single output!
+    if not isinstance(output, torch.Tensor):
+        if isinstance(output, Iterable):
+            return all(
+                [
+                    default_tensor_comparison(item, d_item, atol, rtol)
+                    for item, d_item in zip(output, d_output)
+                ]
+            )
+
+    if isinstance(d_output, ShardTensor):
+        validate_shard_tensor_spec(d_output)
 
     local_output = sharded_to_local(d_output)
+
+    # diff = output - local_output
+    # abs_diff = torch.abs(diff)
+    # max_abs_diff_allowed = 1e-8 + 1e-5 * torch.abs(output)
 
     # Check forward agreement:
     assert torch.allclose(output, local_output, atol=atol, rtol=rtol)
@@ -93,6 +108,34 @@ def default_tensor_comparison(output, d_output, atol, rtol):
 
 def default_loss_fn(output):
     return output.mean()
+
+
+def validate_shard_tensor_spec(shard_tensor):
+    # Take a shard tensor and cross check on the dimensions.
+    # Take care about assertions here, since this is a collective
+
+    # Check out shard shapes
+    # The local shard shape needs to match the local tensor shape:
+    sharding_shapes = shard_tensor._spec.sharding_shapes()
+    mesh = shard_tensor._spec.mesh
+
+    for mesh_dim in range(mesh.ndim):
+        mesh_rank = mesh.get_local_rank(mesh_dim)
+        mesh_size = dist.get_world_size(mesh.get_group(mesh_dim))
+
+        # Is this axis sharded?
+        this_placement = shard_tensor._spec.placements[mesh_dim]
+        if this_placement.is_shard():
+            # This axis is sharded.  the mesh dim should be in the shapes
+            assert mesh_dim in sharding_shapes.keys()
+
+            # The length of the sharding shapes should match the mesh size:
+            assert len(sharding_shapes[mesh_dim]) == mesh_size
+
+            # The local shape should match the listed shape for this rank:
+            assert (
+                sharding_shapes[mesh_dim][mesh_rank] == shard_tensor._local_tensor.shape
+            )
 
 
 def numerical_shard_tensor_check(

--- a/test/distributed/shard_tensor/ops/utils.py
+++ b/test/distributed/shard_tensor/ops/utils.py
@@ -81,37 +81,13 @@ def sharded_to_local(container):
         return container
 
 
-def default_tensor_comparison(output, d_output, atol, rtol):
-    if not isinstance(output, torch.Tensor):
-        if isinstance(output, Iterable):
-            return all(
-                [
-                    default_tensor_comparison(item, d_item, atol, rtol)
-                    for item, d_item in zip(output, d_output)
-                ]
-            )
-
-    if isinstance(d_output, ShardTensor):
-        validate_shard_tensor_spec(d_output)
-
-    local_output = sharded_to_local(d_output)
-
-    # diff = output - local_output
-    # abs_diff = torch.abs(diff)
-    # max_abs_diff_allowed = 1e-8 + 1e-5 * torch.abs(output)
-
-    # Check forward agreement:
-    assert torch.allclose(output, local_output, atol=atol, rtol=rtol)
-
-    return True
-
-
-def default_loss_fn(output):
-    return output.mean()
-
-
 def validate_shard_tensor_spec(shard_tensor):
-    # Take a shard tensor and cross check on the dimensions.
+    """
+    Take a shard tensor and cross check on the dimensions and shapes.
+
+    Basically, this is a consistency-check on sharding shapes.
+    """
+
     # Take care about assertions here, since this is a collective
 
     # Check out shard shapes
@@ -136,6 +112,31 @@ def validate_shard_tensor_spec(shard_tensor):
             assert (
                 sharding_shapes[mesh_dim][mesh_rank] == shard_tensor._local_tensor.shape
             )
+
+
+def default_tensor_comparison(output, d_output, atol, rtol):
+    if not isinstance(output, torch.Tensor):
+        if isinstance(output, Iterable):
+            return all(
+                [
+                    default_tensor_comparison(item, d_item, atol, rtol)
+                    for item, d_item in zip(output, d_output)
+                ]
+            )
+
+    if isinstance(d_output, ShardTensor):
+        validate_shard_tensor_spec(d_output)
+
+    local_output = sharded_to_local(d_output)
+
+    # Check forward agreement:
+    assert torch.allclose(output, local_output, atol=atol, rtol=rtol)
+
+    return True
+
+
+def default_loss_fn(output):
+    return output.mean()
 
 
 def numerical_shard_tensor_check(


### PR DESCRIPTION
This PR adds a distributed wrapper for the cuml based kNN tool in physicsnemo.  It only applies to CUDA tensors, but ShardTensor is CUDA-centric anyways.

Eventually, this is needed for the refactor of the domino pipeline and domain parallelism, but I've split it off here to be standalone and more easily reviewed.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->