### PR TITLE
feat(crash): lazy Zarr loading for multi-GPU DDP training

### DIFF
--- a/examples/structural_mechanics/crash/README.md
+++ b/examples/structural_mechanics/crash/README.md
@@ -190,6 +190,8 @@ Multi-GPU (Distributed Data Parallel):
 torchrun --nproc_per_node=<NUM_GPUS> train.py --config-name=bumper_geotransolver_oneshot
 ```
 
+**Memory note (Zarr + DDP):** `DistributedSampler` shards **sample indices** across ranks, not dataset memory. Each rank still constructs its own dataset object. Without lazy loading, the Zarr reader materializes every run into host RAM at construction time, so memory scales roughly with `world_size × dataset_size`. The built-in Zarr reader defaults to `lazy_load: true` (see `conf/reader/zarr.yaml`), loading mesh trajectories and point features on first access in `__getitem__`. Set `reader.lazy_load=false` only for small datasets or debugging.
+
 ## Inference
 
 Use `inference.py` to evaluate trained models on test crash runs. Outputs are written under `output_dir_pred/rank{N}/{run_name}/`.
@@ -517,7 +519,8 @@ A Zarr reader provided in `zarr_reader.py`. It reads pre-processed Zarr stores c
 - loads pre-computed temporal positions directly from `mesh_pos` (no displacement reconstruction)
 - loads pre-computed edges (no connectivity-to-edge conversion needed)
 - dynamically extracts all point data fields (thickness, etc.) from the Zarr store
-- returns `(srcs, dsts, point_data)` similar to VTP reader
+- supports **lazy loading** (`lazy_load: true` by default) so large datasets do not fully materialize at dataset construction—important for multi-GPU training
+- returns `(srcs, dsts, point_data, global_features)` similar to the VTP reader (global features are empty for Zarr)
 
 Data layout expected by Zarr reader:
 - `<DATA_DIR>/*.zarr/` (each `.zarr` directory is treated as one run)
@@ -531,6 +534,7 @@ Example Hydra configuration for the Zarr reader:
 ```yaml
 # conf/reader/zarr.yaml
 _target_: zarr_reader.Reader
+lazy_load: true   # recommended for large datasets and DDP; set false to eager-load all runs
 ```
 
 Select it in your experiment config defaults:

--- a/examples/structural_mechanics/crash/conf/reader/zarr.yaml
+++ b/examples/structural_mechanics/crash/conf/reader/zarr.yaml
@@ -16,3 +16,4 @@
 
 _target_: zarr_reader.Reader
 _convert_: all
+lazy_load: true

--- a/examples/structural_mechanics/crash/datapipe.py
+++ b/examples/structural_mechanics/crash/datapipe.py
@@ -68,6 +68,7 @@ class SimSample:
         self.target_series = target_series
 
     def to(self, device: torch.device):
+        """Move all sample tensors and optional graph data to *device*."""
         for k, v in self.node_features.items():
             self.node_features[k] = v.to(device)
         self.node_target = self.node_target.to(device)
@@ -80,6 +81,7 @@ class SimSample:
         return self
 
     def is_graph(self) -> bool:
+        """Return True when this sample includes a PyG graph."""
         return self.graph is not None
 
     def __repr__(self) -> str:
@@ -197,13 +199,26 @@ class CrashBaseDataset:
                     "training.global_features_filepath=/path/to/global_features.json"
                 )
 
-        self.srcs, self.dsts, point_data, global_features = reader(
+        reader_out = reader(
             data_dir=self.data_dir,
             num_samples=num_samples,
             split=split,
             global_features_filepath=self.global_features_filepath,
             logger=self.logger,
         )
+        if len(reader_out) == 3:
+            self.srcs, self.dsts, point_data = reader_out
+            global_features = []
+        else:
+            self.srcs, self.dsts, point_data, global_features = reader_out
+
+        self._lazy_mode = bool(point_data) and point_data[0].get("_lazy", False)
+        if self._lazy_mode:
+            self._lazy_records = point_data
+            self.logger.info(
+                f"[{self.__class__.__name__}] Lazy Zarr loading enabled; "
+                "samples are materialized on first access."
+            )
         # Check if any global features are present
         # global_features is a list of dictionaries, each containing the global features for a sample
         has_global = global_features and any(gf for gf in global_features)
@@ -227,90 +242,38 @@ class CrashBaseDataset:
             self.global_features = global_features
 
         # Storage for per-sample tensors
-        self.mesh_pos_seq: list[torch.Tensor] = []  # [T,N,3]
-        self.node_features_data: list[torch.Tensor] = []  # [N,F]
+        self.mesh_pos_seq: list[torch.Tensor | None] = []  # [T,N,3]
+        self.node_features_data: list[torch.Tensor | None] = []  # [N,F]
         self._feature_slices: dict[
             str, tuple[int, int]
         ] = {}  # per-sample feature slices
-        self.target_series_data: list[dict[str, torch.Tensor]] = []
+        self.target_series_data: list[dict[str, torch.Tensor] | None] = []
 
-        for rec in point_data:
-            # Coordinates
-            if "coords" not in rec:
-                raise KeyError(f"Missing coordinates key 'coords' in reader record")
-            coords_np = rec["coords"][:num_steps]
-            assert coords_np.ndim == 3 and coords_np.shape[-1] == 3, (
-                f"coords must be [T,N,3], got {coords_np.shape}"
-            )
-            self.mesh_pos_seq.append(torch.as_tensor(coords_np, dtype=torch.float32))
-
-            # Features: concatenate requested keys if present; allow empty
-            parts = []
-            # Static features: use as-is (N,[C])
-            for k in self.static_features:
-                arr = self._get_static_feature(rec, k)
-                if arr.ndim == 1:
-                    arr = arr[:, None]
-                parts.append(arr)
-            # Dynamic features: collect series up to num_steps, flatten to [N, T*C]
-            T = coords_np.shape[0]
-            for k in self.dynamic_features:
-                dyn = self._get_dynamic_feature(rec, k, T)
-                # dyn: [T,N] or [T,N,C] -> [N, T*C]
-                if dyn.ndim == 2:
-                    dyn_flat = dyn.transpose(1, 0)  # [N,T]
-                else:
-                    dyn_flat = dyn.transpose(1, 0, 2).reshape(
-                        dyn.shape[1], -1
-                    )  # [N,T*C]
-                parts.append(dyn_flat)
-
-            feats_np = (
-                np.concatenate(parts, axis=-1)
-                if len(parts) > 0
-                else np.zeros((coords_np.shape[1], 0), dtype=np.float32)
-            )
-            assert feats_np.ndim == 2 and feats_np.shape[0] == coords_np.shape[1], (
-                f"features must be [N,F], got {feats_np.shape}, N mismatch with {coords_np.shape}"
-            )
-
-            # build slice map on first record to make future slicing trivial
-            if len(self._feature_slices) == 0:
-                start = 0
-                for k in self.static_features:
-                    arr_k = self._get_static_feature(rec, k)
-                    width = arr_k.shape[1] if arr_k.ndim > 1 else 1
-                    self._feature_slices[k] = (start, start + width)
-                    start += width
-                for k in self.dynamic_features:
-                    dyn_k = self._get_dynamic_feature(rec, k, T)
-                    width = (
-                        dyn_k.shape[0]
-                        if dyn_k.ndim == 2
-                        else dyn_k.shape[0] * dyn_k.shape[2]
-                    )
-                    # After flattening to [N, width]
-                    self._feature_slices[k] = (start, start + width)
-                    start += width
-
-            self.node_features_data.append(
-                torch.as_tensor(feats_np, dtype=torch.float32)
-            )
-
-            # Collect dynamic target series (kept as [T,N] or [T,N,C])
-            target_series_rec: dict[str, torch.Tensor] = {}
-            for k in self.dynamic_targets:
-                dyn = self._get_dynamic_feature(rec, k, T)  # [T,N] or [T,N,C]
-                target_series_rec[k] = torch.as_tensor(dyn, dtype=torch.float32)
-            self.target_series_data.append(target_series_rec)
+        if self._lazy_mode:
+            self.mesh_pos_seq = [None] * self.num_samples
+            self.node_features_data = [None] * self.num_samples
+            self.target_series_data = [None] * self.num_samples
+            first_rec = self._materialize_record(0)
+            self._build_feature_slices(first_rec)
+            del first_rec
+        else:
+            for rec in point_data:
+                mesh, feats, targets = self._build_tensors_from_record(rec)
+                self.mesh_pos_seq.append(mesh)
+                self.node_features_data.append(feats)
+                self.target_series_data.append(targets)
 
         # Stats (node + generic features)
         node_stats_path = os.path.join(self._stats_dir, NODE_STATS_FILE)
         feat_stats_path = os.path.join(self._stats_dir, FEATURE_STATS_FILE)
 
         if self.split == "train":
-            self.node_stats = self._compute_autoreg_node_stats()
-            self.feature_stats = self._compute_feature_stats()
+            if self._lazy_mode:
+                self.node_stats = self._compute_autoreg_node_stats_lazy()
+                self.feature_stats = self._compute_feature_stats_lazy()
+            else:
+                self.node_stats = self._compute_autoreg_node_stats()
+                self.feature_stats = self._compute_feature_stats()
             save_json(self.node_stats, node_stats_path)
             save_json(self.feature_stats, feat_stats_path)
         else:
@@ -322,25 +285,8 @@ class CrashBaseDataset:
                     f"Node stats file {node_stats_path} or feature stats file {feat_stats_path} not found"
                 )
 
-        # Normalize trajectories and features
-        for i in range(self.num_samples):
-            self.mesh_pos_seq[i] = self._normalize_node_tensor(
-                self.mesh_pos_seq[i],
-                self.node_stats["pos_mean"],
-                self.node_stats["pos_std"],
-            )
-            if self.node_features_data[i].numel() > 0:
-                mu = torch.as_tensor(
-                    self.feature_stats.get("feature_mean", []), dtype=torch.float32
-                )
-                std = torch.as_tensor(
-                    self.feature_stats.get("feature_std", []), dtype=torch.float32
-                )
-                if mu.numel() == 0:
-                    continue
-                self.node_features_data[i] = (
-                    self.node_features_data[i] - mu.view(1, -1)
-                ) / (std.view(1, -1) + EPS)
+        if not self._lazy_mode:
+            self._normalize_loaded_samples()
 
     def __len__(self):
         return self._max_idx
@@ -358,6 +304,7 @@ class CrashBaseDataset:
             assert 0 <= time_idx < self.num_steps - 1, (
                 f"time_idx {time_idx} out of range [0, {self.num_steps - 1})"
             )
+        self._ensure_sample_loaded(batch_idx)
         pos_seq = self.mesh_pos_seq[batch_idx]  # [T,N,3]
         feats = self.node_features_data[batch_idx]  # [N,F]
         T, N, _ = pos_seq.shape
@@ -414,6 +361,213 @@ class CrashBaseDataset:
                 f"target shape {y.shape} does not match expected (N={N}, T={T_out}, Fo={Fo})"
             )
         return x, y
+
+    def _materialize_record(self, batch_idx: int) -> dict:
+        """Load a lazy Zarr record into an in-memory reader dict."""
+        from zarr_reader import materialize_zarr_record
+
+        rec_meta = self._lazy_records[batch_idx]
+        return materialize_zarr_record(
+            rec_meta["_zarr_path"], num_timesteps=self.num_steps
+        )
+
+    def _build_feature_slices(self, rec: dict):
+        if "coords" not in rec:
+            raise KeyError(f"Missing coordinates key 'coords' in reader record")
+        coords_np = rec["coords"][: self.num_steps]
+        T = coords_np.shape[0]
+        start = 0
+        for k in self.static_features:
+            arr_k = self._get_static_feature(rec, k)
+            width = arr_k.shape[1] if arr_k.ndim > 1 else 1
+            self._feature_slices[k] = (start, start + width)
+            start += width
+        for k in self.dynamic_features:
+            dyn_k = self._get_dynamic_feature(rec, k, T)
+            width = (
+                dyn_k.shape[0] if dyn_k.ndim == 2 else dyn_k.shape[0] * dyn_k.shape[2]
+            )
+            self._feature_slices[k] = (start, start + width)
+            start += width
+
+    def _build_tensors_from_record(
+        self, rec: dict
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor]]:
+        if "coords" not in rec:
+            raise KeyError(f"Missing coordinates key 'coords' in reader record")
+        coords_np = rec["coords"][: self.num_steps]
+        assert coords_np.ndim == 3 and coords_np.shape[-1] == 3, (
+            f"coords must be [T,N,3], got {coords_np.shape}"
+        )
+        mesh = torch.as_tensor(coords_np, dtype=torch.float32)
+
+        parts = []
+        T = coords_np.shape[0]
+        for k in self.static_features:
+            arr = self._get_static_feature(rec, k)
+            if arr.ndim == 1:
+                arr = arr[:, None]
+            parts.append(arr)
+        for k in self.dynamic_features:
+            dyn = self._get_dynamic_feature(rec, k, T)
+            if dyn.ndim == 2:
+                dyn_flat = dyn.transpose(1, 0)
+            else:
+                dyn_flat = dyn.transpose(1, 0, 2).reshape(dyn.shape[1], -1)
+            parts.append(dyn_flat)
+
+        feats_np = (
+            np.concatenate(parts, axis=-1)
+            if len(parts) > 0
+            else np.zeros((coords_np.shape[1], 0), dtype=np.float32)
+        )
+        assert feats_np.ndim == 2 and feats_np.shape[0] == coords_np.shape[1], (
+            f"features must be [N,F], got {feats_np.shape}, N mismatch with {coords_np.shape}"
+        )
+
+        if len(self._feature_slices) == 0:
+            self._build_feature_slices(rec)
+
+        feats = torch.as_tensor(feats_np, dtype=torch.float32)
+
+        target_series_rec: dict[str, torch.Tensor] = {}
+        for k in self.dynamic_targets:
+            dyn = self._get_dynamic_feature(rec, k, T)
+            target_series_rec[k] = torch.as_tensor(dyn, dtype=torch.float32)
+
+        return mesh, feats, target_series_rec
+
+    def _normalize_sample_tensors(
+        self,
+        mesh: torch.Tensor,
+        feats: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        mesh = self._normalize_node_tensor(
+            mesh,
+            self.node_stats["pos_mean"],
+            self.node_stats["pos_std"],
+        )
+        if feats.numel() > 0:
+            mu = torch.as_tensor(
+                self.feature_stats.get("feature_mean", []), dtype=torch.float32
+            )
+            std = torch.as_tensor(
+                self.feature_stats.get("feature_std", []), dtype=torch.float32
+            )
+            if mu.numel() > 0:
+                feats = (feats - mu.view(1, -1)) / (std.view(1, -1) + EPS)
+        return mesh, feats
+
+    def _normalize_loaded_samples(self):
+        for i in range(self.num_samples):
+            mesh, feats = self._normalize_sample_tensors(
+                self.mesh_pos_seq[i], self.node_features_data[i]
+            )
+            self.mesh_pos_seq[i] = mesh
+            self.node_features_data[i] = feats
+
+    def _load_sample_tensors(
+        self, batch_idx: int, *, retain: bool = True, normalize: bool = True
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor]]:
+        if not self._lazy_mode:
+            mesh = self.mesh_pos_seq[batch_idx]
+            feats = self.node_features_data[batch_idx]
+            targets = self.target_series_data[batch_idx]
+            if normalize:
+                mesh, feats = self._normalize_sample_tensors(mesh, feats)
+            return mesh, feats, targets
+
+        if retain and self.mesh_pos_seq[batch_idx] is not None:
+            return (
+                self.mesh_pos_seq[batch_idx],
+                self.node_features_data[batch_idx],
+                self.target_series_data[batch_idx],
+            )
+
+        rec = self._materialize_record(batch_idx)
+        mesh, feats, targets = self._build_tensors_from_record(rec)
+        if normalize:
+            mesh, feats = self._normalize_sample_tensors(mesh, feats)
+
+        if retain:
+            self.mesh_pos_seq[batch_idx] = mesh
+            self.node_features_data[batch_idx] = feats
+            self.target_series_data[batch_idx] = targets
+
+        return mesh, feats, targets
+
+    def _ensure_sample_loaded(self, batch_idx: int):
+        if self._lazy_mode and self.mesh_pos_seq[batch_idx] is None:
+            self._load_sample_tensors(batch_idx, retain=True)
+
+    def _compute_autoreg_node_stats_lazy(self):
+        pos_mean = torch.zeros(3, dtype=torch.float32)
+        pos_meansqr = torch.zeros(3, dtype=torch.float32)
+        for i in range(self.num_samples):
+            mesh, _, _ = self._load_sample_tensors(i, retain=False, normalize=False)
+            pos_mean += torch.mean(mesh, dim=(0, 1)) / self.num_samples
+            pos_meansqr += torch.mean(mesh * mesh, dim=(0, 1)) / self.num_samples
+
+        pos_var = torch.clamp(pos_meansqr - pos_mean * pos_mean, min=0.0)
+        pos_std = torch.sqrt(pos_var + EPS)
+
+        dt = self.dt
+        vel_mean = torch.zeros(3, dtype=torch.float32)
+        vel_meansqr = torch.zeros(3, dtype=torch.float32)
+        for i in range(self.num_samples):
+            mesh, _, _ = self._load_sample_tensors(i, retain=False, normalize=False)
+            vel = (mesh[1:] - mesh[:-1]) / dt
+            vel = vel / pos_std
+            vel_mean += torch.mean(vel, dim=(0, 1)) / self.num_samples
+            vel_meansqr += torch.mean(vel * vel, dim=(0, 1)) / self.num_samples
+        vel_var = torch.clamp(vel_meansqr - vel_mean * vel_mean, min=0.0)
+        vel_std = torch.sqrt(vel_var + EPS)
+
+        acc_mean = torch.zeros(3, dtype=torch.float32)
+        acc_meansqr = torch.zeros(3, dtype=torch.float32)
+        for i in range(self.num_samples):
+            mesh, _, _ = self._load_sample_tensors(i, retain=False, normalize=False)
+            acc = (mesh[:-2] + mesh[2:] - 2 * mesh[1:-1]) / (dt * dt)
+            acc = acc / pos_std
+            acc_mean += torch.mean(acc, dim=(0, 1)) / self.num_samples
+            acc_meansqr += torch.mean(acc * acc, dim=(0, 1)) / self.num_samples
+        acc_var = torch.clamp(acc_meansqr - acc_mean * acc_mean, min=0.0)
+        acc_std = torch.sqrt(acc_var + EPS)
+
+        return {
+            "pos_mean": pos_mean,
+            "pos_std": pos_std,
+            "norm_vel_mean": vel_mean,
+            "norm_vel_std": vel_std,
+            "norm_acc_mean": acc_mean,
+            "norm_acc_std": acc_std,
+        }
+
+    def _compute_feature_stats_lazy(self):
+        if not self.static_features and not self.dynamic_features:
+            mu = torch.zeros(0, dtype=torch.float32)
+            std = torch.ones(0, dtype=torch.float32)
+            return {"feature_mean": mu, "feature_std": std}
+
+        feat_mean = None
+        feat_meansqr = None
+        fdim = None
+        for i in range(self.num_samples):
+            _, feats, _ = self._load_sample_tensors(i, retain=False, normalize=False)
+            x = feats.to(torch.float32)
+            if fdim is None:
+                fdim = x.shape[1]
+            assert x.shape[1] == fdim, f"Feature dim mismatch: {x.shape[1]} vs {fdim}"
+            m = torch.mean(x, dim=0)
+            msq = torch.mean(x * x, dim=0)
+            feat_mean = m if feat_mean is None else feat_mean + m / self.num_samples
+            feat_meansqr = (
+                msq if feat_meansqr is None else feat_meansqr + msq / self.num_samples
+            )
+
+        feat_var = torch.clamp(feat_meansqr - feat_mean * feat_mean, min=0.0)
+        feat_std = torch.sqrt(feat_var + EPS)
+        return {"feature_mean": feat_mean, "feature_std": feat_std}
 
     # ---- stats helpers ----
     def _compute_autoreg_node_stats(self):
@@ -581,23 +735,28 @@ class CrashGraphDataset(CrashBaseDataset):
             _dsts.append(np.asarray(dst)[mask])
         self.srcs, self.dsts = _srcs, _dsts
 
-        Data = _pyg_data.Data
-        self.graphs = []
-        for i in range(self.num_samples):
-            g = self.create_graph(
-                self.srcs[i],
-                self.dsts[i],
-                num_nodes=self.mesh_pos_seq[i][0].shape[0],
-                dtype=torch.long,
-            )
-            pos0 = self.mesh_pos_seq[i][0]
-            g = self.add_edge_features(g, pos0)
-            self.graphs.append(g)
+        self.graphs: list[Any | None] = []
+        if self._lazy_mode:
+            self.graphs = [None] * self.num_samples
+        else:
+            for i in range(self.num_samples):
+                g = self.create_graph(
+                    self.srcs[i],
+                    self.dsts[i],
+                    num_nodes=self.mesh_pos_seq[i][0].shape[0],
+                    dtype=torch.long,
+                )
+                pos0 = self.mesh_pos_seq[i][0]
+                g = self.add_edge_features(g, pos0)
+                self.graphs.append(g)
 
         # Edge stats
         edge_stats_path = os.path.join(self._stats_dir, EDGE_STATS_FILE)
         if self.split == "train":
-            self.edge_stats = self._compute_edge_stats()
+            if self._lazy_mode:
+                self.edge_stats = self._compute_edge_stats_lazy()
+            else:
+                self.edge_stats = self._compute_edge_stats()
             save_json(self.edge_stats, edge_stats_path)
         else:
             if os.path.exists(edge_stats_path):
@@ -613,17 +772,66 @@ class CrashGraphDataset(CrashBaseDataset):
             self.edge_stats["edge_std"], dtype=torch.float32
         )
 
-        # Normalize edge features
+        if not self._lazy_mode:
+            for i in range(self.num_samples):
+                self.graphs[i].edge_attr = self._normalize_edge(
+                    self.graphs[i].edge_attr,
+                    self.edge_stats["edge_mean"],
+                    self.edge_stats["edge_std"],
+                )
+
+    def _ensure_graph_loaded(self, batch_idx: int):
+        if not self._lazy_mode:
+            return
+        if self.graphs[batch_idx] is not None:
+            return
+        self._ensure_sample_loaded(batch_idx)
+        g = self.create_graph(
+            self.srcs[batch_idx],
+            self.dsts[batch_idx],
+            num_nodes=self.mesh_pos_seq[batch_idx][0].shape[0],
+            dtype=torch.long,
+        )
+        pos0 = self.mesh_pos_seq[batch_idx][0]
+        g = self.add_edge_features(g, pos0)
+        g.edge_attr = self._normalize_edge(
+            g.edge_attr,
+            self.edge_stats["edge_mean"],
+            self.edge_stats["edge_std"],
+        )
+        self.graphs[batch_idx] = g
+
+    def _compute_edge_stats_lazy(self):
+        edge_mean = None
+        edge_meansqr = None
         for i in range(self.num_samples):
-            self.graphs[i].edge_attr = self._normalize_edge(
-                self.graphs[i].edge_attr,
-                self.edge_stats["edge_mean"],
-                self.edge_stats["edge_std"],
+            mesh, _, _ = self._load_sample_tensors(i, retain=False, normalize=False)
+            g = self.create_graph(
+                self.srcs[i],
+                self.dsts[i],
+                num_nodes=mesh[0].shape[0],
+                dtype=torch.long,
             )
+            g = self.add_edge_features(g, mesh[0])
+            x_e = g.edge_attr.to(torch.float32)
+            m = torch.mean(x_e, dim=0)
+            msq = torch.mean(x_e * x_e, dim=0)
+            edge_mean = m if edge_mean is None else edge_mean + m / self.num_samples
+            edge_meansqr = (
+                msq if edge_meansqr is None else edge_meansqr + msq / self.num_samples
+            )
+
+        edge_var = torch.clamp(edge_meansqr - edge_mean * edge_mean, min=0.0)
+        edge_std = torch.sqrt(edge_var + EPS)
+        return {
+            "edge_mean": edge_mean,
+            "edge_std": edge_std,
+        }
 
     def __getitem__(self, idx: int):
         assert 0 <= idx < self._max_idx, f"Index {idx} out of range"
         batch_idx, time_idx = self._resolve_idx(idx)
+        self._ensure_graph_loaded(batch_idx)
         g = self.graphs[batch_idx]
         x, y = self.build_xy(batch_idx, time_idx)
         if self.global_features is not None:
@@ -649,6 +857,7 @@ class CrashGraphDataset(CrashBaseDataset):
     # ----- graph-specific helpers (use _pyg_data / _pyg_utils so PyG loads only when used) -----
     @staticmethod
     def create_graph(src, dst, num_nodes: int, dtype=torch.long):
+        """Build a bidirectional PyG graph with self-loops from edge lists."""
         src = torch.as_tensor(src, dtype=dtype)
         dst = torch.as_tensor(dst, dtype=dtype)
         edge_index = torch.stack(
@@ -660,6 +869,7 @@ class CrashGraphDataset(CrashBaseDataset):
 
     @staticmethod
     def add_edge_features(data, pos: torch.Tensor):
+        """Attach displacement and distance edge features from t0 positions."""
         # data: PyG Data; pos: [N,3]
         row, col = data.edge_index
         pos_t = torch.as_tensor(pos, dtype=torch.float32)

--- a/examples/structural_mechanics/crash/datapipe.py
+++ b/examples/structural_mechanics/crash/datapipe.py
@@ -881,14 +881,17 @@ class CrashGraphDataset(CrashBaseDataset):
     def _compute_edge_stats(self):
         edge_mean = None
         edge_meansqr = None
+        edge_dim = None
         for i in range(self.num_samples):
             x_e = self.graphs[i].edge_attr.to(torch.float32)  # [E,De]
+            if edge_dim is None:
+                edge_dim = x_e.shape[1]
+                edge_mean = torch.zeros(edge_dim, dtype=torch.float32)
+                edge_meansqr = torch.zeros(edge_dim, dtype=torch.float32)
             m = torch.mean(x_e, dim=0)
             msq = torch.mean(x_e * x_e, dim=0)
-            edge_mean = m if edge_mean is None else edge_mean + m / self.num_samples
-            edge_meansqr = (
-                msq if edge_meansqr is None else edge_meansqr + msq / self.num_samples
-            )
+            edge_mean += m / self.num_samples
+            edge_meansqr += msq / self.num_samples
 
         edge_var = torch.clamp(edge_meansqr - edge_mean * edge_mean, min=0.0)
         edge_std = torch.sqrt(edge_var + EPS)

--- a/examples/structural_mechanics/crash/datapipe.py
+++ b/examples/structural_mechanics/crash/datapipe.py
@@ -470,12 +470,11 @@ class CrashBaseDataset:
         self, batch_idx: int, *, retain: bool = True, normalize: bool = True
     ) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor]]:
         if not self._lazy_mode:
-            mesh = self.mesh_pos_seq[batch_idx]
-            feats = self.node_features_data[batch_idx]
-            targets = self.target_series_data[batch_idx]
-            if normalize:
-                mesh, feats = self._normalize_sample_tensors(mesh, feats)
-            return mesh, feats, targets
+            return (
+                self.mesh_pos_seq[batch_idx],
+                self.node_features_data[batch_idx],
+                self.target_series_data[batch_idx],
+            )
 
         if retain and self.mesh_pos_seq[batch_idx] is not None:
             return (
@@ -549,21 +548,19 @@ class CrashBaseDataset:
             std = torch.ones(0, dtype=torch.float32)
             return {"feature_mean": mu, "feature_std": std}
 
-        feat_mean = None
-        feat_meansqr = None
-        fdim = None
+        first_feats = self._load_sample_tensors(0, retain=False, normalize=False)[1]
+        fdim = first_feats.shape[1]
+
+        feat_mean = torch.zeros(fdim, dtype=torch.float32)
+        feat_meansqr = torch.zeros(fdim, dtype=torch.float32)
         for i in range(self.num_samples):
             _, feats, _ = self._load_sample_tensors(i, retain=False, normalize=False)
             x = feats.to(torch.float32)
-            if fdim is None:
-                fdim = x.shape[1]
             assert x.shape[1] == fdim, f"Feature dim mismatch: {x.shape[1]} vs {fdim}"
             m = torch.mean(x, dim=0)
             msq = torch.mean(x * x, dim=0)
-            feat_mean = m if feat_mean is None else feat_mean + m / self.num_samples
-            feat_meansqr = (
-                msq if feat_meansqr is None else feat_meansqr + msq / self.num_samples
-            )
+            feat_mean += m / self.num_samples
+            feat_meansqr += msq / self.num_samples
 
         feat_var = torch.clamp(feat_meansqr - feat_mean * feat_mean, min=0.0)
         feat_std = torch.sqrt(feat_var + EPS)
@@ -804,8 +801,9 @@ class CrashGraphDataset(CrashBaseDataset):
     def _compute_edge_stats_lazy(self):
         edge_mean = None
         edge_meansqr = None
+        edge_dim = None
         for i in range(self.num_samples):
-            mesh, _, _ = self._load_sample_tensors(i, retain=False, normalize=False)
+            mesh, _, _ = self._load_sample_tensors(i, retain=False, normalize=True)
             g = self.create_graph(
                 self.srcs[i],
                 self.dsts[i],
@@ -814,12 +812,14 @@ class CrashGraphDataset(CrashBaseDataset):
             )
             g = self.add_edge_features(g, mesh[0])
             x_e = g.edge_attr.to(torch.float32)
+            if edge_dim is None:
+                edge_dim = x_e.shape[1]
+                edge_mean = torch.zeros(edge_dim, dtype=torch.float32)
+                edge_meansqr = torch.zeros(edge_dim, dtype=torch.float32)
             m = torch.mean(x_e, dim=0)
             msq = torch.mean(x_e * x_e, dim=0)
-            edge_mean = m if edge_mean is None else edge_mean + m / self.num_samples
-            edge_meansqr = (
-                msq if edge_meansqr is None else edge_meansqr + msq / self.num_samples
-            )
+            edge_mean += m / self.num_samples
+            edge_meansqr += msq / self.num_samples
 
         edge_var = torch.clamp(edge_meansqr - edge_mean * edge_mean, min=0.0)
         edge_std = torch.sqrt(edge_var + EPS)

--- a/examples/structural_mechanics/crash/tests/test_datapipe_lazy.py
+++ b/examples/structural_mechanics/crash/tests/test_datapipe_lazy.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import datapipe
+import zarr_reader
+
+
+def _create_store(store_path: Path, num_timesteps: int = 4, num_nodes: int = 5):
+    store_path.mkdir(exist_ok=True)
+    mesh_pos = np.random.randn(num_timesteps, num_nodes, 3).astype(np.float32)
+    thickness = np.ones(num_nodes, dtype=np.float32)
+    edges = np.array([[0, 1], [1, 2], [2, 3]], dtype=np.int64)
+    store = zarr.open(str(store_path), mode="w")
+    store.create_array("mesh_pos", data=mesh_pos)
+    store.create_array("thickness", data=thickness)
+    store.create_array("edges", data=edges)
+    return mesh_pos
+
+
+@pytest.fixture
+def lazy_zarr_dir():
+    """Temporary directory with two mock Zarr crash stores."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        for i in range(2):
+            _create_store(temp_path / f"Run{i:03d}.zarr")
+        yield temp_dir
+
+
+def test_lazy_datapipe_defers_materialization(lazy_zarr_dir):
+    """Lazy datasets keep mesh tensors unset until __getitem__ is called."""
+    reader = zarr_reader.Reader(lazy_load=True)
+    stats_dir = Path(lazy_zarr_dir) / "stats"
+
+    dataset = datapipe.CrashPointCloudDataset(
+        reader=reader,
+        data_dir=lazy_zarr_dir,
+        split="train",
+        num_samples=2,
+        num_steps=4,
+        static_features=["thickness"],
+        stats_dir=str(stats_dir),
+    )
+
+    assert dataset._lazy_mode is True
+    assert dataset.mesh_pos_seq == [None, None]
+
+    sample = dataset[0]
+    assert sample.node_features["coords"].shape == (5, 3)
+    assert dataset.mesh_pos_seq[0] is not None
+    assert dataset.mesh_pos_seq[1] is None

--- a/examples/structural_mechanics/crash/tests/test_datapipe_lazy.py
+++ b/examples/structural_mechanics/crash/tests/test_datapipe_lazy.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import torch
 import zarr
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -30,7 +31,10 @@ import zarr_reader
 
 def _create_store(store_path: Path, num_timesteps: int = 4, num_nodes: int = 5):
     store_path.mkdir(exist_ok=True)
-    mesh_pos = np.random.randn(num_timesteps, num_nodes, 3).astype(np.float32)
+    mesh_pos = np.arange(num_timesteps * num_nodes * 3, dtype=np.float32).reshape(
+        num_timesteps, num_nodes, 3
+    )
+    mesh_pos *= np.array([3.0, 5.0, 7.0], dtype=np.float32)
     thickness = np.ones(num_nodes, dtype=np.float32)
     edges = np.array([[0, 1], [1, 2], [2, 3]], dtype=np.int64)
     store = zarr.open(str(store_path), mode="w")
@@ -72,3 +76,32 @@ def test_lazy_datapipe_defers_materialization(lazy_zarr_dir):
     assert sample.node_features["coords"].shape == (5, 3)
     assert dataset.mesh_pos_seq[0] is not None
     assert dataset.mesh_pos_seq[1] is None
+
+
+def test_lazy_graph_matches_eager_edge_normalization(lazy_zarr_dir):
+    """Lazy and eager graphs use the same position scale for edge features."""
+    common_kwargs = {
+        "data_dir": lazy_zarr_dir,
+        "split": "train",
+        "num_samples": 2,
+        "num_steps": 4,
+        "static_features": ["thickness"],
+    }
+    eager = datapipe.CrashGraphDataset(
+        reader=zarr_reader.Reader(lazy_load=False),
+        stats_dir=str(Path(lazy_zarr_dir) / "eager_stats"),
+        **common_kwargs,
+    )
+    lazy = datapipe.CrashGraphDataset(
+        reader=zarr_reader.Reader(lazy_load=True),
+        stats_dir=str(Path(lazy_zarr_dir) / "lazy_stats"),
+        **common_kwargs,
+    )
+
+    torch.testing.assert_close(
+        lazy.edge_stats["edge_mean"], eager.edge_stats["edge_mean"]
+    )
+    torch.testing.assert_close(
+        lazy.edge_stats["edge_std"], eager.edge_stats["edge_std"]
+    )
+    torch.testing.assert_close(lazy[0].graph.edge_attr, eager[0].graph.edge_attr)

--- a/examples/structural_mechanics/crash/tests/test_zarr_reader.py
+++ b/examples/structural_mechanics/crash/tests/test_zarr_reader.py
@@ -55,9 +55,9 @@ def create_mock_zarr_store(
 
     # Write to Zarr store
     store = zarr.open(str(store_path), mode="w")
-    store.create_dataset("mesh_pos", data=mesh_pos, dtype=np.float32)
-    store.create_dataset("thickness", data=node_thickness, dtype=np.float32)
-    store.create_dataset("edges", data=edges, dtype=np.int64)
+    store.create_array("mesh_pos", data=mesh_pos)
+    store.create_array("thickness", data=node_thickness)
+    store.create_array("edges", data=edges)
 
     return mesh_pos, node_thickness, edges
 
@@ -153,7 +153,7 @@ def test_load_zarr_store_missing_fields():
 
         # Create store with only thickness (missing mesh_pos and edges)
         store = zarr.open(str(store_path), mode="w")
-        store.create_dataset("thickness", data=np.ones(4, dtype=np.float32))
+        store.create_array("thickness", data=np.ones(4, dtype=np.float32))
 
         # Should raise KeyError for missing mesh_pos
         with pytest.raises(KeyError, match="mesh_pos"):
@@ -163,7 +163,7 @@ def test_load_zarr_store_missing_fields():
         store_path2 = Path(temp_dir) / "incomplete2.zarr"
         store_path2.mkdir()
         store2 = zarr.open(str(store_path2), mode="w")
-        store2.create_dataset(
+        store2.create_array(
             "mesh_pos", data=np.random.randn(3, 4, 3).astype(np.float32)
         )
 
@@ -181,20 +181,18 @@ def test_load_zarr_store_multiple_point_data_fields():
         # Create store with multiple point data fields
         num_nodes = 10
         store = zarr.open(str(store_path), mode="w")
-        store.create_dataset(
+        store.create_array(
             "mesh_pos", data=np.random.randn(3, num_nodes, 3).astype(np.float32)
         )
-        store.create_dataset("edges", data=np.array([[0, 1]], dtype=np.int64))
+        store.create_array("edges", data=np.array([[0, 1]], dtype=np.int64))
         # Add multiple point data fields
-        store.create_dataset("thickness", data=np.ones(num_nodes, dtype=np.float32))
-        store.create_dataset(
-            "stress", data=np.random.randn(num_nodes).astype(np.float32)
-        )
-        store.create_dataset(
+        store.create_array("thickness", data=np.ones(num_nodes, dtype=np.float32))
+        store.create_array("stress", data=np.random.randn(num_nodes).astype(np.float32))
+        store.create_array(
             "temperature", data=np.random.randn(num_nodes).astype(np.float32)
         )
         # This should be skipped (mesh connectivity, not point data)
-        store.create_dataset(
+        store.create_array(
             "mesh_connectivity_flat", data=np.array([0, 1, 2], dtype=np.int64)
         )
 
@@ -228,15 +226,15 @@ def test_load_zarr_store_2d_feature_arrays():
         num_nodes = 8
         feature_dim = 3
         store = zarr.open(str(store_path), mode="w")
-        store.create_dataset(
+        store.create_array(
             "mesh_pos", data=np.random.randn(3, num_nodes, 3).astype(np.float32)
         )
-        store.create_dataset("edges", data=np.array([[0, 1]], dtype=np.int64))
+        store.create_array("edges", data=np.array([[0, 1]], dtype=np.int64))
         # Add 1D feature (thickness)
-        store.create_dataset("thickness", data=np.ones(num_nodes, dtype=np.float32))
+        store.create_array("thickness", data=np.ones(num_nodes, dtype=np.float32))
         # Add 2D feature array [N, K] (e.g., stress tensor components)
         stress_tensor = np.random.randn(num_nodes, feature_dim).astype(np.float32)
-        store.create_dataset("stress_tensor", data=stress_tensor)
+        store.create_array("stress_tensor", data=stress_tensor)
 
         mesh_pos, edges, point_data_dict = zarr_reader.load_zarr_store(str(store_path))
 
@@ -309,11 +307,11 @@ def test_process_zarr_data_validation():
 
         # Create store with invalid mesh_pos shape (should be [T,N,3])
         store = zarr.open(str(store_path), mode="w")
-        store.create_dataset(
+        store.create_array(
             "mesh_pos", data=np.random.randn(3, 4, 2).astype(np.float32)
         )  # Wrong last dim
-        store.create_dataset("thickness", data=np.ones(4, dtype=np.float32))
-        store.create_dataset("edges", data=np.array([[0, 1]], dtype=np.int64))
+        store.create_array("thickness", data=np.ones(4, dtype=np.float32))
+        store.create_array("edges", data=np.array([[0, 1]], dtype=np.int64))
 
         with pytest.raises(ValueError, match="mesh_pos must be"):
             zarr_reader.process_zarr_data(
@@ -330,12 +328,12 @@ def test_process_zarr_data_edge_bounds():
 
         num_nodes = 4
         store = zarr.open(str(store_path), mode="w")
-        store.create_dataset(
+        store.create_array(
             "mesh_pos", data=np.random.randn(3, num_nodes, 3).astype(np.float32)
         )
-        store.create_dataset("thickness", data=np.ones(num_nodes, dtype=np.float32))
+        store.create_array("thickness", data=np.ones(num_nodes, dtype=np.float32))
         # Edge references node 10 which is out of bounds
-        store.create_dataset("edges", data=np.array([[0, 10]], dtype=np.int64))
+        store.create_array("edges", data=np.array([[0, 10]], dtype=np.int64))
 
         with pytest.raises(ValueError, match="Edge indices out of bounds"):
             zarr_reader.process_zarr_data(
@@ -346,9 +344,9 @@ def test_process_zarr_data_edge_bounds():
 
 def test_reader_class(mock_zarr_directory):
     """Test the Reader class callable interface."""
-    reader = zarr_reader.Reader()
+    reader = zarr_reader.Reader(lazy_load=False)
 
-    srcs, dsts, point_data = reader(
+    srcs, dsts, point_data, global_features = reader(
         data_dir=mock_zarr_directory,
         num_samples=2,
         split="train",
@@ -357,6 +355,58 @@ def test_reader_class(mock_zarr_directory):
     assert len(srcs) == 2
     assert len(dsts) == 2
     assert len(point_data) == 2
+    assert global_features == []
+
+
+def test_reader_lazy_load(mock_zarr_directory):
+    """Lazy reader returns handles without materialized coordinates."""
+    reader = zarr_reader.Reader(lazy_load=True)
+
+    srcs, dsts, point_data, global_features = reader(
+        data_dir=mock_zarr_directory,
+        num_samples=2,
+    )
+
+    assert len(point_data) == 2
+    assert global_features == []
+    for rec in point_data:
+        assert rec["_lazy"] is True
+        assert "_zarr_path" in rec
+        assert "_num_nodes" in rec
+        assert "coords" not in rec
+
+
+def test_materialize_zarr_record(mock_zarr_store):
+    """Materializing a lazy record matches eager load_zarr_store output."""
+    temp_dir, expected_mesh_pos, expected_thickness, expected_edges = mock_zarr_store
+    store_path = Path(temp_dir) / "Run001.zarr"
+
+    record = zarr_reader.materialize_zarr_record(str(store_path))
+
+    assert "coords" in record
+    assert "thickness" in record
+    np.testing.assert_array_almost_equal(record["coords"], expected_mesh_pos)
+    np.testing.assert_array_almost_equal(record["thickness"], expected_thickness)
+
+
+def test_process_zarr_data_lazy(mock_zarr_directory):
+    """Lazy processing validates stores without loading full mesh arrays."""
+    srcs, dsts, point_data = zarr_reader.process_zarr_data(
+        data_dir=mock_zarr_directory,
+        num_samples=2,
+        lazy_load=True,
+    )
+
+    assert len(srcs) == 2
+    assert len(dsts) == 2
+    assert len(point_data) == 2
+    assert all(rec["_lazy"] for rec in point_data)
+    assert all("coords" not in rec for rec in point_data)
+
+    materialized = zarr_reader.materialize_zarr_record(
+        point_data[0]["_zarr_path"], num_timesteps=3
+    )
+    assert materialized["coords"].shape[0] == 3
 
 
 def test_natural_sorting(mock_zarr_directory):

--- a/examples/structural_mechanics/crash/train.py
+++ b/examples/structural_mechanics/crash/train.py
@@ -80,6 +80,12 @@ class Trainer:
         # Dataset
         reader = instantiate(cfg.reader)
         logging.getLogger().setLevel(logging.INFO)
+        if self.dist.world_size > 1 and getattr(reader, "lazy_load", False):
+            logger0.info(
+                "Multi-GPU training with lazy Zarr loading: DistributedSampler "
+                "shards sample indices only; lazy_load=true materializes each run "
+                "when its index is accessed instead of at dataset construction."
+            )
         dataset = instantiate(
             cfg.datapipe,
             name="crash_train",
@@ -238,6 +244,7 @@ class Trainer:
             self.writer = SummaryWriter(log_dir=cfg.training.tensorboard_log_dir)
 
     def train(self, sample: SimSample):
+        """Run one training step on a single collated sample."""
         self.optimizer.zero_grad()
         loss = self.forward(sample)
         self.backward(loss)
@@ -300,6 +307,7 @@ class Trainer:
 
 @hydra.main(version_base="1.3", config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
+    """Hydra entry point for crash model training."""
     DistributedManager.initialize()
     dist = DistributedManager()
 

--- a/examples/structural_mechanics/crash/zarr_reader.py
+++ b/examples/structural_mechanics/crash/zarr_reader.py
@@ -49,12 +49,90 @@ def find_zarr_stores(base_data_dir: str) -> list[str]:
     return sorted(zarr_stores, key=natural_key)
 
 
-def load_zarr_store(zarr_path: str):
+def _validate_point_data_shapes(
+    store,
+    zarr_path: str,
+    num_nodes: int,
+):
+    """Validate point-data array shapes using Zarr metadata only."""
+    for name in store.keys():
+        if name in ("mesh_pos", "edges"):
+            continue
+        if name.startswith("mesh_connectivity_"):
+            continue
+
+        data = store[name]
+        if data.ndim == 1:
+            if data.shape[0] != num_nodes:
+                raise ValueError(
+                    f"Point data '{name}' length {data.shape[0]} doesn't match "
+                    f"number of nodes {num_nodes} in {zarr_path}"
+                )
+        elif data.ndim == 2:
+            if data.shape[0] != num_nodes:
+                raise ValueError(
+                    f"Point data '{name}' shape {data.shape} doesn't match "
+                    f"number of nodes {num_nodes} in {zarr_path}"
+                )
+        else:
+            raise ValueError(
+                f"Point data '{name}' must be [N] or [N,K], got shape {data.shape} in {zarr_path}"
+            )
+
+
+def validate_zarr_store(zarr_path: str) -> int:
+    """
+    Validate a Zarr store and return the number of mesh nodes.
+
+    Reads only metadata and edge indices (small arrays), not full mesh trajectories.
+    """
+    store = zarr.open(zarr_path, mode="r")
+
+    if "mesh_pos" not in store:
+        raise KeyError(f"'mesh_pos' not found in Zarr store {zarr_path}")
+    mesh_pos = store["mesh_pos"]
+    if mesh_pos.ndim != 3 or mesh_pos.shape[-1] != 3:
+        raise ValueError(
+            f"mesh_pos must be [T,N,3], got {mesh_pos.shape} in {zarr_path}"
+        )
+
+    if "edges" not in store:
+        raise KeyError(f"'edges' not found in Zarr store {zarr_path}")
+    edges = store["edges"]
+    if edges.ndim != 2 or edges.shape[-1] != 2:
+        raise ValueError(f"edges must be [E,2], got {edges.shape} in {zarr_path}")
+
+    num_nodes = mesh_pos.shape[1]
+    _validate_point_data_shapes(store, zarr_path, num_nodes)
+
+    edges_arr = np.array(edges[:], dtype=np.int64)
+    if edges_arr.size > 0:
+        if edges_arr.min() < 0 or edges_arr.max() >= num_nodes:
+            raise ValueError(
+                f"Edge indices out of bounds [0, {num_nodes - 1}] in {zarr_path}"
+            )
+
+    return num_nodes
+
+
+def load_zarr_edges(zarr_path: str):
+    """Load edge connectivity from a Zarr store."""
+    store = zarr.open(zarr_path, mode="r")
+    if "edges" not in store:
+        raise KeyError(f"'edges' not found in Zarr store {zarr_path}")
+    edges = np.array(store["edges"][:], dtype=np.int64)
+    if edges.ndim != 2 or edges.shape[-1] != 2:
+        raise ValueError(f"edges must be [E,2], got {edges.shape} in {zarr_path}")
+    return edges
+
+
+def load_zarr_store(zarr_path: str, num_timesteps: int | None = None):
     """
     Load mesh positions, edges, and all point data fields from a Zarr store.
 
     Args:
         zarr_path: Path to the Zarr store directory.
+        num_timesteps: Optional cap on timesteps read from ``mesh_pos``.
 
     Returns:
         mesh_pos: (timesteps, num_nodes, 3) temporal positions
@@ -63,34 +141,81 @@ def load_zarr_store(zarr_path: str):
     """
     store = zarr.open(zarr_path, mode="r")
 
-    # Read mesh positions (temporal coordinates)
     if "mesh_pos" not in store:
         raise KeyError(f"'mesh_pos' not found in Zarr store {zarr_path}")
-    mesh_pos = np.array(store["mesh_pos"][:], dtype=np.float64)
+    mesh_pos_arr = store["mesh_pos"]
+    if num_timesteps is not None:
+        mesh_pos = np.array(mesh_pos_arr[:num_timesteps], dtype=np.float64)
+    else:
+        mesh_pos = np.array(mesh_pos_arr[:], dtype=np.float64)
 
-    # Read edges
     if "edges" not in store:
         raise KeyError(f"'edges' not found in Zarr store {zarr_path}")
     edges = np.array(store["edges"][:], dtype=np.int64)
 
-    # Extract all other datasets as point data (excluding mesh-level data)
-    # Skip: mesh_pos, edges, mesh_connectivity_* (these are not per-node features)
     point_data_dict = {}
     for name in store.keys():
         if name in ("mesh_pos", "edges"):
             continue
         if name.startswith("mesh_connectivity_"):
             continue
-        # Read as point data feature
         point_data_dict[name] = np.array(store[name][:], dtype=np.float32)
 
     return mesh_pos, edges, point_data_dict
+
+
+def materialize_zarr_record(
+    zarr_path: str,
+    num_timesteps: int | None = None,
+) -> dict:
+    """
+    Materialize a lazy Zarr record into an in-memory reader dict.
+
+    Returns a dict with ``coords`` and all point-data fields, matching the eager
+    reader output.
+    """
+    mesh_pos, edges, point_data_dict = load_zarr_store(
+        zarr_path, num_timesteps=num_timesteps
+    )
+    num_nodes = mesh_pos.shape[1]
+
+    if mesh_pos.ndim != 3 or mesh_pos.shape[-1] != 3:
+        raise ValueError(
+            f"mesh_pos must be [T,N,3], got {mesh_pos.shape} in {zarr_path}"
+        )
+    if edges.ndim != 2 or edges.shape[-1] != 2:
+        raise ValueError(f"edges must be [E,2], got {edges.shape} in {zarr_path}")
+
+    for name, data in point_data_dict.items():
+        if data.ndim == 1:
+            if len(data) != num_nodes:
+                raise ValueError(
+                    f"Point data '{name}' length {len(data)} doesn't match "
+                    f"number of nodes {num_nodes} in {zarr_path}"
+                )
+        elif data.ndim == 2:
+            if data.shape[0] != num_nodes:
+                raise ValueError(
+                    f"Point data '{name}' shape {data.shape} doesn't match "
+                    f"number of nodes {num_nodes} in {zarr_path}"
+                )
+
+    if edges.size > 0:
+        if edges.min() < 0 or edges.max() >= num_nodes:
+            raise ValueError(
+                f"Edge indices out of bounds [0, {num_nodes - 1}] in {zarr_path}"
+            )
+
+    record = {"coords": mesh_pos}
+    record.update(point_data_dict)
+    return record
 
 
 def process_zarr_data(
     data_dir: str,
     num_samples: int,
     logger=None,
+    lazy_load: bool = False,
 ):
     """
     Process Zarr crash simulation data from a given directory.
@@ -98,15 +223,21 @@ def process_zarr_data(
     Each .zarr store is treated as one sample. Reads mesh positions, edges,
     and all available point data fields (e.g., thickness, etc.) from the Zarr stores.
 
+    When ``lazy_load=True``, only edge connectivity is loaded eagerly. Mesh
+    trajectories and point features are loaded on demand via
+    :func:`materialize_zarr_record`.
+
     Args:
         data_dir: Directory containing .zarr stores
         num_samples: Maximum number of samples to process
         logger: Optional logger for logging progress
+        lazy_load: Defer loading heavy mesh/point arrays until materialization
 
     Returns:
         srcs: List of source node indices for edges (one array per sample)
         dsts: List of destination node indices for edges (one array per sample)
-        point_data_all: List of dicts with 'coords' and all point data fields
+        point_data_all: List of dicts with 'coords' and all point data fields,
+            or lazy handles when ``lazy_load=True``.
     """
     zarr_stores = find_zarr_stores(data_dir)
 
@@ -127,56 +258,65 @@ def process_zarr_data(
             logger.info(f"Processing Zarr store: {os.path.basename(zarr_path)}")
 
         try:
-            mesh_pos, edges, point_data_dict = load_zarr_store(zarr_path)
-
-            # Validate shapes
-            if mesh_pos.ndim != 3 or mesh_pos.shape[-1] != 3:
-                raise ValueError(
-                    f"mesh_pos must be [T,N,3], got {mesh_pos.shape} in {zarr_path}"
+            if lazy_load:
+                num_nodes = validate_zarr_store(zarr_path)
+                edges = load_zarr_edges(zarr_path)
+                src, dst = edges.T
+                srcs.append(src)
+                dsts.append(dst)
+                point_data_all.append(
+                    {
+                        "_lazy": True,
+                        "_zarr_path": zarr_path,
+                        "_num_nodes": num_nodes,
+                    }
                 )
+            else:
+                mesh_pos, edges, point_data_dict = load_zarr_store(zarr_path)
 
-            if edges.ndim != 2 or edges.shape[-1] != 2:
-                raise ValueError(
-                    f"edges must be [E,2], got {edges.shape} in {zarr_path}"
-                )
-
-            num_nodes = mesh_pos.shape[1]
-
-            # Validate point data features
-            for name, data in point_data_dict.items():
-                if data.ndim == 1:
-                    if len(data) != num_nodes:
-                        raise ValueError(
-                            f"Point data '{name}' length {len(data)} doesn't match "
-                            f"number of nodes {num_nodes} in {zarr_path}"
-                        )
-                elif data.ndim == 2:
-                    if data.shape[0] != num_nodes:
-                        raise ValueError(
-                            f"Point data '{name}' shape {data.shape} doesn't match "
-                            f"number of nodes {num_nodes} in {zarr_path}"
-                        )
-                else:
+                if mesh_pos.ndim != 3 or mesh_pos.shape[-1] != 3:
                     raise ValueError(
-                        f"Point data '{name}' must be [N] or [N,K], got shape {data.shape} in {zarr_path}"
+                        f"mesh_pos must be [T,N,3], got {mesh_pos.shape} in {zarr_path}"
                     )
 
-            # Validate edge indices are within bounds
-            if edges.size > 0:
-                if edges.min() < 0 or edges.max() >= num_nodes:
+                if edges.ndim != 2 or edges.shape[-1] != 2:
                     raise ValueError(
-                        f"Edge indices out of bounds [0, {num_nodes - 1}] in {zarr_path}"
+                        f"edges must be [E,2], got {edges.shape} in {zarr_path}"
                     )
 
-            # Extract source and destination node indices from edges
-            src, dst = edges.T
-            srcs.append(src)
-            dsts.append(dst)
+                num_nodes = mesh_pos.shape[1]
 
-            # Create record with coordinates and all point data fields
-            record = {"coords": mesh_pos}
-            record.update(point_data_dict)  # Add all point data features dynamically
-            point_data_all.append(record)
+                for name, data in point_data_dict.items():
+                    if data.ndim == 1:
+                        if len(data) != num_nodes:
+                            raise ValueError(
+                                f"Point data '{name}' length {len(data)} doesn't match "
+                                f"number of nodes {num_nodes} in {zarr_path}"
+                            )
+                    elif data.ndim == 2:
+                        if data.shape[0] != num_nodes:
+                            raise ValueError(
+                                f"Point data '{name}' shape {data.shape} doesn't match "
+                                f"number of nodes {num_nodes} in {zarr_path}"
+                            )
+                    else:
+                        raise ValueError(
+                            f"Point data '{name}' must be [N] or [N,K], got shape {data.shape} in {zarr_path}"
+                        )
+
+                if edges.size > 0:
+                    if edges.min() < 0 or edges.max() >= num_nodes:
+                        raise ValueError(
+                            f"Edge indices out of bounds [0, {num_nodes - 1}] in {zarr_path}"
+                        )
+
+                src, dst = edges.T
+                srcs.append(src)
+                dsts.append(dst)
+
+                record = {"coords": mesh_pos}
+                record.update(point_data_dict)
+                point_data_all.append(record)
 
             processed_runs += 1
 
@@ -197,11 +337,18 @@ class Reader:
 
     This reader loads preprocessed crash simulation data from Zarr stores
     created by the PhysicsNeMo Curator ETL pipeline.
+
+    By default ``lazy_load=True`` so multi-GPU training does not materialize
+    every run on every rank at dataset construction time.
     """
 
-    def __init__(self):
-        """Initialize the Zarr reader."""
-        pass
+    def __init__(self, lazy_load: bool = True):
+        """
+        Args:
+            lazy_load: When True, defer loading mesh trajectories and point
+                features until the datapipe accesses a sample.
+        """
+        self.lazy_load = lazy_load
 
     def __call__(
         self,
@@ -224,10 +371,14 @@ class Reader:
         Returns:
             srcs: List of source node arrays for graph edges
             dsts: List of destination node arrays for graph edges
-            point_data: List of dicts with 'coords' and all available point data fields
+            point_data: List of dicts with 'coords' and all available point data fields,
+                or lazy handles when ``lazy_load=True``.
+            global_features: Empty list (Zarr stores do not embed global features)
         """
-        return process_zarr_data(
+        srcs, dsts, point_data = process_zarr_data(
             data_dir=data_dir,
             num_samples=num_samples,
             logger=logger,
+            lazy_load=self.lazy_load,
         )
+        return srcs, dsts, point_data, []


### PR DESCRIPTION
## Summary
- Add lazy Zarr loading (`lazy_load: true` by default) so mesh trajectories and point features materialize on first sample access instead of at dataset construction.
- Update the crash datapipe to stream stats and defer per-sample tensors/graphs when lazy records are returned.
- Document DDP memory behavior (`DistributedSampler` shards indices, not host RAM) in the crash README and log a hint in `train.py` when multi-GPU + lazy Zarr are active.

closes #1550

## Test plan
- [x] `pytest examples/structural_mechanics/crash/tests/test_zarr_reader.py examples/structural_mechanics/crash/tests/test_datapipe_lazy.py`
- [x] Eager-mode smoke test with `Reader(lazy_load=False)` (all samples materialized at init)
- [x] pre-commit on changed files

## Notes
- This PR is scoped to #1550 (lazy Zarr + DDP docs). A few short docstrings on existing crash example symbols were added only as a **temporary pre-commit workaround** — the interrogate hook falsely flagged baseline-grandfathered items due to a path-parsing bug in `check_docstring_coverage.py` (details in [follow-up comment](https://github.com/NVIDIA/physicsnemo/pull/1703#issuecomment-4637334934)).
- Root-cause fix tracked in #1704.