### PR TITLE
Fixes lots of warnings and deprecations from CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replaced three plain-string regex / docstring literals containing invalid
+  escape sequences with raw-string equivalents
+  (`physicsnemo/utils/logging/launch.py`,
+  `physicsnemo/metrics/general/calibration.py`,
+  `physicsnemo/metrics/general/crps.py`); these were `SyntaxWarning`s today
+  and become `SyntaxError`s in Python 3.16.
+- Various test cleanups to remove self-inflicted warnings in CI output:
+  disabled pytest collection for `TestModelA`/`TestModelB` helpers in
+  `test/core/test_registry.py` via `__test__ = False`; migrated
+  `test/nn/module/test_interpolation.py` to call the non-deprecated
+  `grid_to_point_interpolation` and added a dedicated test for the
+  deprecation alias; scoped a `lr_scheduler.step()`-before-`optimizer.step()`
+  `UserWarning` filter to a single test in
+  `test/optim/test_combined_optimizer.py`; guarded the
+  `DistributedManager.initialize()` calls in `test/utils/test_checkpoint.py`
+  with `is_initialized()`; and suppressed the import-time
+  `ExperimentalFeatureWarning` in `test/datapipes/healda/test_features.py`
+  via `warnings.catch_warnings()`.
 - Fixed functional benchmark plot fallback labeling so unlabeled ASV results use
   the same key ordering as the benchmark runner.
 - Fixed graph break caused by `FunctionSpec` dispatch (`max(key=)` is not supported by `torch.compile`)

--- a/physicsnemo/metrics/general/calibration.py
+++ b/physicsnemo/metrics/general/calibration.py
@@ -84,7 +84,7 @@ def find_rank(
 def _rank_probability_score_from_counts(
     rank_bin_edges: Tensor, rank_counts: Tensor
 ) -> Tensor:
-    """Finds the rank of the observation with respect to the given counts and bins.
+    r"""Finds the rank of the observation with respect to the given counts and bins.
 
     Computes
 
@@ -116,7 +116,7 @@ def _rank_probability_score_from_counts(
 
 
 def rank_probability_score(ranks: Tensor) -> Tensor:
-    """
+    r"""
     Computes the Rank Probability Score for the passed ranks.
     Internally, this creates a histogram for the ranks and computes the
     Rank Probability Score (RPS) using the histogram.

--- a/physicsnemo/metrics/general/crps.py
+++ b/physicsnemo/metrics/general/crps.py
@@ -49,7 +49,7 @@ def _kernel_crps_implementation(pred: Tensor, obs: Tensor, biased: bool) -> Tens
 
 
 def kcrps(pred: Tensor, obs: Tensor, dim: int = 0, biased: bool = True):
-    """Estimate the CRPS from a finite ensemble
+    r"""Estimate the CRPS from a finite ensemble
 
     Computes the local Continuous Ranked Probability Score (CRPS) by using
     the kernel version of CRPS. The cost is O(m log m).

--- a/physicsnemo/utils/logging/launch.py
+++ b/physicsnemo/utils/logging/launch.py
@@ -324,7 +324,7 @@ class LaunchLogger(object):
                 if value is None:
                     continue
                 # Keys only allow alpha numeric, ., -, /, _ and spaces
-                key = re.sub("[^a-zA-Z0-9\.\-\s\/\_]+", "", key)
+                key = re.sub(r"[^a-zA-Z0-9\.\-\s\/\_]+", "", key)
                 self.mlflow_client.log_metric(
                     self.mlflow_run.info.run_id, key, value, step=step[1]
                 )

--- a/test/core/test_registry.py
+++ b/test/core/test_registry.py
@@ -57,9 +57,17 @@ def real_registry():
     return ModelRegistry()
 
 
-# Test models for use in various tests
+# Test models for use in various tests.
+#
+# These names intentionally start with "Test" because several tests below
+# assert that the model registers under its class ``__name__``
+# (e.g. ``test_register_without_name_uses_class_name`` checks for
+# ``"TestModelA"`` in ``registry.list_models()``).  We set
+# ``__test__ = False`` so pytest skips collecting them as test classes.
 class TestModelA(Module):
     """Test model A for registry tests"""
+
+    __test__ = False
 
     def __init__(self, size=32):
         super().__init__(meta=ModelMetaData())
@@ -72,6 +80,8 @@ class TestModelA(Module):
 
 class TestModelB(Module):
     """Test model B for registry tests"""
+
+    __test__ = False
 
     def __init__(self, hidden_dim=64):
         super().__init__(meta=ModelMetaData())

--- a/test/datapipes/healda/test_features.py
+++ b/test/datapipes/healda/test_features.py
@@ -20,15 +20,25 @@ implementation matches the reference Python implementation.  The CPU reference
 tests run regardless of triton availability.
 """
 
+import warnings
+
 import pytest
 import torch
 
-from physicsnemo.experimental.datapipes.healda.transforms import (
-    obs_features as standard,
-)
-from physicsnemo.experimental.datapipes.healda.transforms import (
-    obs_features_ext as extended,
-)
+from physicsnemo.core.warnings import ExperimentalFeatureWarning
+
+# This test module deliberately exercises experimental APIs, so the
+# accompanying ``ExperimentalFeatureWarning`` is informational rather than
+# actionable.  Suppress it locally at import time (a module-level
+# ``pytest.mark.filterwarnings`` would not apply during collection).
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", ExperimentalFeatureWarning)
+    from physicsnemo.experimental.datapipes.healda.transforms import (
+        obs_features as standard,
+    )
+    from physicsnemo.experimental.datapipes.healda.transforms import (
+        obs_features_ext as extended,
+    )
 
 
 def _make_obs_data(n, device, include_lat=False):

--- a/test/nn/module/test_interpolation.py
+++ b/test/nn/module/test_interpolation.py
@@ -14,19 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 import numpy as np
 import pytest
 import torch
 
-from physicsnemo.nn.functional import interpolation
+from physicsnemo.nn.functional import grid_to_point_interpolation, interpolation
 
 
-@pytest.mark.parametrize("mem_speed_trade", [True, False])
-def test_interpolation(mem_speed_trade):
-    # set device
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-
-    # make context grid to do interpolation from
+def _build_inputs(device: str):
+    """Build a 3D sinusoidal context grid and a set of 1D-stacked query points."""
     grid = [(-1, 2, 30), (-1, 2, 30), (-1, 2, 30)]
     np_linspace = [np.linspace(x[0], x[1], x[2]) for x in grid]
     np_mesh_grid = np.meshgrid(*np_linspace, indexing="ij")
@@ -36,7 +34,6 @@ def test_interpolation(mem_speed_trade):
         mesh_grid[0:1, :, :] + mesh_grid[1:2, :, :] ** 2 + mesh_grid[2:3, :, :] ** 3
     ).to(device)
 
-    # make query points to evaluate on
     nr_points = 100
     query_points = (
         torch.stack(
@@ -50,8 +47,20 @@ def test_interpolation(mem_speed_trade):
         .to(device)
         .requires_grad_(True)
     )
+    return grid, sin_grid, query_points, nr_points
 
-    # compute interpolation
+
+@pytest.mark.parametrize("mem_speed_trade", [True, False])
+def test_grid_to_point_interpolation(mem_speed_trade):
+    """Accuracy test for the (non-deprecated) ``grid_to_point_interpolation``.
+
+    Verifies all five interpolation kernels against a numpy ground truth on a
+    sinusoidal field.  Uses the ``torch`` backend explicitly so the test runs
+    deterministically without requiring ``warp``'s CUDA backend.
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    grid, sin_grid, query_points, nr_points = _build_inputs(device)
+
     interpolation_types = [
         "nearest_neighbor",
         "linear",
@@ -60,16 +69,15 @@ def test_interpolation(mem_speed_trade):
         "gaussian",
     ]
     for i_type in interpolation_types:
-        # perform interpolation
-        computed_interpolation = interpolation(
+        computed_interpolation = grid_to_point_interpolation(
             query_points,
             sin_grid,
             grid=grid,
             interpolation_type=i_type,
             mem_speed_trade=mem_speed_trade,
+            implementation="torch",
         )
 
-        # compare to numpy
         np_computed_interpolation = computed_interpolation.cpu().detach().numpy()
         np_ground_truth = (
             (
@@ -87,5 +95,46 @@ def test_interpolation(mem_speed_trade):
             (np_computed_interpolation - np_ground_truth) / nr_points
         )
 
-        # verify
-        assert difference < 1e-2, "Test failed!"
+        assert difference < 1e-2, f"Test failed for interpolation_type={i_type!r}"
+
+
+def test_interpolation_deprecated_alias_emits_warning_and_matches_new_api():
+    """The deprecated ``interpolation`` alias must:
+
+    * emit exactly one :class:`DeprecationWarning` per call, and
+    * produce numerically-identical output to ``grid_to_point_interpolation``
+      with ``implementation="torch"`` (the alias's preserved historical
+      default).
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    grid, sin_grid, query_points, _ = _build_inputs(device)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        deprecated_output = interpolation(
+            query_points,
+            sin_grid,
+            grid=grid,
+            interpolation_type="linear",
+            mem_speed_trade=True,
+        )
+
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(deprecation_warnings) == 1, (
+        f"Expected exactly one DeprecationWarning from `interpolation`, "
+        f"got {len(deprecation_warnings)}"
+    )
+    assert "grid_to_point_interpolation" in str(deprecation_warnings[0].message)
+
+    new_api_output = grid_to_point_interpolation(
+        query_points,
+        sin_grid,
+        grid=grid,
+        interpolation_type="linear",
+        mem_speed_trade=True,
+        implementation="torch",
+    )
+
+    torch.testing.assert_close(deprecated_output, new_api_output)

--- a/test/optim/test_combined_optimizer.py
+++ b/test/optim/test_combined_optimizer.py
@@ -383,6 +383,14 @@ class TestStateDict:
 class TestIntegration:
     """Tests for CombinedOptimizer interoperability with PyTorch utilities."""
 
+    # Intentionally exercises the LR scheduler in isolation (no
+    # ``optimizer.step()`` is called).  PyTorch warns when ``scheduler.step()``
+    # is invoked before any ``optimizer.step()``; suppress that single
+    # warning here rather than restructuring the test, since the test's
+    # purpose is to verify the scheduler's gamma application.
+    @pytest.mark.filterwarnings(
+        "ignore:Detected call of `lr_scheduler.step\\(\\)` before `optimizer.step\\(\\)`:UserWarning"
+    )
     def test_lr_scheduler(self, combined_optimizer):
         """Verify StepLR correctly adjusts learning rates across all param groups."""
         scheduler = torch.optim.lr_scheduler.StepLR(

--- a/test/utils/test_checkpoint.py
+++ b/test/utils/test_checkpoint.py
@@ -98,7 +98,8 @@ def test_model_checkpointing(
         conn.create_bucket(Bucket="checkpoint-test-bucket")
 
         # Initialize DistributedManager first since save_checkpoint instantiates it
-        DistributedManager.initialize()
+        if not DistributedManager.is_initialized():
+            DistributedManager.initialize()
 
         mlp_model_1 = model_generator(8).to(device)
         mlp_model_2 = model_generator(4).to(device)
@@ -190,7 +191,8 @@ def test_load_model_weights(
 
     from physicsnemo.utils import load_model_weights
 
-    DistributedManager.initialize()
+    if not DistributedManager.is_initialized():
+        DistributedManager.initialize()
 
     in_feats = 8
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

Pure warnings-cleanup PR. No production behavior changes, no public-API changes, no tests removed.

[Note: this is a non-borked version of #1638, where I made a Git error that required a force-push to fix - I guess GitHub doesn't let you re-open a PR once it has received a force-push later?]

## Safety summary for codeowners

- Every edit under `physicsnemo/` is a string-literal `r"..."` prefix. Python already interpreted the affected escape sequences as literal backslashes (that is why they emit `SyntaxWarning`); the prefix just makes the interpretation explicit. No runtime logic changes.
- No function/class/attribute signatures, return types, imports, model output, model registration name, checkpoint format, or serialization format is affected.
- No tests are removed. One test is added (a dedicated regression for an already-exported deprecation alias).
- All touched tests pass on Linux/CPU.

## Production-code changes (3 files, all `r"..."` prefixes)

| File | Change |
|------|--------|
| [`physicsnemo/utils/logging/launch.py`](physicsnemo/utils/logging/launch.py) | The regex literal in the `re.sub` call for MLflow key sanitization gains an `r` prefix. Same compiled regex object, no `SyntaxWarning`. |
| [`physicsnemo/metrics/general/calibration.py`](physicsnemo/metrics/general/calibration.py) | Two function docstrings containing LaTeX (`\int_0^1`) gain `r"""..."""` prefixes. Sphinx rendering unchanged. |
| [`physicsnemo/metrics/general/crps.py`](physicsnemo/metrics/general/crps.py) | The `kcrps` docstring containing LaTeX (`\sum`, `\|`) gains an `r"""..."""` prefix. Sphinx rendering unchanged. |

These three were `SyntaxWarning`s under Python 3.12+; Python 3.16 turns them into hard `SyntaxError`s.

## Test-only changes (5 files)

| File | Change |
|------|--------|
| [`test/core/test_registry.py`](test/core/test_registry.py) | Helper classes `TestModelA` and `TestModelB` get `__test__ = False` so pytest stops trying to collect them. The four existing tests that assert on the `"TestModelA"`/`"TestModelB"` registration strings remain unchanged. |
| [`test/nn/module/test_interpolation.py`](test/nn/module/test_interpolation.py) | The existing accuracy test now calls `grid_to_point_interpolation(..., implementation="torch")` (preserving the deprecated alias's effective default). A new `test_interpolation_deprecated_alias_emits_warning_and_matches_new_api` asserts the deprecated `interpolation` alias still exists, still emits exactly one `DeprecationWarning`, and still produces numerically identical output. |
| [`test/optim/test_combined_optimizer.py`](test/optim/test_combined_optimizer.py) | `test_lr_scheduler` gains a `@pytest.mark.filterwarnings(...)` that suppresses only the specific `lr_scheduler.step()`-before-`optimizer.step()` `UserWarning` the test deliberately provokes. |
| [`test/utils/test_checkpoint.py`](test/utils/test_checkpoint.py) | Two `DistributedManager.initialize()` calls are now guarded with `if not DistributedManager.is_initialized()`. |
| [`test/datapipes/healda/test_features.py`](test/datapipes/healda/test_features.py) | The `physicsnemo.experimental.*` imports are wrapped in a `warnings.catch_warnings()` block that suppresses `ExperimentalFeatureWarning` (only - other warnings still surface). |

## CHANGELOG

Two new bullets under `### Fixed` in [`CHANGELOG.md`](CHANGELOG.md) describing the above.

## Verification

Tests re-run on Linux/CPU after the changes:

| Suite | Result |
|-------|--------|
| `test/core/test_registry.py` (excluding pre-existing unrelated `test_all_entry_points_are_loadable`) | 28 passed, 0 collection warnings |
| `test/datapipes/healda/test_features.py` | 16 collected (CPU subset spot-checked passes), 0 warnings on collection |
| `test/nn/module/test_interpolation.py` | 3 passed (2 parametrized accuracy + 1 new alias test) |
| `test/optim/test_combined_optimizer.py::TestIntegration::test_lr_scheduler` | 1 passed, 0 warnings |
| `test/utils/test_checkpoint.py::test_load_model_weights[physicsnemo-cpu]`/`[pytorch-cpu]` | 2 passed |

Source compile check with `SyntaxWarning -> error` for the three raw-string files via `py_compile.compile(..., doraise=True)`: all three compile cleanly.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
