### PR TITLE
Add a timestamp to avoid doing a mlflow gc

### DIFF
--- a/physicsnemo/launch/logging/mlflow.py
+++ b/physicsnemo/launch/logging/mlflow.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Literal, Tuple
@@ -182,7 +183,7 @@ def check_mlflow_logged_in(client: MlflowClient):
     try:
         # Adjust http timeout to 5 seconds
         os.environ["MLFLOW_HTTP_REQUEST_TIMEOUT"] = str(max(int(t0), 5)) if t0 else "5"
-        experiment = client.create_experiment("test")
+        experiment = client.create_experiment(f"test-{int(time.time())}")
         client.delete_experiment(experiment)
 
     except Exception as e:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Mlflow's `delete_experiment` only does a soft delete, leaving a `.trash` directory in the `mlruns` folder. This causes issues with new experiments, unless the `.trash` folder is explicitly removed. This adds a timestamp so that we avoid conficts in subsequent runs. 

Internal bug: https://nvbugspro.nvidia.com/bug/5497196

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->