### PR TITLE
Exclude 'merge_group' event from CI jobs

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -39,6 +39,7 @@ jobs:
     # This job only runs for pull request comments
     # Comment must be `/blossom-ci`
     if: >
+         github.event_name != 'merge_group' &&
          (github.event.comment.body == '/blossom-ci' || github.event.comment.body == '/multi-gpu-ci') &&
          (
            github.actor == 'nickgeneva' ||
@@ -78,6 +79,7 @@ jobs:
     name: Vulnerability scan
     needs: [Authorization]
     runs-on: vulnerability-scan
+    if: github.event_name != 'merge_group'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -113,6 +115,7 @@ jobs:
     name: Start ci job
     needs: [Vulnerability-scan]
     runs-on: blossom
+    if: github.event_name != 'merge_group'
     steps:
       - name: Start ci job
         run: blossom-ci
@@ -124,7 +127,7 @@ jobs:
   Upload-Log:
     name: Upload log
     runs-on: blossom
-    if : github.event_name == 'workflow_dispatch'
+    if : github.event_name != 'merge_group' && github.event_name == 'workflow_dispatch'
     steps:
       - name: Jenkins log for pull request ${{ fromJson(github.event.inputs.args).pr }} (click here)
         run: blossom-ci


### PR DESCRIPTION
Updated conditions to exclude 'merge_group' event for multiple jobs.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
