### PR TITLE
fix(ci): parse single-equals interrogate section headers

### DIFF
--- a/test/ci_tests/check_docstring_coverage.py
+++ b/test/ci_tests/check_docstring_coverage.py
@@ -87,9 +87,9 @@ def _parse_interrogate_output(output: str, repo_root: Path) -> list[str]:
 
     for line in output.splitlines():
         ### Section header
-        # Interrogate section headers vary by version ("==== ... ====" vs
-        # "===== ... ====="), so accept both 4+ and 5+ equals styles.
-        m = re.match(r"={4,}\s+Coverage for (.+?)\s*={4,}", line)
+        # Interrogate section headers vary by version and use different
+        # numbers of equals signs, e.g. "= Coverage ... =" or "===== ... =====".
+        m = re.match(r"=+\s+Coverage for (.+?)\s*=+", line)
         if m:
             current_dir = m.group(1).rstrip("/")
             current_file = ""

--- a/test/ci_tests/conftest.py
+++ b/test/ci_tests/conftest.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/test/ci_tests/test_check_docstring_coverage.py
+++ b/test/ci_tests/test_check_docstring_coverage.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from check_docstring_coverage import _parse_interrogate_output
+
+
+def test_parse_interrogate_output_single_equals_header():
+    """Interrogate 1.7 uses single-equals section headers."""
+    repo_root = Path("/repo")
+    output = """
+= Coverage for /repo/examples/structural_mechanics/crash/ =
+| datapipe.py                                            |                     |
+| SimSample.to (L70)                                     |              MISSED |
+"""
+    results = _parse_interrogate_output(output, repo_root)
+    assert results == ["examples/structural_mechanics/crash/datapipe.py:SimSample.to"]
+
+
+def test_parse_interrogate_output_multi_equals_header():
+    """Older interrogate versions may use longer equals runs."""
+    repo_root = Path("/repo")
+    output = """
+===== Coverage for /repo/physicsnemo/utils/ =====
+| logging.py                                             |                     |
+| PythonLogger.info (L10)                                |              MISSED |
+"""
+    results = _parse_interrogate_output(output, repo_root)
+    assert results == ["physicsnemo/utils/logging.py:PythonLogger.info"]


### PR DESCRIPTION
## Summary
- Broaden the interrogate output parser in `check_docstring_coverage.py` to accept section headers with any number of equals signs (including the single-`=` format used by interrogate 1.7).
- Add unit tests for single- and multi-equals header parsing.

Related context: #1703 added docstrings on a few crash example symbols because the hook falsely reported baseline-grandfathered items as new when editing example files. This PR fixes that root cause.

## Test plan
- [x] `pytest test/ci_tests/test_check_docstring_coverage.py`
- [x] `python test/ci_tests/check_docstring_coverage.py examples/structural_mechanics/crash/datapipe.py examples/structural_mechanics/crash/train.py` (passes with baseline-only gaps, no false positives)