### PR TITLE
Fix domino data factors logic

### DIFF
--- a/examples/cfd/external_aerodynamics/domino/src/utils.py
+++ b/examples/cfd/external_aerodynamics/domino/src/utils.py
@@ -336,40 +336,58 @@ def load_scaling_factors(
         )
 
     if cfg.model.normalization == "min_max_scaling":
-        vol_factors = np.asarray(
-            [
-                scaling_factors.max_val["volume_fields"],
-                scaling_factors.min_val["volume_fields"],
-            ]
-        )
-        surf_factors = np.asarray(
-            [
-                scaling_factors.max_val["surface_fields"],
-                scaling_factors.min_val["surface_fields"],
-            ]
-        )
+        if cfg.model.model_type == "volume" or cfg.model.model_type == "combined":
+            vol_factors = np.asarray(
+                [
+                    scaling_factors.max_val["volume_fields"],
+                    scaling_factors.min_val["volume_fields"],
+                ]
+            )
+        else:
+            vol_factors = None
+        if cfg.model.model_type == "surface" or cfg.model.model_type == "combined":
+            surf_factors = np.asarray(
+                [
+                    scaling_factors.max_val["surface_fields"],
+                    scaling_factors.min_val["surface_fields"],
+                ]
+            )
+        else:
+            surf_factors = None
     elif cfg.model.normalization == "mean_std_scaling":
-        vol_factors = np.asarray(
-            [
-                scaling_factors.mean["volume_fields"],
-                scaling_factors.std["volume_fields"],
-            ]
-        )
-        surf_factors = np.asarray(
-            [
-                scaling_factors.mean["surface_fields"],
-                scaling_factors.std["surface_fields"],
-            ]
-        )
+        if cfg.model.model_type == "volume" or cfg.model.model_type == "combined":
+            vol_factors = np.asarray(
+                [
+                    scaling_factors.mean["volume_fields"],
+                    scaling_factors.std["volume_fields"],
+                ]
+            )
+        else:
+            vol_factors = None
+        if cfg.model.model_type == "surface" or cfg.model.model_type == "combined":
+            surf_factors = np.asarray(
+                [
+                    scaling_factors.mean["surface_fields"],
+                    scaling_factors.std["surface_fields"],
+                ]
+            )
+        else:
+            surf_factors = None
     else:
         raise ValueError(f"Invalid normalization mode: {cfg.model.normalization}")
 
-    vol_factors_tensor = torch.from_numpy(vol_factors)
-    surf_factors_tensor = torch.from_numpy(surf_factors)
-
     dm = DistributedManager()
-    vol_factors_tensor = vol_factors_tensor.to(dm.device, dtype=torch.float32)
-    surf_factors_tensor = surf_factors_tensor.to(dm.device, dtype=torch.float32)
+
+    if cfg.model.model_type == "volume" or cfg.model.model_type == "combined":
+        vol_factors_tensor = torch.from_numpy(vol_factors)
+        vol_factors_tensor = vol_factors_tensor.to(dm.device, dtype=torch.float32)
+    else:
+        vol_factors_tensor = None
+    if cfg.model.model_type == "surface" or cfg.model.model_type == "combined":
+        surf_factors_tensor = torch.from_numpy(surf_factors)
+        surf_factors_tensor = surf_factors_tensor.to(dm.device, dtype=torch.float32)
+    else:
+        surf_factors_tensor = None
 
     return vol_factors_tensor, surf_factors_tensor
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request
Currently, if you have surface-only or volume-only data, it will fail when loading the scaling factors.

This should nsure training sets factors to none if not used, and doesn't look for them if not needed.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
