### PR TITLE
[IGNORE] Prevent memory explosion during GeoTransolver inference on large meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed memory explosion during GeoTransolver inference on large meshes (2M+ cells).
+  The `broadcast_global_features` is now disabled in the datapipe for VTK inference,
+  with per-sub-batch broadcasting in `batched_inference_loop` to maintain compatibility
+  with models trained with `broadcast_global_features: true`.
+
 ### Security
 
 ### Dependencies

--- a/examples/cfd/external_aerodynamics/transformer_models/src/inference_on_vtk.py
+++ b/examples/cfd/external_aerodynamics/transformer_models/src/inference_on_vtk.py
@@ -261,7 +261,7 @@ def build_data_dict(
     data_dict = {}
 
     # Always read STL geometry (needed for SDF in volume mode, center of mass calculation)
-    stl_path = run_dir / f"drivaer_{run_idx}_single_solid.stl"
+    stl_path = run_dir / f"{run_idx}_surface.stl"
     if stl_path.exists():
         stl_data = read_stl_geometry(str(stl_path), device)
         data_dict.update(stl_data)
@@ -276,7 +276,7 @@ def build_data_dict(
 
     # Read surface data if needed
     if data_mode in ["surface", "combined"]:
-        vtp_path = run_dir / f"boundary_{run_idx}.vtp"
+        vtp_path = run_dir / f"{run_idx}_boundary.vtp"
         if not vtp_path.exists():
             # Try alternative naming
             vtp_files = list(run_dir.glob("boundary_*.vtp"))
@@ -328,6 +328,8 @@ def write_surface_predictions_to_vtk(
     """
     Write surface predictions to a VTP file.
 
+    Supports both pressure-only (out_dim=1) and full predictions (out_dim=4).
+
     Parameters
     ----------
     vtp_path : str
@@ -335,7 +337,9 @@ def write_surface_predictions_to_vtk(
     output_path : str
         Path to write the output VTP file.
     predictions : torch.Tensor
-        Model predictions, shape (num_cells, 4) - [pressure, wss_x, wss_y, wss_z].
+        Model predictions, shape (num_cells, out_dim) where:
+        - out_dim=1: [pressure]
+        - out_dim=4: [pressure, wss_x, wss_y, wss_z]
     air_density : float
         Air density for dimensional scaling.
     stream_velocity : float
@@ -347,18 +351,23 @@ def write_surface_predictions_to_vtk(
     # Convert to numpy
     pred_np = predictions.cpu().numpy()
 
-    # Split into pressure and wall shear stress
-    pred_pressure = pred_np[:, 0]  # Shape: (num_cells,)
-    pred_wss = pred_np[:, 1:4]  # Shape: (num_cells, 3)
+    # Determine output dimension
+    out_dim = pred_np.shape[-1] if pred_np.ndim > 1 else 1
 
     # Scale to physical units
     dynamic_pressure = air_density * stream_velocity**2
-    pred_pressure = pred_pressure * dynamic_pressure
-    pred_wss = pred_wss * dynamic_pressure
 
-    # Add to mesh
-    output_mesh.cell_data["PredictedPressure"] = pred_pressure
-    output_mesh.cell_data["PredictedWallShearStress"] = pred_wss
+    if out_dim == 1:
+        # Pressure-only mode
+        pred_pressure = pred_np.reshape(-1) * dynamic_pressure
+        output_mesh.cell_data["PredictedPressure"] = pred_pressure
+    else:
+        # Full mode with pressure + wall shear stress
+        pred_pressure = pred_np[:, 0] * dynamic_pressure
+        pred_wss = pred_np[:, 1:4] * dynamic_pressure
+
+        output_mesh.cell_data["PredictedPressure"] = pred_pressure
+        output_mesh.cell_data["PredictedWallShearStress"] = pred_wss
 
     # Save
     output_mesh.save(output_path)
@@ -452,7 +461,6 @@ def create_datapipe(
     optional_keys = [
         "include_normals",
         "include_sdf",
-        "broadcast_global_features",
         "include_geometry",
         "geometry_sampling",
         "translational_invariance",
@@ -464,6 +472,12 @@ def create_datapipe(
     for key in optional_keys:
         if cfg.data.get(key, None) is not None:
             overrides[key] = cfg.data[key]
+
+    # IMPORTANT: Always disable broadcast_global_features in the datapipe for inference
+    # on large meshes. The broadcasting will be done per sub-batch in batched_inference_loop
+    # to avoid memory explosion on huge meshes.
+    # This works regardless of how the model was trained (broadcast true or false).
+    overrides["broadcast_global_features"] = False
 
     # Create the datapipe with no resolution limit (we handle batching ourselves)
     datapipe = TransolverDataPipe(
@@ -603,11 +617,9 @@ def inference_on_vtk(cfg: DictConfig) -> None:
 
     # Find all run directories
     if run_indices is not None:
-        run_dirs = [input_dir / f"run_{idx}" for idx in run_indices]
+        run_dirs = [input_dir / f"{idx}" for idx in run_indices]
     else:
-        run_dirs = sorted(
-            [d for d in input_dir.iterdir() if d.is_dir() and d.name.startswith("run_")]
-        )
+        run_dirs = sorted([d for d in input_dir.iterdir() if d.is_dir()])
 
     logger.info(f"Found {len(run_dirs)} run directories to process")
 
@@ -617,7 +629,7 @@ def inference_on_vtk(cfg: DictConfig) -> None:
 
     # Process each run
     for run_dir in this_device_runs:
-        run_idx = int(run_dir.name.split("_")[1])
+        run_idx = int(run_dir.name)
         logger.info(f"Processing run {run_idx}: {run_dir}")
 
         start_time = time.time()
@@ -657,11 +669,11 @@ def inference_on_vtk(cfg: DictConfig) -> None:
             run_output_dir.mkdir(parents=True, exist_ok=True)
 
             if data_mode in ["surface", "combined"]:
-                vtp_path = run_dir / f"boundary_{run_idx}.vtp"
+                vtp_path = run_dir / f"{run_idx}_boundary.vtp"
                 if not vtp_path.exists():
-                    vtp_path = list(run_dir.glob("boundary_*.vtp"))[0]
+                    vtp_path = list(run_dir.glob(f"{run_idx}_boundary.vtp"))[0]
 
-                output_vtp = run_output_dir / f"pred_boundary_{run_idx}.vtp"
+                output_vtp = run_output_dir / f"pred_{run_idx}_boundary.vtp"
                 write_surface_predictions_to_vtk(
                     str(vtp_path),
                     str(output_vtp),

--- a/examples/cfd/external_aerodynamics/transformer_models/src/inference_on_zarr.py
+++ b/examples/cfd/external_aerodynamics/transformer_models/src/inference_on_zarr.py
@@ -145,11 +145,25 @@ def batched_inference_loop(
         local_embeddings = batch["embeddings"][:, index_block]
         local_fields = batch["fields"][:, index_block]
 
-        # fx does not need to be sliced for TransolverX:
+        # Handle fx (global features) based on model type:
         if "geometry" not in batch.keys():
+            # Transolver path - fx is broadcast to all points, slice for sub-batch
             local_fx = batch["fx"][:, index_block]
         else:
-            local_fx = batch["fx"]
+            # GeoTransolver path - broadcast fx to sub-batch size on-demand
+            # (avoids memory explosion on large meshes by not pre-broadcasting to full mesh)
+            sub_batch_size = index_block.shape[0]
+            fx = batch["fx"]
+
+            # Normalize to 3D (B, tokens, features) - datapipe may add extra dims
+            while fx.ndim > 3:
+                fx = fx.squeeze(1)
+
+            # Broadcast single-token fx, or slice full-mesh fx
+            if fx.shape[1] == 1:
+                local_fx = fx.expand(-1, sub_batch_size, -1)
+            else:
+                local_fx = fx[:, index_block]
 
         local_batch = {
             "fx": local_fx,
@@ -340,55 +354,10 @@ def inference(cfg: DictConfig) -> None:
             metrics = metrics_fn_surface(
                 global_predictions, global_targets, dist_manager
             )
-            # Compute the drag and loss coefficients:
-            # (Index on [0] is to remove the 1 batch index)
-            pred_pressure, pred_shear = torch.split(
-                global_predictions[0], (1, 3), dim=-1
-            )
 
-            pred_pressure = pred_pressure.reshape(-1)
-            pred_drag_coeff, _, _ = compute_force_coefficients(
-                batch["surface_normals"][0],
-                batch["surface_areas"],
-                coeff,
-                pred_pressure,
-                pred_shear,
-                torch.tensor([[1, 0, 0]], device=dist_manager.device),
-            )
-
-            pred_lift_coeff, _, _ = compute_force_coefficients(
-                batch["surface_normals"][0],
-                batch["surface_areas"],
-                coeff,
-                pred_pressure,
-                pred_shear,
-                torch.tensor([[0, 0, 1]], device=dist_manager.device),
-            )
-
-            # true_fields = val_dataset.unscale_model_targets(batch["fields"], air_density=air_density, stream_velocity=stream_velocity)
-            true_pressure, true_shear = torch.split(global_targets[0], (1, 3), dim=-1)
-
-            true_pressure = true_pressure.reshape(-1)
-            true_drag_coeff, _, _ = compute_force_coefficients(
-                batch["surface_normals"][0],
-                batch["surface_areas"],
-                coeff,
-                true_pressure,
-                true_shear,
-                torch.tensor([[1, 0, 0]], device=dist_manager.device),
-            )
-
-            true_lift_coeff, _, _ = compute_force_coefficients(
-                batch["surface_normals"][0],
-                batch["surface_areas"],
-                coeff,
-                true_pressure,
-                true_shear,
-                torch.tensor([[0, 0, 1]], device=dist_manager.device),
-            )
-
-            pred_lift_coeff = pred_lift_coeff.item()
-            pred_drag_coeff = pred_drag_coeff.item()
+            # Determine output dimension for handling pressure-only vs full predictions
+            out_dim = global_predictions.shape[-1]
+            has_shear = out_dim >= 4
 
             # Extract metric values and convert tensors to floats
             l2_pressure = (
@@ -406,39 +375,104 @@ def inference(cfg: DictConfig) -> None:
                 if hasattr(metrics["mae_pressure_surf"], "item")
                 else metrics["mae_pressure_surf"]
             )
-            l2_wall_shear_stress = (
-                metrics["l2_wall_shear_stress"].item()
-                if hasattr(metrics["l2_wall_shear_stress"], "item")
-                else metrics["l2_wall_shear_stress"]
-            )
-            l1_wall_shear_stress = (
-                metrics["l1_wall_shear_stress"].item()
-                if hasattr(metrics["l1_wall_shear_stress"], "item")
-                else metrics["l1_wall_shear_stress"]
-            )
-            mae_wall_shear_stress = (
-                metrics["mae_wall_shear_stress"].item()
-                if hasattr(metrics["mae_wall_shear_stress"], "item")
-                else metrics["mae_wall_shear_stress"]
-            )
 
-            results.append(
-                [
-                    batch_idx,
-                    f"{loss:.4f}",
-                    f"{l2_pressure:.4f}",
-                    f"{l1_pressure:.4f}",
-                    f"{mae_pressure:.4f}",
-                    f"{l2_wall_shear_stress:.4f}",
-                    f"{l1_wall_shear_stress:.4f}",
-                    f"{mae_wall_shear_stress:.4f}",
-                    f"{pred_drag_coeff:.4f}",
-                    f"{pred_lift_coeff:.4f}",
-                    f"{true_drag_coeff:.4f}",
-                    f"{true_lift_coeff:.4f}",
-                    f"{elapsed:.4f}",
-                ]
-            )
+            if has_shear:
+                # Compute the drag and lift coefficients when we have pressure + wall shear stress
+                # (Index on [0] is to remove the 1 batch index)
+                pred_pressure, pred_shear = torch.split(
+                    global_predictions[0], (1, 3), dim=-1
+                )
+
+                pred_pressure = pred_pressure.reshape(-1)
+                pred_drag_coeff, _, _ = compute_force_coefficients(
+                    batch["surface_normals"][0],
+                    batch["surface_areas"],
+                    coeff,
+                    pred_pressure,
+                    pred_shear,
+                    torch.tensor([[1, 0, 0]], device=dist_manager.device),
+                )
+
+                pred_lift_coeff, _, _ = compute_force_coefficients(
+                    batch["surface_normals"][0],
+                    batch["surface_areas"],
+                    coeff,
+                    pred_pressure,
+                    pred_shear,
+                    torch.tensor([[0, 0, 1]], device=dist_manager.device),
+                )
+
+                true_pressure, true_shear = torch.split(
+                    global_targets[0], (1, 3), dim=-1
+                )
+
+                true_pressure = true_pressure.reshape(-1)
+                true_drag_coeff, _, _ = compute_force_coefficients(
+                    batch["surface_normals"][0],
+                    batch["surface_areas"],
+                    coeff,
+                    true_pressure,
+                    true_shear,
+                    torch.tensor([[1, 0, 0]], device=dist_manager.device),
+                )
+
+                true_lift_coeff, _, _ = compute_force_coefficients(
+                    batch["surface_normals"][0],
+                    batch["surface_areas"],
+                    coeff,
+                    true_pressure,
+                    true_shear,
+                    torch.tensor([[0, 0, 1]], device=dist_manager.device),
+                )
+
+                pred_lift_coeff = pred_lift_coeff.item()
+                pred_drag_coeff = pred_drag_coeff.item()
+
+                l2_wall_shear_stress = (
+                    metrics["l2_wall_shear_stress"].item()
+                    if hasattr(metrics["l2_wall_shear_stress"], "item")
+                    else metrics["l2_wall_shear_stress"]
+                )
+                l1_wall_shear_stress = (
+                    metrics["l1_wall_shear_stress"].item()
+                    if hasattr(metrics["l1_wall_shear_stress"], "item")
+                    else metrics["l1_wall_shear_stress"]
+                )
+                mae_wall_shear_stress = (
+                    metrics["mae_wall_shear_stress"].item()
+                    if hasattr(metrics["mae_wall_shear_stress"], "item")
+                    else metrics["mae_wall_shear_stress"]
+                )
+
+                results.append(
+                    [
+                        batch_idx,
+                        f"{loss:.4f}",
+                        f"{l2_pressure:.4f}",
+                        f"{l1_pressure:.4f}",
+                        f"{mae_pressure:.4f}",
+                        f"{l2_wall_shear_stress:.4f}",
+                        f"{l1_wall_shear_stress:.4f}",
+                        f"{mae_wall_shear_stress:.4f}",
+                        f"{pred_drag_coeff:.4f}",
+                        f"{pred_lift_coeff:.4f}",
+                        f"{true_drag_coeff:.4f}",
+                        f"{true_lift_coeff:.4f}",
+                        f"{elapsed:.4f}",
+                    ]
+                )
+            else:
+                # Pressure-only mode (out_dim=1)
+                results.append(
+                    [
+                        batch_idx,
+                        f"{loss:.4f}",
+                        f"{l2_pressure:.4f}",
+                        f"{l1_pressure:.4f}",
+                        f"{mae_pressure:.4f}",
+                        f"{elapsed:.4f}",
+                    ]
+                )
 
         elif cfg.data.mode == "volume":
             if stream_velocity is not None:
@@ -528,35 +562,57 @@ def inference(cfg: DictConfig) -> None:
             )
 
     if cfg.data.mode == "surface":
-        pred_drag_coeffs = [r[8] for r in results]
-        pred_lift_coeffs = [r[9] for r in results]
-        true_drag_coeffs = [r[10] for r in results]
-        true_lift_coeffs = [r[11] for r in results]
+        # Determine if we have shear data based on results row length
+        # Full results: 13 columns, Pressure-only: 6 columns
+        has_shear_results = len(results[0]) > 6 if results else False
 
-        # Compute the R2 scores for lift and drag:
-        r2_lift = r2_score(true_lift_coeffs, pred_lift_coeffs)
-        r2_drag = r2_score(true_drag_coeffs, pred_drag_coeffs)
+        if has_shear_results:
+            pred_drag_coeffs = [r[8] for r in results]
+            pred_lift_coeffs = [r[9] for r in results]
+            true_drag_coeffs = [r[10] for r in results]
+            true_lift_coeffs = [r[11] for r in results]
 
-        headers = [
-            "Batch",
-            "Loss",
-            "L2 Pressure",
-            "L1 Pressure",
-            "MAE Pressure",
-            "L2 Wall Shear Stress",
-            "L1 Wall Shear Stress",
-            "MAE Wall Shear Stress",
-            "Predicted Drag Coefficient",
-            "Pred Lift Coefficient",
-            "True Drag Coefficient",
-            "True Lift Coefficient",
-            "Elapsed (s)",
-        ]
-        logger.info(
-            f"Results:\n{tabulate(results, headers=headers, tablefmt='github')}"
-        )
-        logger.info(f"R2 score for lift: {r2_lift:.4f}")
-        logger.info(f"R2 score for drag: {r2_drag:.4f}")
+            # Compute the R2 scores for lift and drag:
+            r2_lift = r2_score(true_lift_coeffs, pred_lift_coeffs)
+            r2_drag = r2_score(true_drag_coeffs, pred_drag_coeffs)
+
+            headers = [
+                "Batch",
+                "Loss",
+                "L2 Pressure",
+                "L1 Pressure",
+                "MAE Pressure",
+                "L2 Wall Shear Stress",
+                "L1 Wall Shear Stress",
+                "MAE Wall Shear Stress",
+                "Predicted Drag Coefficient",
+                "Pred Lift Coefficient",
+                "True Drag Coefficient",
+                "True Lift Coefficient",
+                "Elapsed (s)",
+            ]
+            logger.info(
+                f"Results:\n{tabulate(results, headers=headers, tablefmt='github')}"
+            )
+            logger.info(f"R2 score for lift: {r2_lift:.4f}")
+            logger.info(f"R2 score for drag: {r2_drag:.4f}")
+        else:
+            # Pressure-only mode
+            headers = [
+                "Batch",
+                "Loss",
+                "L2 Pressure",
+                "L1 Pressure",
+                "MAE Pressure",
+                "Elapsed (s)",
+            ]
+            logger.info(
+                f"Results:\n{tabulate(results, headers=headers, tablefmt='github')}"
+            )
+            logger.info(
+                "Note: Pressure-only mode (out_dim=1) - no wall shear stress or force coefficients computed"
+            )
+
         csv_filename = f"{cfg.output_dir}/{cfg.run_id}/surface_inference_results_{datetime.now()}.csv"
         with open(csv_filename, "w", newline="") as f:
             writer = csv.writer(f)


### PR DESCRIPTION
…er sub batch

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

This PR fixes an out-of-memory (OOM) issue when running GeoTransolver inference on large meshes (10M+ cells) that was causing the process to be killed.

During inference on full car meshes, the broadcast_global_features: true setting caused fx (global features: air density, stream velocity) to be replicated to every mesh point before sub-batching.

This, combined with downstream processing in the ContextProjector, exceeded GPU memory before even the first forward pass.

The GeoTransolver model uses a global_tokenizer (ContextProjector) that processes the global features through linear projections and multi-head attention. When fx is broadcast to 2M+ tokens upfront, the intermediate activations and attention computations scale linearly with mesh size, causing OOM.

Solution:

inference_on_vtk.py: Force broadcast_global_features: false in the datapipe for inference, regardless of the training config. This keeps fx as a single token (B, 1, 2).

inference_on_zarr.py: Modified batched_inference_loop to broadcast fx per sub-batch dynamically:
If fx is single-token → expand to match sub-batch size
If fx is full-mesh (legacy path) → slice for sub-batch

Why This Doesn't Affect Inference Quality?
Since all tokens in broadcast fx have identical values, the aggregation result is mathematically equivalent. The model sees the same sub-batch size it was trained on, just processed sequentially instead of all at once.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [X] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

None

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
