### PR TITLE
Update test_time_utils.py

### DIFF
--- a/test/datapipes/healda/test_time_utils.py
+++ b/test/datapipes/healda/test_time_utils.py
@@ -35,7 +35,7 @@ def test_as_numpy_from_pandas_index():
     idx = pd.date_range("2020-01-01", periods=3, freq="h")
     result = as_numpy(idx)
     assert isinstance(result, np.ndarray)
-    assert result.dtype == np.dtype("datetime64[ns]")
+    assert np.issubdtype(result.dtype, np.datetime64)
     assert len(result) == 3
 
 


### PR DESCRIPTION
Change assertion in healda time utils testing.

This fixes one of our install CI tests breaking against pandas installed via pip:
https://github.com/NVIDIA/physicsnemo/actions/runs/25421107284/job/74563236147

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
