### PR TITLE
Fix Warp import crash: use public wp.Device, not wp.context.Device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug in Pangu, FengWu attention window shift for asymmetric longitudes
 - Fixed a bug in `mesh.sampling.find_nearest_cells`, where a mixup between L2 and L-inf norms
   could cause slightly incorrect nearest-neighbor assignments in highly skewed meshes.
+- Fixed an import crash with recent Warp by using the public `wp.Device` instead of the
+  removed `wp.context.Device` in the `radius_search` Warp interop. This unblocks importing
+  `physicsnemo.nn` and `physicsnemo.models`.
 
 ### Security
 

--- a/physicsnemo/nn/functional/neighbors/radius_search/_warp_impl.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_warp_impl.py
@@ -53,7 +53,7 @@ def count_neighbors(
     grid: wp.HashGrid,
     wp_points: wp.array(dtype=wp.vec3),
     wp_queries: wp.array(dtype=wp.vec3),
-    wp_launch_device: wp.context.Device | None,
+    wp_launch_device: wp.Device | None,
     wp_launch_stream: wp.Stream | None,
     radius: float,
     N_queries: int,
@@ -65,7 +65,7 @@ def count_neighbors(
         grid (wp.HashGrid): The hash grid to use for the search.
         wp_points (wp.array): The points to search in, as a warp array.
         wp_queries (wp.array): The queries to search for, as a warp array.
-        wp_launch_device (wp.context.Device | None): The device to launch the kernel on.
+        wp_launch_device (wp.Device | None): The device to launch the kernel on.
         wp_launch_stream (wp.Stream | None): The stream to launch the kernel on.
         radius (float): The radius that bounds the search.
         N_queries (int): Total number of query points.
@@ -114,7 +114,7 @@ def gather_neighbors(
     wp_points: wp.array(dtype=wp.vec3),
     wp_queries: wp.array(dtype=wp.vec3),
     wp_offset: wp.array(dtype=wp.int32),
-    wp_launch_device: wp.context.Device | None,
+    wp_launch_device: wp.Device | None,
     wp_launch_stream: wp.Stream | None,
     radius: float,
     N_queries: int,
@@ -131,7 +131,7 @@ def gather_neighbors(
         wp_points (wp.array): The points to search in, as a warp array.
         wp_queries (wp.array): The queries to search for, as a warp array.
         wp_offset (wp.array): The offset in output for each input point, as a warp array.
-        wp_launch_device (wp.context.Device | None): The device to launch the kernel on.
+        wp_launch_device (wp.Device | None): The device to launch the kernel on.
         wp_launch_stream (wp.Stream | None): The stream to launch the kernel on.
         radius (float): The radius that bounds the search.
         N_queries (int): Total number of query points.


### PR DESCRIPTION
## Description

Recent Warp removed the public `warp.context` namespace (it now lives at
`warp._src.context`). `radius_search/_warp_impl.py` used `wp.context.Device` as a
runtime-evaluated type annotation, so importing it crashes and breaks the whole
`physicsnemo.nn` / `physicsnemo.models` import chain.

This switches to the public `wp.Device` (matching the adjacent `wp.Stream` annotation), as recommended by Warp's
own deprecation message ("Use `warp.Device` instead"). 

Note that PhysicsNeMo's uncapped warp-lang>=1.5.0 dependency already resolves to the current stable Warp 1.13.0, which has removed the public warp.context namespace, so this import crash affects fresh installs today (not just Warp 1.14 nightlies), while the wp.Device replacement is verified to import correctly on both Warp 1.13.0 and 1.14.


Repro (Warp 1.14):

    from physicsnemo.models.mlp.fully_connected import FullyConnected
    # AttributeError: module 'warp' has no attribute 'context'

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.
- [ ] An issue is linked to this pull request.
- [x] If I am implementing a new model or modifying any existing model, I have followed the Models Implementation Coding Standards.

## Dependencies

None.