### PR TITLE
Docs improvement for `Module.from_checkpoint`

### DIFF
--- a/physicsnemo/models/module.py
+++ b/physicsnemo/models/module.py
@@ -639,8 +639,18 @@ class Module(torch.nn.Module):
             class is known beforehand (say ``MyModuleSubclass``), it is
             recommended to use ``MyModuleSubclass.from_checkpoint`` instead.
             This applies to both models classes included as part of the
-            PhysicsNeMo libraray, as well as user-defined subclasses of
-            ``physicsnemo.Module``.
+            PhysicsNeMo library, as well as user-defined subclasses of
+            ``physicsnemo.Module``. More specifically, the mechanism for inferring
+            the class attempts to, by order of precedence:
+
+                1. Use the qualifier (in the example above,
+                   "MyModuleSubclass") as the class.
+                2. Lookup the class in the model registry
+                   (:class:`~physicsnemo.registry.model_registry.ModelRegistry`).
+                3. Import the class from the module path specified in
+                   the checkpoint file. Note that this will fail if the module
+                   path is modified from the original path (e.g. if the class
+                   definition was moved from one module to another).
 
 
         Examples


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

This PR improves the docstring for the method `Module.from_checkpoint` with added details regarding the mechanism to infer the class, as well as recommended usage.

**Note:** This PR has a companion PR in the documentation repo, and they should be merged together.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->