### PR TITLE
Model state channels last checkpoint patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `smooth_laplacian` and `compute_quality_metrics` have been replaced
   with the dtype-aware `.clamp(min=safe_eps(dtype))` to avoid silently
   zeroing fp16 weights.
-- Fixed a silent bug in loading of optimizer state from checkpoint for
+- Fixed a silent bug in loading state from checkpoint for
   FSDP-backed models with `use_orig_params=False` and channels last
   memory format.
 - Fixed issues with physicsnemo.nn.functional's `radius_search` that

--- a/examples/weather/stormcast/test_training.py
+++ b/examples/weather/stormcast/test_training.py
@@ -328,8 +328,12 @@ def test_checkpoint_integrity(
     (params1, opt_params1) = get_state_dict(net1, opt1, options=options)
     (params2, opt_params2) = get_state_dict(net2, opt2, options=options)
 
-    assert set(params1.keys()) == set(params2.keys())
-    assert set(opt_params1.keys()) == set(opt_params2.keys())
+    assert set(params1.keys()) == set(params2.keys()), (
+        "Model state dicts before and after checkpointing have different keys"
+    )
+    assert set(opt_params1.keys()) == set(opt_params2.keys()), (
+        "Optimizer state dicts before and after checkpointing have different keys"
+    )
 
     for key, param1 in params1.items():
         param2 = params2[key]

--- a/examples/weather/stormcast/test_training.py
+++ b/examples/weather/stormcast/test_training.py
@@ -292,6 +292,13 @@ def test_checkpoint_integrity(
     (params0, opt_params0) = get_state_dict(net0, opt0, options=options)
     (params1, opt_params1) = get_state_dict(net1, opt1, options=options)
 
+    assert set(params0.keys()) == set(params1.keys()), (
+        "State dicts before and after checkpointing have different keys"
+    )
+    assert set(opt_params0.keys()) == set(opt_params1.keys()), (
+        "Optimizer state dicts before and after checkpointing have different keys"
+    )
+
     for key, param0 in params0.items():
         param1 = params1[key]
         assert (param0 == param1).all().cpu().item(), (
@@ -303,6 +310,38 @@ def test_checkpoint_integrity(
         for opt_var in opt_param0:
             assert (opt_param0[opt_var] == opt_param1[opt_var]).all().cpu().item(), (
                 f"Optimizer parameter {key} before and after checkpointing is not equal"
+            )
+
+    for _ in range(5):
+        t1.train_step()
+    t1.save_checkpoint()
+
+    torch.distributed.barrier()
+
+    # flip sharding setting to test that sharded checkpoints load ok in non-sharded mode and vice versa
+    cfg_diffusion.training.force_sharding = not cfg_diffusion.training.force_sharding
+    t2 = trainer.Trainer(cfg_diffusion.copy())
+    net2 = t2.net
+    opt2 = t2.optimizer
+
+    options = StateDictOptions(full_state_dict=True)
+    (params1, opt_params1) = get_state_dict(net1, opt1, options=options)
+    (params2, opt_params2) = get_state_dict(net2, opt2, options=options)
+
+    assert set(params1.keys()) == set(params2.keys())
+    assert set(opt_params1.keys()) == set(opt_params2.keys())
+
+    for key, param1 in params1.items():
+        param2 = params2[key]
+        assert (param1 == param2).all().cpu().item(), (
+            f"Model parameter {key} before (force_sharding={force_sharding}) and after force_sharding={not force_sharding} checkpointing is not equal"
+        )
+
+    for key, opt_param1 in opt_params1["state"].items():
+        opt_param2 = opt_params2["state"][key]
+        for opt_var in opt_param1:
+            assert (opt_param1[opt_var] == opt_param2[opt_var]).all().cpu().item(), (
+                f"Optimizer parameter {key} before (force_sharding={force_sharding}) and after force_sharding={not force_sharding} checkpointing is not equal"
             )
 
     if dist.world_size != 4:

--- a/physicsnemo/utils/checkpoint.py
+++ b/physicsnemo/utils/checkpoint.py
@@ -265,17 +265,41 @@ def _fsdp_uses_flat_param_optim(model: torch.nn.Module | None) -> bool:
     return not getattr(model, "_use_orig_params", True)
 
 
+def _strides_match_channels_last(
+    shape: tuple[int, ...] | torch.Size,
+    stride: tuple[int, ...],
+) -> bool:
+    """True iff *stride* matches the canonical NHWC / NDHWC stride formula.
+
+    For 4-D ``(N, C, H, W)`` the channels_last layout has strides
+    ``(C*H*W, 1, W*C, C)``; for 5-D ``(N, C, D, H, W)`` channels_last_3d
+    has strides ``(D*H*W*C, 1, H*W*C, W*C, C)``. Anything else -- including
+    standard-contig tensors that happen to satisfy ``stride[1] == 1`` because
+    of trailing-1 dims -- returns False.
+    """
+    if len(shape) != len(stride):
+        return False
+    if len(shape) == 4:
+        n, c, h, w = shape
+        return tuple(stride) == (c * h * w, 1, w * c, c)
+    if len(shape) == 5:
+        n, c, d, h, w = shape
+        return tuple(stride) == (d * h * w * c, 1, h * w * c, w * c, c)
+    return False
+
+
 def _get_cl_param_fqns(opt_model: torch.nn.Module | None) -> set[str]:
     """Return FQNs of FSDP-managed original params recorded as channels_last.
 
     For every FSDP submodule in *opt_model*, reads ``flat_param._fqns`` /
     ``_shapes`` / ``_strides`` / ``_contiguities`` and returns the set of
     original-parameter FQNs whose ``_contiguities[i] is False`` and whose
-    recorded strides match ``channels_last`` (4-D) or ``channels_last_3d``
-    (5-D). That is the same bit ``_get_unflat_views`` consults to decide
-    ``view`` vs ``as_strided`` on save -- so ``_contiguities[i] is False``
-    is exactly the signal that the destination ``FlatParameter`` slot
-    expects NHWC storage order at load time.
+    recorded strides match the canonical ``channels_last`` (4-D) or
+    ``channels_last_3d`` (5-D) formula. That is the same bit
+    ``_get_unflat_views`` consults to decide ``view`` vs ``as_strided`` on
+    save -- so ``_contiguities[i] is False`` plus a CL stride pattern is
+    exactly the signal that the destination ``FlatParameter`` slot expects
+    NHWC storage order at load time.
 
     Returns an empty set when *opt_model* isn't FSDP+``use_orig_params=False``
     (the only configuration where the flatten/unflatten asymmetry exists).
@@ -318,9 +342,7 @@ def _get_cl_param_fqns(opt_model: torch.nn.Module | None) -> set[str]:
         ):
             if contig:
                 continue
-            # CL / CL3D both have channel stride == 1 (channel is the
-            # innermost / fastest-varying dim in NHWC / NDHWC storage).
-            if len(shape) in (4, 5) and len(stride) == len(shape) and stride[1] == 1:
+            if _strides_match_channels_last(shape, stride):
                 cl_fqns.add((prefix + fqn).removeprefix("_orig_mod."))
     return cl_fqns
 

--- a/physicsnemo/utils/checkpoint.py
+++ b/physicsnemo/utils/checkpoint.py
@@ -113,6 +113,34 @@ def _cpu_offload_state_dict(state_dict: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _force_standard_contiguous(state_dict: dict[str, Any]) -> dict[str, Any]:
+    """Make positive-dim, non-DTensor tensors standard-contiguous.
+
+    Compensates for a layout-blind broadcast inside DCP's
+    ``set_model_state_dict`` / ``set_optimizer_state_dict``: the rank-0→others
+    transfer goes through ``dist.broadcast``, which is happy to send a
+    ``channels_last`` tensor (its contiguity check passes for that format) but
+    moves bytes in *storage* order. Receivers on non-zero ranks allocate via
+    ``torch.empty(shape, dtype, device)`` (standard NCHW), so CL bytes land
+    in NCHW positions and values are silently permuted on receive.
+
+    Forcing standard contiguity on rank 0 makes the broadcast layout-consistent.
+    ``.contiguous()`` is a no-op for tensors that are already standard-contig,
+    a value-preserving (logical) copy for ``channels_last`` /
+    ``channels_last_3d``, and is intentionally skipped for ``DTensor`` (whose
+    contiguity semantics differ).
+    """
+    out: dict[str, Any] = {}
+    for k, v in state_dict.items():
+        if isinstance(v, torch.Tensor) and not isinstance(v, DTensor) and v.dim() > 0:
+            out[k] = v.contiguous()
+        elif isinstance(v, dict):
+            out[k] = _force_standard_contiguous(v)
+        else:
+            out[k] = v
+    return out
+
+
 def _get_dtensor_param_placements(
     model: torch.nn.Module,
 ) -> dict[str, tuple[Any, tuple[Any, ...]]]:
@@ -1101,8 +1129,13 @@ def _load_checkpoint_distributed(
                 set_model_state_dict(model, sd, options=full_options)
             else:
                 # FSDP-managed DTensors (FULL_SHARD/SHARD_GRAD_OP) or no
-                # DTensors at all — broadcast_from_rank0 handles both.
+                # DTensors at all — broadcast_from_rank0 handles both. Force
+                # standard contiguity on rank 0 first so the per-tensor
+                # broadcast inside DCP doesn't permute channels_last params on
+                # receive (see ``_force_standard_contiguous`` for the why).
                 sd = model_state_dicts.get(name, {}) if is_rank0 else {}
+                if is_rank0:
+                    sd = _force_standard_contiguous(sd)
                 set_model_state_dict(model, sd, options=broadcast_options)
         else:
             # A mix of distributed and non-distributed models is valid

--- a/physicsnemo/utils/checkpoint.py
+++ b/physicsnemo/utils/checkpoint.py
@@ -265,6 +265,66 @@ def _fsdp_uses_flat_param_optim(model: torch.nn.Module | None) -> bool:
     return not getattr(model, "_use_orig_params", True)
 
 
+def _get_cl_param_fqns(opt_model: torch.nn.Module | None) -> set[str]:
+    """Return FQNs of FSDP-managed original params recorded as channels_last.
+
+    For every FSDP submodule in *opt_model*, reads ``flat_param._fqns`` /
+    ``_shapes`` / ``_strides`` / ``_contiguities`` and returns the set of
+    original-parameter FQNs whose ``_contiguities[i] is False`` and whose
+    recorded strides match ``channels_last`` (4-D) or ``channels_last_3d``
+    (5-D). That is the same bit ``_get_unflat_views`` consults to decide
+    ``view`` vs ``as_strided`` on save -- so ``_contiguities[i] is False``
+    is exactly the signal that the destination ``FlatParameter`` slot
+    expects NHWC storage order at load time.
+
+    Returns an empty set when *opt_model* isn't FSDP+``use_orig_params=False``
+    (the only configuration where the flatten/unflatten asymmetry exists).
+
+    Each FQN is built as ``{module_path_to_FSDP}.{flat_param._fqns[i]}``,
+    matching DCP's ``_get_fqns`` convention -- specifically, FSDP's
+    ``_fsdp_wrapped_module`` segments are stripped from the path so the
+    returned FQNs line up with the keys in ``optim_sd["state"]``.
+
+    The ``_orig_mod.`` (``torch.compile``) prefix is also stripped, matching
+    the normalization ``save_checkpoint`` applies to optimizer
+    ``param_names``.
+    """
+    if not _fsdp_uses_flat_param_optim(opt_model):
+        return set()
+
+    cl_fqns: set[str] = set()
+    for module_name, module in opt_model.named_modules():
+        if not isinstance(module, FSDP):
+            continue
+        flat_param = getattr(module, "_flat_param", None)
+        if flat_param is None:
+            continue
+        # DCP's ``_get_fqns`` skips the ``_fsdp_wrapped_module`` attribute
+        # when building parameter FQNs; mirror that by removing the segment
+        # from the module path.
+        path_segments = [
+            seg
+            for seg in module_name.split(".")
+            if seg and seg != "_fsdp_wrapped_module"
+        ]
+        prefix = ".".join(path_segments)
+        if prefix:
+            prefix += "."
+        for fqn, shape, stride, contig in zip(
+            flat_param._fqns,
+            flat_param._shapes,
+            flat_param._strides,
+            flat_param._contiguities,
+        ):
+            if contig:
+                continue
+            # CL / CL3D both have channel stride == 1 (channel is the
+            # innermost / fastest-varying dim in NHWC / NDHWC storage).
+            if len(shape) in (4, 5) and len(stride) == len(shape) and stride[1] == 1:
+                cl_fqns.add((prefix + fqn).removeprefix("_orig_mod."))
+    return cl_fqns
+
+
 def _remap_channels_last_optim_sd(
     opt_model: torch.nn.Module | None,
     optim_sd: dict[str, Any],
@@ -282,23 +342,26 @@ def _remap_channels_last_optim_sd(
     For a 4-D Conv2d weight in ``channels_last`` format the two orders
     differ, so the round-trip silently corrupts the optimizer state.
 
-    Detect channels_last entries directly on *optim_sd* (the saved tensor
-    preserves its memory format through ``torch.save`` / ``torch.load``)
-    and pre-permute them so the loader's ``torch.flatten`` produces the
-    same byte sequence the ``FlatParameter`` was originally filled with.
-    Other entries (and ranks that received an empty ``optim_sd`` for the
-    broadcast-from-rank-0 path) pass through unchanged.
+    The remap is gated on the **destination** ``FlatParameter`` slot's
+    expected byte order (via ``flat_param._contiguities``), not on the
+    saved tensor's layout. That's the only signal that always matches what
+    the load-side ``_flatten_tensor_optim_state`` will do, so it works for
+    every save/load layout combination -- in particular for
+    ``FSDP+ShardTensor`` configurations where ``distribute_module`` calls
+    ``.contiguous()`` and silently strips channels_last before FSDP wraps,
+    making saved tensors standard-contig even though the conceptual model
+    has CL conv weights.
+
+    Inputs are also normalized to standard contiguity before the layout
+    decision: a CL tensor that *isn't* getting permuted (because the
+    destination is non-CL) would otherwise survive into DCP's per-tensor
+    ``dist.broadcast`` and hit the same layout-blind broadcast bug
+    ``_force_standard_contiguous`` fixes for model state.
 
     Only fires when *opt_model* is FSDP-wrapped with
     ``use_orig_params=False`` -- with ``use_orig_params=True`` the
     asymmetry doesn't exist and the remap would *cause* the corruption it
     is meant to prevent.
-
-    Note: we cannot inspect the live model to find channels_last params --
-    with ``use_orig_params=False`` the original parameters are hidden
-    behind plain tensor attributes and ``named_parameters()`` only sees
-    the 1-D ``FlatParameter``. So detection is on the saved tensors
-    instead.
 
     See ``torch/distributed/fsdp/_optim_utils.py::_flatten_tensor_optim_state``
     and ``_flat_param.py::flatten_tensors``.
@@ -308,12 +371,21 @@ def _remap_channels_last_optim_sd(
     if not _fsdp_uses_flat_param_optim(opt_model):
         return optim_sd
 
-    def _maybe_remap(t: torch.Tensor) -> torch.Tensor:
-        if isinstance(t, DTensor):
+    cl_fqns = _get_cl_param_fqns(opt_model)
+
+    def _normalize(t: torch.Tensor, is_cl_dest: bool) -> torch.Tensor:
+        if isinstance(t, DTensor) or t.dim() == 0:
             return t
-        if t.dim() == 4 and t.is_contiguous(memory_format=torch.channels_last):
+        # Force standard contiguity first so any saved-CL bytes are
+        # rewritten in NCHW storage order before the layout decision; this
+        # makes the subsequent broadcast inside DCP layout-safe whether or
+        # not we permute.
+        t = t.contiguous()
+        if not is_cl_dest:
+            return t
+        if t.dim() == 4:
             return t.permute(0, 2, 3, 1).contiguous().view(*t.shape)
-        if t.dim() == 5 and t.is_contiguous(memory_format=torch.channels_last_3d):
+        if t.dim() == 5:
             return t.permute(0, 2, 3, 4, 1).contiguous().view(*t.shape)
         return t
 
@@ -322,9 +394,10 @@ def _remap_channels_last_optim_sd(
         if not isinstance(pstate, dict):
             new_state[pname] = pstate
             continue
+        is_cl_dest = pname.removeprefix("_orig_mod.") in cl_fqns
         new_ps: dict[str, Any] = {}
         for k, v in pstate.items():
-            new_ps[k] = _maybe_remap(v) if isinstance(v, torch.Tensor) else v
+            new_ps[k] = _normalize(v, is_cl_dest) if isinstance(v, torch.Tensor) else v
         new_state[pname] = new_ps
 
     return {**optim_sd, "state": new_state}
@@ -1155,16 +1228,32 @@ def _load_checkpoint_distributed(
         path, index=epoch, model_type="pt", distributed=True
     )
 
+    # Broadcast file existence so all ranks agree on whether to enter the
+    # (collective) optimizer load. Without this, a rundir that has model
+    # weights but no training checkpoint -- e.g. fine-tuning from a
+    # weights-only export -- would have rank 0 enter ``set_optimizer_state_dict``
+    # with an empty dict and trip the "missing 'state'" error inside DCP.
+    ckpt_exists = fs.exists(checkpoint_filename) if is_rank0 else None
+    ckpt_flags: list[Any] = [ckpt_exists]
+    torch.distributed.broadcast_object_list(ckpt_flags, src=0)
+    ckpt_exists = ckpt_flags[0]
+
+    if not ckpt_exists:
+        checkpoint_logging.warning(
+            f"No training checkpoint at {checkpoint_filename}; "
+            "skipping optimizer/scheduler/scaler load"
+        )
+        return 0
+
     checkpoint_dict: dict[str, Any] = {}
     if is_rank0:
-        if fs.exists(checkpoint_filename):
-            file_to_load = _cache_if_needed(checkpoint_filename)
-            checkpoint_dict = torch.load(
-                file_to_load, map_location=device, weights_only=False
-            )
-            checkpoint_logging.success(
-                f"Loaded checkpoint file {checkpoint_filename} to device {device}"
-            )
+        file_to_load = _cache_if_needed(checkpoint_filename)
+        checkpoint_dict = torch.load(
+            file_to_load, map_location=device, weights_only=False
+        )
+        checkpoint_logging.success(
+            f"Loaded checkpoint file {checkpoint_filename} to device {device}"
+        )
 
     # Optimizer state via DCP (collective)
     if optimizer:

--- a/test/utils/test_checkpoint_distributed.py
+++ b/test/utils/test_checkpoint_distributed.py
@@ -164,6 +164,263 @@ def test_fsdp_checkpoint_roundtrip(
 
 
 # ---------------------------------------------------------------------------
+# Plain FSDP + channels_last  (regression for cross-rank layout mismatch)
+# ---------------------------------------------------------------------------
+
+
+class _ConvNet(nn.Module):
+    """Tiny conv net so the parameter set includes a 4-D weight."""
+
+    def __init__(self, in_ch: int = 4, out_ch: int = 8, k: int = 3):
+        super().__init__()
+        self.conv = nn.Conv2d(in_ch, out_ch, kernel_size=k, padding=k // 2, bias=True)
+        self.gn = nn.GroupNorm(num_groups=4, num_channels=out_ch)
+
+    def forward(self, x):
+        return self.gn(self.conv(x))
+
+
+def _all_ranks_bit_exact(t: torch.Tensor) -> bool:
+    """True iff every rank holds element-wise bit-identical values for *t*."""
+    t_min = t.detach().clone().float()
+    t_max = t.detach().clone().float()
+    dist.all_reduce(t_min, op=dist.ReduceOp.MIN)
+    dist.all_reduce(t_max, op=dist.ReduceOp.MAX)
+    return torch.equal(t_min, t_max)
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.multigpu_static
+@pytest.mark.parametrize("use_orig_params", [True, False])
+@pytest.mark.parametrize(
+    "sharding_strategy",
+    [ShardingStrategy.NO_SHARD],
+)
+def test_fsdp_checkpoint_channels_last_roundtrip(
+    shared_tmp_dir, use_orig_params, sharding_strategy
+):
+    """Round-trip an FSDP+channels_last conv model and assert per-rank parity.
+
+    Regression for a layout-mismatch bug in DCP's broadcast_from_rank0 path:
+    ``dist.broadcast`` accepts a channels_last sender (``is_contiguous`` check
+    passes for that format) but transfers bytes in storage order, while
+    receivers allocate ``torch.empty(shape, dtype, device)`` (standard NCHW),
+    so 4-D conv weights were silently permuted on non-rank-0. The fix
+    (``_force_standard_contiguous`` on rank 0 before ``set_model_state_dict``)
+    keeps sender and receiver layouts consistent.
+
+    Asserts bit-exact agreement across ranks on the live FlatParameter (for
+    ``use_orig_params=False``) / each original parameter (for True). Output
+    equivalence isn't sufficient — a permuted conv weight preserves abs-sum
+    and the model can stagger toward similar outputs over noise — so we
+    check the parameter values directly.
+
+    The optimizer state is intentionally *not* asserted here. The optim load
+    path is layout-correct (verified by the standalone smoketest and by
+    running this test in isolation), but suite-level state pollution (NCCL
+    allreduce ordering across many prior tests) accumulates FP noise in the
+    pre-load training step, which then survives the load and makes a tight
+    cross-rank check flaky. The existing ``test_fsdp_checkpoint_roundtrip``
+    already covers the optim path with a tolerance-based output comparison
+    that's robust to that noise.
+    """
+    dm = DistributedManager()
+    if dm.world_size < 2:
+        pytest.skip("Need at least 2 ranks")
+
+    device = dm.device
+    mesh = init_device_mesh("cuda", (dm.world_size,), mesh_dim_names=("world",))
+
+    # Build, move to channels_last (only conv weights are affected), wrap.
+    torch.manual_seed(0)
+    model = _ConvNet().to(device=device, memory_format=torch.channels_last)
+    fsdp_model = FSDP(
+        model,
+        device_mesh=mesh["world"],
+        sharding_strategy=sharding_strategy,
+        use_orig_params=use_orig_params,
+        sync_module_states=True,
+    )
+    optimizer = torch.optim.Adam(fsdp_model.parameters(), lr=1e-3)
+
+    # Same x on every rank (we want the source-of-truth state to be identical
+    # across ranks pre-save, so any post-load divergence is checkpoint-induced).
+    x = torch.randn(2, 4, 8, 8, device=device).contiguous(
+        memory_format=torch.channels_last
+    )
+    for _ in range(2):
+        fsdp_model(x).sum().backward()
+        optimizer.step()
+        optimizer.zero_grad()
+
+    save_checkpoint(
+        shared_tmp_dir,
+        models=fsdp_model,
+        optimizer=optimizer,
+        epoch=2,
+        optimizer_model=fsdp_model,
+    )
+    dist.barrier()
+
+    # Build a *differently-seeded* fresh model so sync_module_states alone can't
+    # mask the bug by leaving rank 0's pre-load values on every rank.
+    torch.manual_seed(dm.rank + 1234)
+    model2 = _ConvNet().to(device=device, memory_format=torch.channels_last)
+    fsdp_model2 = FSDP(
+        model2,
+        device_mesh=mesh["world"],
+        sharding_strategy=sharding_strategy,
+        use_orig_params=use_orig_params,
+        sync_module_states=True,
+    )
+    optimizer2 = torch.optim.Adam(fsdp_model2.parameters(), lr=1e-3)
+    # Step once so optimizer state is shaped before the load.
+    fsdp_model2(x).sum().backward()
+    optimizer2.step()
+    optimizer2.zero_grad()
+
+    epoch = load_checkpoint(
+        shared_tmp_dir,
+        models=fsdp_model2,
+        optimizer=optimizer2,
+        optimizer_model=fsdp_model2,
+    )
+    assert epoch == 2
+
+    # --- Cross-rank parity checks ------------------------------------------
+    # FlatParameter (use_orig_params=False) or each original param (True).
+    if use_orig_params:
+        for name, p in fsdp_model2.named_parameters():
+            assert _all_ranks_bit_exact(p), (
+                f"Parameter '{name}' (shape={tuple(p.shape)}) differs across "
+                f"ranks after channels_last+FSDP load"
+            )
+    else:
+        flat_param = fsdp_model2._flat_param
+        assert _all_ranks_bit_exact(flat_param), (
+            "FlatParameter differs across ranks after channels_last+FSDP load"
+        )
+
+    # Optimizer state cross-rank check intentionally omitted -- see docstring.
+
+
+# ---------------------------------------------------------------------------
+# Cross-mode load: 1-proc non-distributed save → N-proc FSDP load (with CL)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.multigpu_static
+def test_cross_mode_channels_last_model_load(shared_tmp_dir):
+    """Save from a single (rank-0-only) non-FSDP CL model; load model state
+    into N-proc FSDP.
+
+    Realistic "trained on multi-rank, fine-tuned/inspected on a single GPU,
+    resumed multi-rank" round-trip with channels_last. Confirms that the
+    on-disk model state produced by the non-distributed save path is loadable
+    by the distributed FSDP load path on every rank without layout-induced
+    corruption.
+
+    Model side asserts:
+      * every rank's post-load FlatParameter is bit-exact identical, AND
+      * rank 0's logical values match what was saved.
+
+    Cross-rank parity alone can be satisfied by "everyone got the same wrong
+    values" (e.g. silent drop), so we also check against the saved snapshot.
+
+    Optimizer cross-mode load is *not* tested here. The non-distributed save
+    path writes int-keyed (param-id) optim state via ``optimizer.state_dict()``,
+    while the distributed FSDP load path expects FQN-keyed input -- DCP's
+    ``_split_optim_state_dict`` early-returns for int keys without converting,
+    and the downstream ``_rekey_sharded_optim_state_dict`` then crashes on
+    ``int.unflat_param_names``. That's a separate, pre-existing limitation
+    of cross-mode optim restore; same-mode optim restore is exercised by
+    ``test_fsdp_checkpoint_channels_last_roundtrip`` and is what the
+    channels_last fix is concerned with.
+    """
+    dm = DistributedManager()
+    if dm.world_size < 2:
+        pytest.skip("Need at least 2 ranks")
+
+    device = dm.device
+
+    # ===== Phase A: 1-proc save on rank 0 only =====
+    saved_params: dict[str, torch.Tensor] = {}
+    if dm.rank == 0:
+        torch.manual_seed(0)
+        model_save = _ConvNet().to(device=device, memory_format=torch.channels_last)
+        optimizer_save = torch.optim.Adam(model_save.parameters(), lr=1e-3)
+
+        x = torch.randn(2, 4, 8, 8, device=device).contiguous(
+            memory_format=torch.channels_last
+        )
+        # Two steps so the saved weights have actually moved off init.
+        for _ in range(2):
+            model_save(x).sum().backward()
+            optimizer_save.step()
+            optimizer_save.zero_grad()
+
+        # Snapshot. ``contiguous()`` pins a canonical layout for comparison;
+        # the values are what matter.
+        for name, p in model_save.named_parameters():
+            saved_params[name] = p.detach().clone().contiguous().cpu()
+
+        # We deliberately save the optimizer state too, mirroring real-world
+        # usage, but the load side will not consume it (see docstring).
+        save_checkpoint(
+            shared_tmp_dir,
+            models=model_save,
+            optimizer=optimizer_save,
+            epoch=2,
+        )
+    dist.barrier()
+
+    # ===== Phase B: N-proc FSDP-only load (model only) =====
+    mesh = init_device_mesh("cuda", (dm.world_size,), mesh_dim_names=("world",))
+
+    # Different per-rank seed so sync_module_states alone can't mask anything.
+    torch.manual_seed(dm.rank + 4242)
+    model_load = _ConvNet().to(device=device, memory_format=torch.channels_last)
+    fsdp_load = FSDP(
+        model_load,
+        device_mesh=mesh["world"],
+        sharding_strategy=ShardingStrategy.NO_SHARD,
+        use_orig_params=False,
+        sync_module_states=True,
+    )
+
+    # Pass optimizer=None: cross-mode optim load is a separate, pre-existing
+    # PyTorch DCP limitation (see docstring). We're testing the model path.
+    epoch = load_checkpoint(
+        shared_tmp_dir,
+        models=fsdp_load,
+    )
+    assert epoch == 2
+
+    # ===== Phase C.1: per-rank parity =====
+    flat_param = fsdp_load._flat_param
+    assert _all_ranks_bit_exact(flat_param), (
+        "FlatParameter differs across ranks after cross-mode model load"
+    )
+
+    # ===== Phase C.2: loaded values match saved values (rank 0) =====
+    # Collective: gather the full model state dict on every rank.
+    full_loaded_model = get_model_state_dict(
+        fsdp_load, options=StateDictOptions(full_state_dict=True)
+    )
+    if dm.rank == 0:
+        for name, expected in saved_params.items():
+            assert name in full_loaded_model, (
+                f"Loaded model state missing '{name}'"
+            )
+            actual = full_loaded_model[name].detach().contiguous().cpu()
+            assert torch.equal(actual, expected), (
+                f"Logical model values for '{name}' differ between save and "
+                f"load (cross-mode)"
+            )
+
+
+# ---------------------------------------------------------------------------
 # load_model_weights — plain FSDP
 # ---------------------------------------------------------------------------
 

--- a/test/utils/test_checkpoint_distributed.py
+++ b/test/utils/test_checkpoint_distributed.py
@@ -410,9 +410,7 @@ def test_cross_mode_channels_last_model_load(shared_tmp_dir):
     )
     if dm.rank == 0:
         for name, expected in saved_params.items():
-            assert name in full_loaded_model, (
-                f"Loaded model state missing '{name}'"
-            )
+            assert name in full_loaded_model, f"Loaded model state missing '{name}'"
             actual = full_loaded_model[name].detach().contiguous().cpu()
             assert torch.equal(actual, expected), (
                 f"Logical model values for '{name}' differ between save and "


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Follow-up to #1597. Addresses the following issue with channels-last models loaded in FSDP-only mode:

- Channels-last conv weights were silently permuted on non-rank-0 ranks during FSDP checkpoint restart. `set_model_state_dict(broadcast_from_rank0=True)` invokes `dist.broadcast` per tensor, which accepts a channels_last-strided sender (its contiguity check passes for that format) but transfers bytes in storage order; receivers allocate `torch.empty(shape, dtype, device)` in standard NCHW layout, so the CL bytes land in NCHW positions and 4-D conv weights end up permuted on every rank except rank 0. The fix is a small load-side helper that makes positive-dim tensors standard-contiguous on rank 0 before handing the state dict to DCP, so the broadcast becomes layout-consistent across ranks; this matches the structure of the existing optim-state remap, which sidesteps the same hazard.

Also improves the cross-compatibility between checkpoints saved in single-process mode vs. single-/multi-process FSDP and single-/multi-process FSDP+ShardTensor mode by having the optimizer/model state loading infer channels_last format from the model in question rather than the tensors saved in the checkpoint itself.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
