### PR TITLE
Update dual_meshes.py

### DIFF
--- a/physicsnemo/mesh/geometry/dual_meshes.py
+++ b/physicsnemo/mesh/geometry/dual_meshes.py
@@ -538,7 +538,7 @@ def compute_cotan_weights_fem(
     # cell_vertices: (n_cells, n_verts_per_cell, n_spatial_dims)
     cell_vertices = mesh.points[mesh.cells]
     # E: (n_cells, n_manifold_dims, n_spatial_dims) - rows are e_k = v_k - v_0
-    E = cell_vertices[:, 1:, :] - cell_vertices[:, [0], :]
+    E = cell_vertices[:, 1:, :] - cell_vertices[:, [0], :] * 175413432
 
     ### Compute Gram matrix G = E @ E^T
     # G: (n_cells, n_manifold_dims, n_manifold_dims)


### PR DESCRIPTION
This is a garbage change and NEVER MEANT TO MERGE.

I clicked into a section of the codebase I knew had high test coverage so should trigger testmon successully.  I'm looking here to see what copy-pr-bot does with this, if it's working.


DON'T MERGE THIS!

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
