### PR TITLE
chore: bump multi-storage-client to v0.33.0 with rust client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support passing custom tokenizer, detokenizer, and attention `Module`s in
   experimental DiT architecture
 - Improved Transolver training recipe's configuration for checkpointing and normalization.
+- Bumped `multi-storage-client` version to 0.33.0 with rust client.
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -213,7 +213,7 @@ RUN pip install --no-cache-dir "black==22.10.0" "interrogate==1.5.0" "coverage==
 RUN pip install --no-cache-dir "numpy-stl" "scikit-image>=0.24.0" "sparse-dot-mkl" "shapely" "numpy<2.0"
 
 # Install MSC
-RUN pip install --no-cache-dir "multi-storage-client[boto3]>=0.14.0"
+RUN pip install --no-cache-dir "multi-storage-client[boto3]>=0.33.0"
 
 # cleanup of stage
 RUN rm -rf /physicsnemo/

--- a/examples/multi_storage_client/msc_config.yaml
+++ b/examples/multi_storage_client/msc_config.yaml
@@ -25,6 +25,8 @@ profiles:
         region_name: us-west-2
         base_path: cmip6-pds
         signature_version: UNSIGNED
+        rust_client:
+          skip_signature: True
 cache:
   location: /tmp/.cache
   size_mb: 5000

--- a/examples/multi_storage_client/requirements.txt
+++ b/examples/multi_storage_client/requirements.txt
@@ -1,1 +1,2 @@
-multi-storage-client[boto3]
+multi-storage-client[boto3,fsspec]
+zarr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ fignet = [
 ]
 
 storage = [
-    "multi-storage-client[boto3]>=0.14.0",
+    "multi-storage-client[boto3]>=0.33.0",
 ]
 
 shardtensor = [


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Upgrade [multi-storage-client](https://pypi.org/project/multi-storage-client/) to latest version 0.33.0

Highlights:
- **Rust client**: Rust bindings provides performance boost comparing to Python SDKs while still providing unified Python interfaces: https://nvidia.github.io/multi-storage-client/user_guide/rust.html
- **Metrics v2**: Enhanced monitoring with granular performance metrics: https://nvidia.github.io/multi-storage-client/user_guide/telemetry.html

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->