### PR TITLE
Update version specification in require_version_spec function

### DIFF
--- a/physicsnemo/core/version_check.py
+++ b/physicsnemo/core/version_check.py
@@ -98,13 +98,13 @@ def check_version_spec(
     return True
 
 
-def require_version_spec(package_name: str, spec: str = ">=0.0.0"):
+def require_version_spec(package_name: str, spec: str = "0.0.0"):
     """
-    Decorator variant that accepts a full version specifier instead of a single minimum version.
+    Decorator that checks a package version requirement before function execution.
 
     Args:
         package_name: Name of the package to check
-        spec: version specifier (e.g., '2.4') (Not PEP 440 to allow dev versions, etc.)
+        spec: Minimum version required (e.g., '2.4')
 
     Returns:
         Decorator function that checks version requirement before execution

--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -179,7 +179,7 @@ class DistributedManager(object):
         """
 
         # Properties don't mesh with decorators.  So in this function, I call the check manually:
-        check_version_spec("torch", ">=2.4", hard_fail=True)
+        check_version_spec("torch", "2.4", hard_fail=True)
 
         if self._global_mesh is None:
             # Fully flat mesh (1D) by default:
@@ -187,14 +187,14 @@ class DistributedManager(object):
 
         return self._global_mesh
 
-    @require_version_spec("torch", ">=2.4")
+    @require_version_spec("torch", "2.4")
     def mesh_names(self):
         """
         Return mesh axis names
         """
         return self._mesh_dims.keys()
 
-    @require_version_spec("torch", ">=2.4")
+    @require_version_spec("torch", "2.4")
     def mesh_sizes(self):
         """
         Return mesh axis sizes
@@ -214,7 +214,7 @@ class DistributedManager(object):
         else:
             raise PhysicsNeMoUndefinedGroupError(name)
 
-    @require_version_spec("torch", ">=2.4")
+    @require_version_spec("torch", "2.4")
     def mesh(self, name=None):
         """
         Return a device_mesh with the given name.
@@ -434,7 +434,7 @@ class DistributedManager(object):
         # Set per rank numpy random seed for data sampling
         np.random.seed(seed=DistributedManager().rank)
 
-    @require_version_spec("torch", ">=2.4")
+    @require_version_spec("torch", "2.4")
     def initialize_mesh(
         self, mesh_shape: Tuple[int, ...], mesh_dim_names: Tuple[str, ...]
     ) -> "torch.distributed.DeviceMesh":
@@ -521,7 +521,7 @@ class DistributedManager(object):
         return self._global_mesh
 
     # Device mesh available in torch 2.4 or higher
-    @require_version_spec("torch", ">=2.4")
+    @require_version_spec("torch", "2.4")
     def get_mesh_group(self, mesh: "dist.DeviceMesh") -> dist.ProcessGroup:
         """
         Get the process group for a given mesh.


### PR DESCRIPTION
Changed the default version specifier in the require_version_spec function from ">=0.0.0" to "0.0.0" to enforce a minimum version requirement. Updated the function's docstring for clarity on the expected argument format.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [x] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
