### PR TITLE
Change skip_scale to Python float

### DIFF
--- a/physicsnemo/models/diffusion/song_unet.py
+++ b/physicsnemo/models/diffusion/song_unet.py
@@ -312,7 +312,7 @@ class SongUNet(Module):
             emb_channels=emb_channels,
             num_heads=1,
             dropout=dropout,
-            skip_scale=np.sqrt(0.5),
+            skip_scale=0.7071067811865476, # 1 / sqrt(2)
             eps=1e-6,
             resample_filter=resample_filter,
             resample_proj=True,


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Using the PhysicsNeMo 25.08 container with PyTorch 2.8.0, I get the following error trying to use U-Nets with `torch.compile`:
```python
AssertionError: Guard check failed: 1/0: tensor '___from_numpy(self._modules['enc']._modules['256x256_block0'].skip_scale)' dispatch key set mismatch. expected DispatchKeySet(CPU, BackendSelect, ADInplaceOrView), actual DispatchKeySet(CPU, BackendSelect)
```
According to this line https://github.com/NVIDIA/physicsnemo/blob/c4a30b5a486f5e07d47b74e9e021bcf30a8a1575/physicsnemo/models/diffusion/layers.py#L824 the `skip_scale` parameter is supposed to be a `float` but is actually set to a `np.float64` here: https://github.com/NVIDIA/physicsnemo/blob/c4a30b5a486f5e07d47b74e9e021bcf30a8a1575/physicsnemo/models/diffusion/song_unet.py#L315 Somehow, this confuses the compiler in the new version of PyTorch. It works again if I change it to a Python float as in this PR.

I will try make a minimum example later to report the problem to the PyTorch devs as I can't find anything comparable by searching. Meanwhile, I don't see any downside in the proposed change so I think it's safe to make while waiting for a possible fix in PyTorch.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->