### PR TITLE
Mesh Docs Improvements (caching, dimension-parameterized types)

### DIFF
--- a/physicsnemo/mesh/README.md
+++ b/physicsnemo/mesh/README.md
@@ -450,8 +450,25 @@ Mesh(
 ```
 
 All data moves together with `.to("cuda")` or `.to("cpu")`. Expensive computations
-(centroids, normals, curvature) are automatically cached in the data dictionaries with
-keys starting with `_`.
+(centroids, normals, curvature) are lazily cached in a dedicated `_cache` TensorDict,
+separate from `point_data` / `cell_data` so user data is never mixed with internal
+cached geometry.
+
+### Dimension-Parametrized Types
+
+`Mesh` supports subscript notation `Mesh[manifold_dims, spatial_dims]` for type
+annotations and runtime `isinstance` checks:
+
+```python
+def compute_normals(mesh: Mesh[2, 3]) -> torch.Tensor:
+    ...  # accepts only triangle meshes in 3D
+
+isinstance(mesh, Mesh[2, 3])    # True for triangles in 3D
+isinstance(mesh, Mesh[1, ...])  # True for any edge mesh
+Mesh[2, 3].boundary             # -> Mesh[1, 3]
+```
+
+Use `...` (Ellipsis) to leave a dimension unconstrained.
 
 ---
 

--- a/physicsnemo/mesh/README.md
+++ b/physicsnemo/mesh/README.md
@@ -173,7 +173,7 @@ pv_mesh = pv.examples.load_airplane()  # See pyvista.org for more datasets
 mesh = from_pyvista(pv_mesh)
 
 # Or, equivalently:
-from physicsnemo.mesh.examples.pyvista_datasets.airplane import load
+from physicsnemo.mesh.primitives.pyvista_datasets.airplane import load
 mesh = load()
 
 print(mesh)

--- a/physicsnemo/mesh/domain_mesh.py
+++ b/physicsnemo/mesh/domain_mesh.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from collections.abc import Callable, Iterator
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self
 
 import torch
@@ -242,7 +243,7 @@ class DomainMesh:
 
         def save(
             self,
-            prefix: str | None = None,
+            prefix: str | Path | None = None,
             copy_existing: bool = False,
             *,
             num_threads: int = 0,
@@ -257,7 +258,7 @@ class DomainMesh:
 
             Parameters
             ----------
-            prefix : str or None
+            prefix : str, Path, or None
                 Directory path where the memory-mapped files will be
                 written.  If ``None``, a temporary directory is used.
             copy_existing : bool
@@ -286,7 +287,7 @@ class DomainMesh:
         @classmethod
         def load(
             cls,
-            prefix: str,
+            prefix: str | Path,
             device: torch.device | None = None,
             non_blocking: bool = False,
         ) -> Self:
@@ -300,9 +301,8 @@ class DomainMesh:
 
             Parameters
             ----------
-            prefix : str
+            prefix : str or Path
                 Path to the directory created by :meth:`save`.
-                ``pathlib.Path`` objects are also accepted at runtime.
             device : torch.device or None
                 If provided, move all tensors to this device after
                 loading.

--- a/physicsnemo/mesh/domain_mesh.py
+++ b/physicsnemo/mesh/domain_mesh.py
@@ -256,6 +256,11 @@ class DomainMesh:
             to a directory tree of ``.memmap`` files.  Proxy for the
             tensorclass ``memmap()`` method.
 
+            This is the recommended serialization method. Compared to
+            ``torch.save`` (pickle-based), memmap serialization is
+            faster (parallel I/O across files), safer (no arbitrary code
+            execution on load), and supports partial loading.
+
             Parameters
             ----------
             prefix : str, Path, or None

--- a/physicsnemo/mesh/domain_mesh.py
+++ b/physicsnemo/mesh/domain_mesh.py
@@ -233,10 +233,90 @@ class DomainMesh:
             ...
 
         def clone(self) -> Self:
-            """Return a shallow clone of this DomainMesh.
+            """Return a deep clone of this DomainMesh.
 
-            All tensor storage is shared with the original; metadata and
-            TensorDict structure are independent copies.
+            All tensors are copied (independent storage); the clone can
+            be modified without affecting the original.
+            """
+            ...
+
+        def save(
+            self,
+            prefix: str | None = None,
+            copy_existing: bool = False,
+            *,
+            num_threads: int = 0,
+            return_early: bool = False,
+            share_non_tensor: bool = False,
+        ) -> Self:
+            """Save the domain mesh to disk as memory-mapped tensors.
+
+            Writes ``interior``, all ``boundaries``, and ``global_data``
+            to a directory tree of ``.memmap`` files.  Proxy for the
+            tensorclass ``memmap()`` method.
+
+            Parameters
+            ----------
+            prefix : str or None
+                Directory path where the memory-mapped files will be
+                written.  If ``None``, a temporary directory is used.
+            copy_existing : bool
+                If ``True``, copy tensors that are already memory-mapped
+                to the new location.
+            num_threads : int
+                Number of threads for parallel I/O (0 = sequential).
+            return_early : bool
+                If ``True``, return before all data is flushed to disk.
+            share_non_tensor : bool
+                If ``True``, share non-tensor data across processes.
+
+            Returns
+            -------
+            DomainMesh
+                A new DomainMesh backed by the on-disk memory-mapped
+                storage.
+
+            Examples
+            --------
+            >>> dm.save("/path/to/domain_mesh")  # doctest: +SKIP
+            >>> reloaded = DomainMesh.load("/path/to/domain_mesh")  # doctest: +SKIP
+            """
+            ...
+
+        @classmethod
+        def load(
+            cls,
+            prefix: str,
+            device: torch.device | None = None,
+            non_blocking: bool = False,
+        ) -> Self:
+            """Load a previously saved domain mesh from disk.
+
+            Reads a directory tree of memory-mapped tensors written by
+            :meth:`save` and reconstructs the ``DomainMesh`` instance,
+            including the ``interior`` mesh, all ``boundaries``, and
+            ``global_data``.  Proxy for the tensorclass
+            ``load_memmap()`` class method.
+
+            Parameters
+            ----------
+            prefix : str
+                Path to the directory created by :meth:`save`.
+                ``pathlib.Path`` objects are also accepted at runtime.
+            device : torch.device or None
+                If provided, move all tensors to this device after
+                loading.
+            non_blocking : bool
+                Whether device transfers should be non-blocking.
+
+            Returns
+            -------
+            DomainMesh
+                The reconstructed DomainMesh instance.
+
+            Examples
+            --------
+            >>> dm = DomainMesh.load("/path/to/domain_mesh")  # doctest: +SKIP
             """
             ...
 

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -493,6 +493,87 @@ class Mesh:
             """
             ...
 
+        def save(
+            self,
+            prefix: str | None = None,
+            copy_existing: bool = False,
+            *,
+            num_threads: int = 0,
+            return_early: bool = False,
+            share_non_tensor: bool = False,
+        ) -> Self:
+            """Save the mesh to disk as memory-mapped tensors.
+
+            Writes ``points``, ``cells``, ``point_data``, ``cell_data``,
+            ``global_data``, and ``_cache`` to a directory tree of
+            ``.memmap`` files.  Proxy for the tensorclass ``memmap()``
+            method.
+
+            Parameters
+            ----------
+            prefix : str or None
+                Directory path where the memory-mapped files will be
+                written.  If ``None``, a temporary directory is used.
+            copy_existing : bool
+                If ``True``, copy tensors that are already memory-mapped
+                to the new location.
+            num_threads : int
+                Number of threads for parallel I/O (0 = sequential).
+            return_early : bool
+                If ``True``, return before all data is flushed to disk.
+            share_non_tensor : bool
+                If ``True``, share non-tensor data across processes.
+
+            Returns
+            -------
+            Mesh
+                A new Mesh backed by the on-disk memory-mapped storage.
+
+            Examples
+            --------
+            >>> mesh.save("/path/to/mesh")  # doctest: +SKIP
+            >>> reloaded = Mesh.load("/path/to/mesh")  # doctest: +SKIP
+            """
+            ...
+
+        @classmethod
+        def load(
+            cls,
+            prefix: str,
+            device: torch.device | None = None,
+            non_blocking: bool = False,
+        ) -> Self:
+            """Load a previously saved mesh from disk.
+
+            Reads a directory tree of memory-mapped tensors written by
+            :meth:`save` and reconstructs the ``Mesh`` instance,
+            including all attached ``point_data``, ``cell_data``, and
+            ``global_data``.  Proxy for the tensorclass
+            ``load_memmap()`` class method.
+
+            Parameters
+            ----------
+            prefix : str
+                Path to the directory created by :meth:`save`.
+                ``pathlib.Path`` objects are also accepted at runtime.
+            device : torch.device or None
+                If provided, move all tensors to this device after
+                loading.
+            non_blocking : bool
+                Whether device transfers should be non-blocking.
+
+            Returns
+            -------
+            Mesh
+                The reconstructed Mesh instance.
+
+            Examples
+            --------
+            >>> mesh = Mesh.load("/path/to/mesh")  # doctest: +SKIP
+            >>> mesh_gpu = Mesh.load("/path/to/mesh", device="cuda")  # doctest: +SKIP
+            """
+            ...
+
     @property
     def n_points(self) -> int:
         return self.points.shape[0]

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -84,6 +84,25 @@ class Mesh:
     - Codimension 0 (triangles in 2D, tets in 3D): no normal direction exists
     - Codimension > 1 (edges in 3D): infinitely many normal directions
 
+    **Dimension-Parametrized Types**
+
+    ``Mesh`` supports subscript notation ``Mesh[manifold_dims, spatial_dims]``
+    for type annotations and runtime ``isinstance`` checks::
+
+        def compute_normals(mesh: Mesh[2, 3]) -> torch.Tensor:
+            ...  # accepts only triangle meshes in 3D
+
+        isinstance(mesh, Mesh[2, 3])   # True for triangles in 3D
+        isinstance(mesh, Mesh[1, ...]) # True for any edge mesh
+
+    Use ``...`` (Ellipsis) to leave a dimension unconstrained. The notation
+    also supports ``.boundary`` to derive the boundary type::
+
+        Mesh[2, 3].boundary  # -> Mesh[1, 3]
+
+    See :meth:`__class_getitem__` for the full specification, including
+    symbolic dimension expressions like ``Mesh["n-1", "n"]``.
+
     **Core Data Structure**
 
     A mesh is defined by two tensors:
@@ -196,18 +215,54 @@ class Mesh:
     - **Hexahedra** → split into 5 or 6 tetrahedra each
     - **Polygons/polyhedra** → triangulate/tetrahedralize
 
+    **Immutability**
+
+    ``Mesh`` operations return new instances rather than modifying in place.
+    For example, ``mesh.translate(offset)`` returns a new ``Mesh`` with
+    translated points -- the original ``mesh`` is unchanged. This design
+    enables safe caching of derived geometry (centroids, normals, curvature):
+    cached values remain valid because the underlying ``points`` and ``cells``
+    never change after construction.
+
+    .. important::
+
+       In-place modification of ``points`` or ``cells`` (e.g.,
+       ``mesh.points[0] = ...``) is unsupported and will **silently
+       invalidate** all cached properties. Always construct a new ``Mesh``
+       instead.
+
     **Caching**
 
-    Expensive geometric computations (centroids, areas, normals, etc.) are
-    cached in the ``_cache`` field - a nested TensorDict with ``"cell"`` and
-    ``"point"`` sub-TensorDicts. Access cached values via nested keys::
+    Expensive geometric computations (centroids, areas, normals, curvature,
+    adjacency) are cached in the ``_cache`` field -- a nested ``TensorDict``
+    with ``"cell"``, ``"point"``, and ``"topology"`` sub-dicts. The cache is
+    separate from ``point_data`` / ``cell_data``, so user data is never mixed
+    with internal cached geometry.
+
+    Caches are populated lazily on first access (e.g., the first call to
+    ``mesh.cell_normals`` computes and caches the result; subsequent calls
+    return the cached value). Because ``Mesh`` is effectively immutable (see
+    above), cached values never go stale -- they remain valid for the
+    lifetime of the ``Mesh`` instance.
+
+    Geometric transforms (``translate``, ``rotate``, ``scale``, ``transform``)
+    carry forward applicable cache entries to the new ``Mesh`` rather than
+    discarding them. Topology caches are always preserved (transforms do not
+    change connectivity). Geometric caches (areas, normals, centroids) are
+    re-derived from the transform matrix where possible, avoiding
+    recomputation from raw vertex data.
+
+    Slicing operations (``slice_cells``, ``slice_points``) produce new
+    ``Mesh`` instances with topology caches cleared (since connectivity has
+    changed) but cell-level geometric caches sliced in lockstep.
+
+    Access cached values directly via nested keys::
 
         mesh._cache["cell", "centroids"]   # shape (n_cells, n_dims)
         mesh._cache["point", "normals"]    # shape (n_points, n_dims)
 
-    The cache is separate from ``cell_data`` / ``point_data``, so user data
-    is never mixed with internal cached geometry. To clear all caches,
-    construct a new Mesh without passing ``_cache`` (it defaults to empty).
+    Prefer using properties (``mesh.cell_centroids``, ``mesh.point_normals``)
+    over direct ``_cache`` access.
     """
 
     points: torch.Tensor  # shape: (n_points, n_spatial_dimensions)
@@ -431,10 +486,10 @@ class Mesh:
             ...
 
         def clone(self) -> Self:
-            """Return a shallow clone of this Mesh.
+            """Return a deep clone of this Mesh.
 
-            All tensor storage is shared with the original; metadata and
-            TensorDict structure are independent copies.
+            All tensors are copied (independent storage); the clone can
+            be modified without affecting the original.
             """
             ...
 

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -510,6 +510,11 @@ class Mesh:
             ``.memmap`` files.  Proxy for the tensorclass ``memmap()``
             method.
 
+            This is the recommended serialization method. Compared to
+            ``torch.save`` (pickle-based), memmap serialization is
+            faster (parallel I/O across files), safer (no arbitrary code
+            execution on load), and supports partial loading.
+
             Parameters
             ----------
             prefix : str, Path, or None

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -16,6 +16,7 @@
 
 import math
 import types
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, Sequence
 
 import torch
@@ -495,7 +496,7 @@ class Mesh:
 
         def save(
             self,
-            prefix: str | None = None,
+            prefix: str | Path | None = None,
             copy_existing: bool = False,
             *,
             num_threads: int = 0,
@@ -511,7 +512,7 @@ class Mesh:
 
             Parameters
             ----------
-            prefix : str or None
+            prefix : str, Path, or None
                 Directory path where the memory-mapped files will be
                 written.  If ``None``, a temporary directory is used.
             copy_existing : bool
@@ -539,7 +540,7 @@ class Mesh:
         @classmethod
         def load(
             cls,
-            prefix: str,
+            prefix: str | Path,
             device: torch.device | None = None,
             non_blocking: bool = False,
         ) -> Self:
@@ -553,9 +554,8 @@ class Mesh:
 
             Parameters
             ----------
-            prefix : str
+            prefix : str or Path
                 Path to the directory created by :meth:`save`.
-                ``pathlib.Path`` objects are also accepted at runtime.
             device : torch.device or None
                 If provided, move all tensors to this device after
                 loading.


### PR DESCRIPTION

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

- Enhance Mesh class documentation with dimension-parametrized types and immutability details
- Added support for subscript notation in type annotations for `Mesh`, allowing for clearer type checks and boundary type derivation.
- Documented the immutability of `Mesh` operations, emphasizing that they return new instances and the importance of avoiding in-place modifications.
- Updated caching mechanism details to clarify lazy population and separation from user data, ensuring cached values remain valid throughout the `Mesh` instance's lifetime.
- Improved clarity in the README regarding caching and dimension-parameterized types.


## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
