### PR TITLE
Update torchvision version to 0.25.0a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "treelib>=1.2.5",
     "numpy>=1.22.4",
     "torch>=2.10.0",
-    "torchvision>=0.25.0",
+    "torchvision>=0.25.0a0",
     "tqdm>=4.60.0",
     "requests>=2.32.2",
     # urllib3 is a transitive dependency (via requests/botocore/etc.); pin to
@@ -240,7 +240,7 @@ dev = [
 # packages are installed.
 cu13 = [
     "torch>=2.10.0",
-    "torchvision>=0.25.0",
+    "torchvision>=0.25.0a0",
     "cuml-cu13>=26.2.0",
     "pylibraft-cu13>=26.2.0",
     # Avoid cupy 14.x: 14.0.0 ships a broken cuda13 wheel
@@ -252,7 +252,7 @@ cu13 = [
 ]
 cu12 = [
     "torch>=2.10.0",
-    "torchvision>=0.25.0",
+    "torchvision>=0.25.0a0",
     "cuml-cu12>=26.2.0",
     "pylibraft-cu12>=26.2.0",
     # See cu13 note: cupy 14.x also interacts badly with torch>=2.11 on the


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Update the lower bound of torchvision version to satisfy the NVAIE builds. Without this, the pip install will update torchvision (and with it, torch too) which breaks the builds.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
