### PR TITLE
Fix inverted path traversal logic and enhance torch.load security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Fixes a critical logic inversion in path traversal protection during checkpoint extraction.
+- Enables `weights_only=True` in `torch.load` calls for enhanced security when loading model weights. Note: This may be a breaking change for legacy checkpoints containing custom Python objects not in the allowed list.
+
 ### Dependencies
 
 - Updates the minimum supported `warp-lang` version to 1.14.0.

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -259,17 +259,21 @@ class Module(torch.nn.Module):
 
     @staticmethod
     def _safe_members(tar, local_path):
+        resolved_local_path = os.path.join(os.path.realpath(local_path), "")
         for member in tar.getmembers():
             if (
                 ".." in member.name
                 or os.path.isabs(member.name)
-                or os.path.realpath(os.path.join(local_path, member.name)).startswith(
-                    os.path.realpath(local_path)
+                or not os.path.realpath(os.path.join(local_path, member.name)).startswith(
+                    resolved_local_path
                 )
+                and os.path.realpath(os.path.join(local_path, member.name)) != resolved_local_path
             ):
-                yield member
+                logging.getLogger("core.module").warning(
+                    f"Skipping potentially malicious file: {member.name}"
+                )
             else:
-                print(f"Skipping potentially malicious file: {member.name}")
+                yield member
 
     @classmethod
     def _backward_compat_arg_mapper(
@@ -756,7 +760,9 @@ class Module(torch.nn.Module):
                 model_bytes = archive.read("model.pt")
 
             # Load state dict after closing archive
-            model_dict = torch.load(io.BytesIO(model_bytes), map_location=device)
+            model_dict = torch.load(
+                io.BytesIO(model_bytes), map_location=device, weights_only=True
+            )
 
             # Load state_dict into the model
             _load_state_dict_with_logging(self, model_dict, strict=strict)
@@ -782,7 +788,9 @@ class Module(torch.nn.Module):
 
                 # Load the model weights
                 model_dict = torch.load(
-                    local_path.joinpath("model.pt"), map_location=device
+                    local_path.joinpath("model.pt"),
+                    map_location=device,
+                    weights_only=True,
                 )
 
             # Load state dict into the model
@@ -1063,7 +1071,9 @@ class Module(torch.nn.Module):
                 model_bytes = archive.read("model.pt")
 
             # Load state dict after closing archive
-            model_dict = torch.load(io.BytesIO(model_bytes), map_location=model.device)
+            model_dict = torch.load(
+                io.BytesIO(model_bytes), map_location=model.device, weights_only=True
+            )
 
             # Load state_dict into the model
             _load_state_dict_with_logging(model, model_dict, strict=strict)
@@ -1105,7 +1115,9 @@ class Module(torch.nn.Module):
 
                 # Load the model weights
                 model_dict = torch.load(
-                    local_path.joinpath("model.pt"), map_location=model.device
+                    local_path.joinpath("model.pt"),
+                    map_location=model.device,
+                    weights_only=True,
                 )
 
             # Load state_dict into the model


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description
A critical logic error in `_safe_members` was identified where the path traversal protection was inverted, allowing unsafe members while blocking legitimate ones. This fix correctly yields only safe members during tarball extraction.

Security of model loading is also improved by enabling `weights_only=True` in all core `torch.load` calls. This mitigates the risk of arbitrary code execution from malicious pickles in model checkpoints.

## Checklist

- [x] Familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] Verified logic correctness with local PoC for path traversal.
- [ ] Documentation updated.
- [x] CHANGELOG.md updated.
- [ ] Issue linked.

## Dependencies
None.