### PR TITLE
darcy_transolver: update requirements.txt to include tensorboard

### DIFF
--- a/examples/cfd/darcy_transolver/requirements.txt
+++ b/examples/cfd/darcy_transolver/requirements.txt
@@ -6,3 +6,4 @@ warp-lang>=1.7.0
 termcolor>=2.1.1
 mlflow>=2.1.1
 torchinfo
+tensorboard


### PR DESCRIPTION
Added `tensorboard` to requirements

Needed to run `train_transolver_darcy_fix.py`:

`from torch.utils.tensorboard import SummaryWriter
`