### PR TITLE
ci: declare contents:read on install-ci and pre-commit workflows

### DIFF
--- a/.github/workflows/install-ci.yml
+++ b/.github/workflows/install-ci.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch:  # Allows manual triggering from GitHub UI
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   test-pip:
     name: Test with pip (Python ${{ matrix.python-version }}, OS ${{ matrix.os }})

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,6 +21,9 @@ on:
     branches: [main, v2.0-refactor]
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     name: Run pre-commit hooks


### PR DESCRIPTION
Two test-only workflows currently leave the workflow `GITHUB_TOKEN` scope implicit:

- `.github/workflows/install-ci.yml` -- the `test-pip` and `test-uv` jobs only run `actions/checkout`, `actions/setup-python`, and `pytest`. There is no call to the GitHub API beyond checkout.
- `.github/workflows/pre-commit.yml` -- a single job that runs `pre-commit/action@v3.0.1`. Same read-only profile.

This patch pins both to `permissions: contents: read` at workflow scope. The style is already idiomatic here: `github-pr.yml` declares workflow-level permissions, and `stale.yml` declares per-job permissions for `actions/stale`. Either pattern is acceptable; workflow-level is cleaner when every job needs the same scope.

Out of scope (deliberately left for a separate change):

- `blossom-ci.yml` triggers on `issue_comment` with bespoke authorization logic against a fixed list of maintainers. Its permissions story is non-trivial.
- `github-nightly-container.yml` uses `actions/cache/save@v4` for the uv environment and testmon database. Pinning explicit permissions there also requires the `actions: write` story for cache save, which is its own discussion.

No behavioural change.