### PR TITLE
Fix test_conv_nd and test_conv_ndfc tests flakiness on Blackwell GPUs

### DIFF
--- a/test/models/test_nd_conv_layers.py
+++ b/test/models/test_nd_conv_layers.py
@@ -232,7 +232,7 @@ def test_conv_nd(device, dimension):
     bsize = 2
     in_channels = 4
     out_channels = 2
-    tens_size = 8
+    tens_size = 128
 
     conv_nd = layers.ConvNdKernel1Layer(in_channels, out_channels).to(device)
 
@@ -272,7 +272,7 @@ def test_conv_ndfc(device, dimension):
     bsize = 2
     in_channels = 4
     out_channels = 2
-    tens_size = 8
+    tens_size = 128
 
     conv_nd = layers.ConvNdFCLayer(in_channels, out_channels).to(device)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
test_conv_nd and test_conv_ndfc tests are flaky on Blackwell GPUs.
Implementing @coreyjadams suggestion:
>  bumping the image size to 512 / 256**2 / 64 **3 to have more data without slowing down the tests substantially.
Verified that this fix works on H100 and B100 GPUs

## Checklist

- [x ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->