### PR TITLE
Port SDF function to static, torch-only interface

### DIFF
--- a/physicsnemo/datapipes/cae/domino_datapipe.py
+++ b/physicsnemo/datapipes/cae/domino_datapipe.py
@@ -64,6 +64,31 @@ from physicsnemo.utils.domino.utils import (
 from physicsnemo.utils.profiling import profile
 from physicsnemo.utils.sdf import signed_distance_field
 
+"""
+These functions, below, are to handle the SDF calculation which only 
+accepts torch tensors.  The entire pipeline is moving to torch, so
+these aren't necessary after that.
+"""
+
+
+def convert_array_to_torch(array: cp.ndarray | np.ndarray) -> torch.Tensor:
+    """
+    TEMPORARY function to convert cupy and numpy arrays to torch tensors.
+    """
+    if isinstance(array, cp.ndarray):
+        return torch.utils.dlpack.from_dlpack(array)
+    elif isinstance(array, np.ndarray):
+        return torch.from_numpy(array)
+    else:
+        raise ValueError(f"Unsupported array type: {type(array)}")
+
+
+def convert_torch_to_array(array: torch.Tensor, provider) -> cp.ndarray | np.ndarray:
+    """
+    TEMPORARY function to convert torch tensors to cupy arrays.
+    """
+    return provider.from_dlpack(array)
+
 
 def domino_collate_fn(batch):
     """
@@ -537,12 +562,14 @@ class DoMINODataPipe(Dataset):
             surf_grid = create_grid(s_max, s_min, [nx, ny, nz])
             surf_grid_reshaped = surf_grid.reshape(nx * ny * nz, 3)
 
-            sdf_surf_grid = signed_distance_field(
-                stl_vertices,
-                mesh_indices_flattened,
-                surf_grid_reshaped,
+            sdf_surf_grid, _ = signed_distance_field(
+                convert_array_to_torch(stl_vertices),
+                convert_array_to_torch(mesh_indices_flattened),
+                convert_array_to_torch(surf_grid_reshaped),
                 use_sign_winding_number=True,
-            ).reshape(nx, ny, nz)
+            )
+            sdf_surf_grid = sdf_surf_grid.reshape(nx, ny, nz)
+            sdf_surf_grid = convert_torch_to_array(sdf_surf_grid, self.array_provider)
 
         else:
             surf_grid = None
@@ -855,12 +882,14 @@ class DoMINODataPipe(Dataset):
             grid_reshaped = grid.reshape(nx * ny * nz, 3)
 
             # SDF calculation on the grid using WARP
-            sdf_grid = signed_distance_field(
-                stl_vertices,
-                mesh_indices_flattened,
-                grid_reshaped,
+            sdf_grid, _ = signed_distance_field(
+                convert_array_to_torch(stl_vertices),
+                convert_array_to_torch(mesh_indices_flattened),
+                convert_array_to_torch(grid_reshaped),
                 use_sign_winding_number=True,
-            ).reshape((nx, ny, nz))
+            )
+            sdf_grid = sdf_grid.reshape((nx, ny, nz))
+            sdf_grid = convert_torch_to_array(sdf_grid, self.array_provider)
 
             if self.config.sampling:
                 volume_coordinates_sampled, idx_volume = shuffle_array(
@@ -879,12 +908,16 @@ class DoMINODataPipe(Dataset):
                 volume_coordinates = volume_coordinates_sampled
 
             sdf_nodes, sdf_node_closest_point = signed_distance_field(
-                stl_vertices,
-                mesh_indices_flattened,
-                volume_coordinates,
-                include_hit_points=True,
+                convert_array_to_torch(stl_vertices),
+                convert_array_to_torch(mesh_indices_flattened),
+                convert_array_to_torch(volume_coordinates),
                 use_sign_winding_number=True,
             )
+            sdf_nodes = convert_torch_to_array(sdf_nodes, self.array_provider)
+            sdf_node_closest_point = convert_torch_to_array(
+                sdf_node_closest_point, self.array_provider
+            )
+
             # TODO - is this needed?
             sdf_nodes = xp.asarray(sdf_nodes)
             sdf_node_closest_point = xp.asarray(sdf_node_closest_point)

--- a/physicsnemo/distributed/shard_utils/__init__.py
+++ b/physicsnemo/distributed/shard_utils/__init__.py
@@ -32,6 +32,7 @@ try:
             sharded_select_backward_helper,
             sharded_select_helper,
         )
+        from .mesh_ops import sharded_signed_distance_field_wrapper
 
         # Currently disabled until wrapt is removed
         # from .natten_patches import na2d_wrapper

--- a/physicsnemo/distributed/shard_utils/mesh_ops.py
+++ b/physicsnemo/distributed/shard_utils/mesh_ops.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import torch
+
+from physicsnemo.utils.sdf import signed_distance_field
+from physicsnemo.utils.version_check import check_module_requirements
+
+check_module_requirements("physicsnemo.distributed.shard_tensor")
+
+
+from physicsnemo.distributed import ShardTensor  # noqa: E402
+
+
+def sharded_signed_distance_field(
+    mesh_vertices: ShardTensor,
+    mesh_indices: ShardTensor,
+    input_points: ShardTensor,
+    max_dist: float = 1e8,
+    use_sign_winding_number: bool = False,
+) -> tuple[ShardTensor, ShardTensor]:
+    """
+    Compute the signed distance field for a (possibly sharded) mesh.
+
+    Args:
+        mesh_vertices: Sharded tensor of mesh vertices
+        mesh_indices: Sharded tensor of mesh indices
+        input_points: Sharded tensor of input points
+        max_dist: Maximum distance for the signed distance field
+        use_sign_winding_number: Whether to use sign winding number
+    """
+
+    # We can not actually compute the signed distance function on a sharded mesh.
+    # So, in this case, force the mesh to replicate placement if necessary:
+
+    local_mesh_vertices = mesh_vertices.full_tensor()
+    local_mesh_indices = mesh_indices.full_tensor()
+
+    # For the input points, though, it doesn't matter - they can be sharded.
+    # No communication is necessary
+
+    local_input_points = input_points.to_local()
+
+    local_sdf, local_sdf_hit_point = signed_distance_field(
+        local_mesh_vertices,
+        local_mesh_indices,
+        local_input_points,
+        max_dist,
+        use_sign_winding_number,
+    )
+
+    # Then, construct the output shard tensors:
+
+    if input_points._spec.placements[0].is_shard():
+        # Compute the output sharding shapes
+
+        # Output shape is always (N, 1), hit point is (N, 3)
+        input_shard_shapes = input_points._spec.sharding_shapes()
+
+        output_shard_shapes = {
+            mesh_dim: tuple(torch.Size((s[0],)) for s in input_shard_shapes[mesh_dim])
+            for mesh_dim in input_shard_shapes.keys()
+        }
+
+        sharded_sdf_output = ShardTensor.from_local(
+            local_sdf,
+            input_points._spec.mesh,
+            input_points._spec.placements,
+            sharding_shapes=output_shard_shapes,
+        ).reshape(input_points.shape[:-1])
+
+        sharded_sdf_hit_point_output = ShardTensor.from_local(
+            local_sdf_hit_point,
+            input_points._spec.mesh,
+            input_points._spec.placements,
+            sharding_shapes=input_shard_shapes,
+        ).reshape(input_points.shape)
+
+    else:
+        # The input points were replicated, use that for output:
+        sharded_sdf_output = ShardTensor.from_local(
+            local_sdf,
+            input_points._spec.mesh,
+            input_points._spec.placements,
+        )
+        sharded_sdf_hit_point_output = ShardTensor.from_local(
+            local_sdf_hit_point,
+            input_points._spec.mesh,
+            input_points._spec.placements,
+        )
+
+    return sharded_sdf_output, sharded_sdf_hit_point_output
+
+
+def repackage_radius_search_wrapper_args(
+    mesh_vertices: torch.Tensor,
+    mesh_indices: torch.Tensor,
+    input_points: torch.Tensor,
+    max_dist: float = 1e8,
+    use_sign_winding_number: bool = False,
+    *args,
+    **kwargs,
+) -> tuple[ShardTensor, ShardTensor, dict]:
+    """Repackages sdf arguments into a standard format."""
+    # Extract any additional parameters that might be in kwargs
+    # or use defaults if not provided
+    return_kwargs = {
+        "max_dist": max_dist,
+        "use_sign_winding_number": use_sign_winding_number,
+    }
+
+    # Add any explicitly passed parameters
+    if kwargs:
+        return_kwargs.update(kwargs)
+
+    return mesh_vertices, mesh_indices, input_points, return_kwargs
+
+
+def sharded_signed_distance_field_wrapper(
+    func: Any, type: Any, args: tuple, kwargs: dict
+) -> tuple[ShardTensor, ShardTensor]:
+    """
+    Wrapper for sharded_signed_distance_field to support sharded tensors.
+    """
+
+    return sharded_signed_distance_field(*args, **kwargs)
+
+
+ShardTensor.register_named_function_handler(
+    "physicsnemo.signed_distance_field.default", sharded_signed_distance_field_wrapper
+)

--- a/physicsnemo/utils/sdf.py
+++ b/physicsnemo/utils/sdf.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cupy as cp
-import numpy as np
+import torch
 import warp as wp
 
 wp.config.quiet = True
@@ -28,7 +27,6 @@ def _bvh_query_distance(
     max_dist: wp.float32,
     sdf: wp.array(dtype=wp.float32),
     sdf_hit_point: wp.array(dtype=wp.vec3f),
-    sdf_hit_point_id: wp.array(dtype=wp.int32),
     use_sign_winding_number: bool = False,
 ):
     """
@@ -67,22 +65,16 @@ def _bvh_query_distance(
 
     sdf[tid] = res.sign * wp.abs(wp.length(points[tid] - p_closest))
     sdf_hit_point[tid] = p_closest
-    sdf_hit_point_id[tid] = res.face
 
 
-Array = np.ndarray | cp.ndarray
-
-
+@torch.library.custom_op("physicsnemo::signed_distance_field", mutates_args=())
 def signed_distance_field(
-    mesh_vertices: Array,
-    mesh_indices: Array,
-    input_points: Array,
+    mesh_vertices: torch.Tensor,
+    mesh_indices: torch.Tensor,
+    input_points: torch.Tensor,
     max_dist: float = 1e8,
-    include_hit_points: bool = False,
-    include_hit_points_id: bool = False,
     use_sign_winding_number: bool = False,
-    return_cupy: bool | None = None,
-) -> Array | tuple[Array, ...]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Computes the signed distance field (SDF) for a given mesh and input points.
 
@@ -100,11 +92,7 @@ def signed_distance_field(
         max_dist (float, optional): Maximum distance within which
             to search for the closest point on the mesh. Default is 1e8.
         include_hit_points (bool, optional): Whether to include hit points in
-            the output. Here, "hit points" are the points on the mesh that are
-            closest to the input points, and hence, are defining the SDF.
-            Default is False.
-        include_hit_points_id (bool, optional): Whether to include hit point
-            IDs in the output. Default is False.
+            the output. Here,
         use_sign_winding_number (bool, optional): Whether to use sign winding
             number method for SDF. Default is False. If False, your mesh should
             be watertight to obtain correct results.
@@ -115,88 +103,103 @@ def signed_distance_field(
     Returns:
     -------
     Returns:
-        np.ndarray | cp.ndarray or tuple:
-            - If both `include_hit_points` and `include_hit_points_id` are False
-              (default), returns a 1D array of signed distances for each input
-              point.
-            - If `include_hit_points` is True, returns a tuple: (sdf,
-              hit_points), where `hit_points` contains the closest mesh point
-              for each input point.
-            - If `include_hit_points_id` is True, returns a tuple: (sdf,
-              hit_point_ids), where `hit_point_ids` contains the face index of
-              the closest mesh face for each input point.
-            - If both `include_hit_points` and `include_hit_points_id` are True,
-              returns a tuple: (sdf, hit_points, hit_point_ids).
-            - The returned array type (NumPy or CuPy) is determined by the
-            `return_cupy` argument, or inferred from the input arrays.
+        tuple[torch.Tensor, torch.Tensor] of:
+            - signed distance to the mesh, per input point
+            - hith point, per input point. "hit points" are the points on the
+              mesh that are closest to the input points, and hence, are
+              defining the SDF.
 
     Example:
     -------
     >>> mesh_vertices = [(0, 0, 0), (1, 0, 0), (0, 1, 0)]
-    >>> mesh_indices = np.array((0, 1, 2))
-    >>> input_points = [(0.5, 0.5, 0.5)]
+    >>> mesh_indices = torch.tensor((0, 1, 2))
+    >>> input_points = torch.tensor((0.5, 0.5, 0.5))
     >>> signed_distance_field(mesh_vertices, mesh_indices, input_points)
-    array([0.5], dtype=float32)
+    (tensor([0.5]), tensor([0.5, 0.5, 0.5]))
     """
-    if return_cupy is None:
-        return_cupy = any(
-            isinstance(arr, cp.ndarray)
-            for arr in (mesh_vertices, mesh_indices, input_points)
+
+    if input_points.shape[-1] != 3:
+        raise ValueError("Input points must be a tensor with last dimension of size 3")
+
+    input_shape = input_points.shape
+
+    # Flatten the input points:
+    input_points = input_points.reshape(-1, 3)
+
+    N = len(input_points)
+
+    # Allocate output tensors with torch:
+    sdf = torch.zeros(N, dtype=torch.float32, device=input_points.device)
+    sdf_hit_point = torch.zeros(N, 3, dtype=torch.float32, device=input_points.device)
+
+    if input_points.device.type == "cuda":
+        wp_launch_stream = wp.stream_from_torch(
+            torch.cuda.current_stream(input_points.device)
         )
-
-    wp.init()
-
-    if isinstance(mesh_vertices, cp.ndarray):
-        device = mesh_vertices.device
-        wp_device = f"cuda:{device.id}"
+        wp_launch_device = None  # We explicitly pass None if using the stream.
     else:
-        wp_device = wp.get_device()
+        wp_launch_stream = None
+        wp_launch_device = "cpu"  # CPUs have no streams
 
-    with wp.ScopedDevice(wp_device):
+    with wp.ScopedStream(wp_launch_stream):
+        wp.init()
+
+        # zero copy the vertices, indices, and input points to warp:
+        wp_vertices = wp.from_torch(mesh_vertices.to(torch.float32), dtype=wp.vec3)
+        wp_indices = wp.from_torch(mesh_indices.to(torch.int32), dtype=wp.int32)
+        wp_input_points = wp.from_torch(input_points.to(torch.float32), dtype=wp.vec3)
+
+        # Convert output points:
+        wp_sdf = wp.from_torch(sdf, dtype=wp.float32)
+        wp_sdf_hit_point = wp.from_torch(sdf_hit_point, dtype=wp.vec3f)
+
         mesh = wp.Mesh(
-            points=wp.array(mesh_vertices, dtype=wp.vec3f, device=wp_device),
-            indices=wp.array(mesh_indices, dtype=wp.int32, device=wp_device),
+            points=wp_vertices,
+            indices=wp_indices,
+            support_winding_number=use_sign_winding_number,
         )
-
-        warp_input_points = wp.array(input_points, dtype=wp.vec3f, device=wp_device)
-
-        N = len(warp_input_points)
-
-        sdf = wp.empty(shape=(N,), dtype=wp.float32, device=wp_device)
-        sdf_hit_point = wp.empty(shape=(N,), dtype=wp.vec3f, device=wp_device)
-        sdf_hit_point_id = wp.empty(shape=(N,), dtype=wp.int32, device=wp_device)
 
         wp.launch(
             kernel=_bvh_query_distance,
             dim=N,
             inputs=[
                 mesh.id,
-                warp_input_points,
+                wp_input_points,
                 max_dist,
-                sdf,
-                sdf_hit_point,
-                sdf_hit_point_id,
+                wp_sdf,
+                wp_sdf_hit_point,
                 use_sign_winding_number,
             ],
-            device=wp_device,
+            device=wp_launch_device,
+            stream=wp_launch_stream,
         )
 
-        def convert(array: wp.array) -> np.ndarray | cp.ndarray:
-            """Converts a Warp array to CuPy/NumPy based on the `return_cupy` flag."""
-            if return_cupy:
-                return cp.asarray(array)
-            else:
-                return array.numpy()
+    # Unflatten the output to be like the input:
+    sdf = sdf.reshape(input_shape[:-1])
+    sdf_hit_point = sdf_hit_point.reshape(input_shape)
 
-        arrays_to_return: list[np.ndarray | cp.ndarray] = [convert(sdf)]
+    return sdf.to(input_points.dtype), sdf_hit_point.to(input_points.dtype)
 
-        if include_hit_points:
-            arrays_to_return.append(convert(sdf_hit_point))
-        if include_hit_points_id:
-            arrays_to_return.append(convert(sdf_hit_point_id))
 
-        return (
-            arrays_to_return[0]
-            if len(arrays_to_return) == 1
-            else tuple(arrays_to_return)
-        )
+@signed_distance_field.register_fake
+def _(
+    mesh_vertices: torch.Tensor,
+    mesh_indices: torch.Tensor,
+    input_points: torch.Tensor,
+    max_dist: float = 1e8,
+    use_sign_winding_number: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if mesh_vertices.device != input_points.device:
+        raise RuntimeError("mesh_vertices and input_points must be on the same device")
+
+    if mesh_vertices.device != mesh_indices.device:
+        raise RuntimeError("mesh_vertices and mesh_indices must be on the same device")
+
+    N = input_points.shape[0]
+
+    sdf_output = torch.empty(N, 1, device=input_points.device, dtype=input_points.dtype)
+    sdf_hit_point_output = torch.empty(
+        N, 3, device=input_points.device, dtype=input_points.dtype
+    )
+
+    return sdf_output, sdf_hit_point_output

--- a/test/distributed/shard_tensor/ops/test_sdf.py
+++ b/test/distributed/shard_tensor/ops/test_sdf.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+from scipy.spatial import ConvexHull
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from physicsnemo.distributed import DistributedManager, scatter_tensor
+from physicsnemo.utils.sdf import signed_distance_field
+
+from .utils import numerical_shard_tensor_check
+
+
+# This is from the domino datapipe, too:
+def random_sample_on_unit_sphere(n_points):
+    # Random points on the sphere:
+    phi = np.random.uniform(0, 2 * np.pi, n_points)
+    cos_theta = np.random.uniform(-1, 1, n_points)
+    theta = np.arccos(cos_theta)
+
+    # Convert to x/y/z and stack:
+    x = np.sin(theta) * np.cos(phi)
+    y = np.sin(theta) * np.sin(phi)
+    z = np.cos(theta)
+    points = np.stack([x, y, z], axis=1)
+    return points
+
+
+def mesh_vertices_and_indices(n_points):
+    # We are generating a mesh on a random sphere.
+    stl_points = random_sample_on_unit_sphere(n_points)
+
+    # Generate the triangles with ConvexHull:
+    hull = ConvexHull(stl_points)
+    faces = hull.simplices  # (M, 3)
+
+    return stl_points, faces
+
+
+class SDFModule(torch.nn.Module):
+    """
+    This is a test module to run the SDF function ... don't use it elsewhere.
+    """
+
+    def __init__(self, max_dist=1e8, use_sign_winding_number=False):
+        super().__init__()
+
+        self.max_dist = max_dist
+        self.use_sign_winding_number = use_sign_winding_number
+
+    def forward(self, mesh_vertices, mesh_indices, input_points):
+        return signed_distance_field(
+            mesh_vertices,
+            mesh_indices,
+            input_points,
+            self.max_dist,
+            self.use_sign_winding_number,
+        )
+
+
+@pytest.mark.multigpu_static
+@pytest.mark.parametrize("scatter_mesh", [True, False])
+@pytest.mark.parametrize("scatter_inputs", [True, False])
+def test_sdf_1dmesh(
+    distributed_mesh,
+    scatter_mesh: bool,
+    scatter_inputs: bool,
+):
+    dm = DistributedManager()
+
+    # Generate a mesh on a unit sphere:
+    mesh_vertices, mesh_indices = mesh_vertices_and_indices(932)
+
+    # Cast the vertices and indices to tensors:
+    mesh_vertices = torch.tensor(mesh_vertices).to(dm.device)
+    mesh_indices = torch.tensor(mesh_indices.flatten()).to(dm.device)
+
+    # Distribute the inputs:
+    mesh_placements = (Shard(0),) if scatter_mesh else (Replicate(),)
+    input_placements = (Shard(0),) if scatter_inputs else (Replicate(),)
+
+    sharded_mesh_vertices = scatter_tensor(
+        mesh_vertices, 0, distributed_mesh, mesh_placements
+    )
+    sharded_mesh_indices = scatter_tensor(
+        mesh_indices, 0, distributed_mesh, mesh_placements
+    )
+
+    # Generate random points in the volume:
+    input_points = torch.randn(1043, 3).to(dm.device)
+
+    sharded_input_points = scatter_tensor(
+        input_points, 0, distributed_mesh, input_placements
+    )
+
+    module = SDFModule()
+
+    numerical_shard_tensor_check(
+        distributed_mesh,
+        module,
+        [sharded_mesh_vertices, sharded_mesh_indices, sharded_input_points],
+        {},
+        check_grads=False,
+    )

--- a/test/utils/test_mesh_utils.py
+++ b/test/utils/test_mesh_utils.py
@@ -19,6 +19,7 @@ import random
 
 import numpy as np
 import pytest
+import torch
 from pytest_utils import import_or_fail
 
 stl = pytest.importorskip("stl")
@@ -213,7 +214,14 @@ def test_stl_gen(pytestconfig, backend, sphere_stl, tmp_path):
         [xx.reshape(-1, 1), yy.reshape(-1, 1), zz.reshape(-1, 1)], axis=1
     )
 
-    sdf_test = signed_distance_field(vertices_3d, vert_indices, coords.flatten())
+    # SDF only accepts torch tensors:
+
+    sdf_test, _ = signed_distance_field(
+        torch.from_numpy(vertices_3d),
+        torch.from_numpy(vert_indices),
+        torch.from_numpy(coords.flatten()),
+    )
+    sdf_test = sdf_test.numpy()
     output_filename = tmp_path / "output_stl.stl"
     sdf_to_stl(
         sdf_test.reshape(n[0], n[1], n[2]),


### PR DESCRIPTION
Port SDF function to stream-respecting, torch-only interface with static shapes.

This also enables torch.compile over sdf calls, and I've implemented a distributed interface for the SDF function.  Unfortunately, without more sophisticated planning, the distributed algorithm must realize the mesh on all nodes.  But for very large input point vectors, which is the realistic use case, it should be efficient at scale.

This does not, yet, address the proliferation of other sdf implementation in the examples folders.  I have left them be, 
they aren't hurting anyone ...

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->