### PR TITLE
Add configurable checkpoint filenames and state-dict key remapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds `FourierPositionalEmbedding` to `physicsnemo.nn`, a deterministic
   axis-wise (NeRF-style) Fourier positional embedding for continuous
   coordinates with no learnable parameters.
+- Adds optional ``filename_format`` to ``save_checkpoint`` for custom model
+  checkpoint basenames (e.g. zero-padded epochs via ``"{name}.{epoch:06d}"``).
+- Adds ``Module._backward_compat_state_dict_mapper`` for version-aware
+  state-dict key remapping in ``Module.from_checkpoint``.
 - Adds radiation transport example (`examples/nuclear_engineering/radiation_transport`)
 - Adds agent skills structure, and initial skill for 'discoverability'.
 - Adds the experimental AeroJEPA model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds optional ``filename_format`` to ``save_checkpoint`` for custom model
+  checkpoint basenames (e.g. zero-padded epochs via ``"{name}.{epoch:06d}"``).
+- Adds ``Module._backward_compat_state_dict_mapper`` for version-aware
+  state-dict key remapping in ``Module.from_checkpoint``.
 - Adds radiation transport example (`examples/nuclear_engineering/radiation_transport`)
 - Adds agent skills structure, and initial skill for 'discoverability'.
 - Adds xDeepONet to experimental models

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -295,6 +295,46 @@ class Module(torch.nn.Module):
         return args
 
     @classmethod
+    def _backward_compat_state_dict_mapper(
+        cls, version: str, state_dict: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Map state-dict keys from older checkpoint versions to the current layout.
+
+        This base implementation is a no-op. Subclasses should override this method
+        when refactoring parameter or buffer names across checkpoint versions.
+
+        Parameters
+        ----------
+        version : str
+            Version of the checkpoint being loaded
+        state_dict : Dict[str, Any]
+            State dictionary loaded from the checkpoint
+
+        Returns
+        -------
+        Dict[str, Any]
+            Updated state dictionary compatible with the current module layout
+        """
+        return state_dict
+
+    @staticmethod
+    def _apply_backward_compat_state_dict(
+        model: "Module",
+        state_dict: Dict[str, Any],
+        metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Apply version-aware state-dict key remapping before ``load_state_dict``."""
+        model_cls = type(model)
+        version = metadata.get(
+            "mdlus_file_version",
+            model_cls.__model_checkpoint_version__,
+        )
+        if version != model_cls.__model_checkpoint_version__:
+            if version in model_cls.__supported_model_checkpoint_version__:
+                return model_cls._backward_compat_state_dict_mapper(version, state_dict)
+        return state_dict
+
+    @classmethod
     def _override_args(
         cls, args: Dict[str, Any], override_args: Dict[str, Any]
     ) -> None:
@@ -1064,6 +1104,9 @@ class Module(torch.nn.Module):
 
             # Load state dict after closing archive
             model_dict = torch.load(io.BytesIO(model_bytes), map_location=model.device)
+            model_dict = Module._apply_backward_compat_state_dict(
+                model, model_dict, metadata
+            )
 
             # Load state_dict into the model
             _load_state_dict_with_logging(model, model_dict, strict=strict)
@@ -1107,6 +1150,9 @@ class Module(torch.nn.Module):
                 model_dict = torch.load(
                     local_path.joinpath("model.pt"), map_location=model.device
                 )
+            model_dict = Module._apply_backward_compat_state_dict(
+                model, model_dict, metadata
+            )
 
             # Load state_dict into the model
             _load_state_dict_with_logging(model, model_dict, strict=strict)

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -298,6 +298,46 @@ class Module(torch.nn.Module):
         return args
 
     @classmethod
+    def _backward_compat_state_dict_mapper(
+        cls, version: str, state_dict: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Map state-dict keys from older checkpoint versions to the current layout.
+
+        This base implementation is a no-op. Subclasses should override this method
+        when refactoring parameter or buffer names across checkpoint versions.
+
+        Parameters
+        ----------
+        version : str
+            Version of the checkpoint being loaded
+        state_dict : Dict[str, Any]
+            State dictionary loaded from the checkpoint
+
+        Returns
+        -------
+        Dict[str, Any]
+            Updated state dictionary compatible with the current module layout
+        """
+        return state_dict
+
+    @staticmethod
+    def _apply_backward_compat_state_dict(
+        model: "Module",
+        state_dict: Dict[str, Any],
+        metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Apply version-aware state-dict key remapping before ``load_state_dict``."""
+        model_cls = type(model)
+        version = metadata.get(
+            "mdlus_file_version",
+            model_cls.__model_checkpoint_version__,
+        )
+        if version != model_cls.__model_checkpoint_version__:
+            if version in model_cls.__supported_model_checkpoint_version__:
+                return model_cls._backward_compat_state_dict_mapper(version, state_dict)
+        return state_dict
+
+    @classmethod
     def _override_args(
         cls, args: Dict[str, Any], override_args: Dict[str, Any]
     ) -> None:
@@ -1067,6 +1107,9 @@ class Module(torch.nn.Module):
 
             # Load state dict after closing archive
             model_dict = torch.load(io.BytesIO(model_bytes), map_location=model.device)
+            model_dict = Module._apply_backward_compat_state_dict(
+                model, model_dict, metadata
+            )
 
             # Load state_dict into the model
             _load_state_dict_with_logging(model, model_dict, strict=strict)
@@ -1110,6 +1153,9 @@ class Module(torch.nn.Module):
                 model_dict = torch.load(
                     local_path.joinpath("model.pt"), map_location=model.device
                 )
+            model_dict = Module._apply_backward_compat_state_dict(
+                model, model_dict, metadata
+            )
 
             # Load state_dict into the model
             _load_state_dict_with_logging(model, model_dict, strict=strict)

--- a/physicsnemo/utils/checkpoint.py
+++ b/physicsnemo/utils/checkpoint.py
@@ -567,6 +567,82 @@ def _extract_mdlus_state_dict(
         )
 
 
+def _filename_format_index_pattern(
+    filename_format: str,
+    base_name: str,
+    model_parallel_rank: int,
+    file_extension: str,
+) -> re.Pattern[str]:
+    """Build a regex that matches formatted checkpoint filenames and captures epoch."""
+    token_pattern = re.compile(r"\{(name|mp_rank|epoch)(?::[^}]*)?\}")
+
+    regex_parts: list[str] = ["^"]
+    last_end = 0
+    for match in token_pattern.finditer(filename_format):
+        regex_parts.append(re.escape(filename_format[last_end : match.start()]))
+        field = match.group(1)
+        if field == "name":
+            regex_parts.append(re.escape(base_name))
+        elif field == "mp_rank":
+            regex_parts.append(re.escape(str(model_parallel_rank)))
+        elif field == "epoch":
+            regex_parts.append(r"(\d+)")
+        last_end = match.end()
+
+    regex_parts.append(re.escape(filename_format[last_end:]))
+    regex_parts.append(re.escape(file_extension))
+    regex_parts.append("$")
+    return re.compile("".join(regex_parts))
+
+
+def _resolve_checkpoint_index(
+    fs,
+    path: str,
+    base_name: str,
+    model_parallel_rank: int,
+    file_extension: str,
+    index: int | None,
+    saving: bool,
+    filename_format: str | None = None,
+) -> int:
+    """Resolve the numeric checkpoint index when ``index`` is ``None``."""
+    if index is not None:
+        return index
+
+    if filename_format is not None:
+        if "{name}" in filename_format:
+            glob_pattern = f"{path}/{base_name}*{file_extension}"
+        else:
+            glob_pattern = f"{path}/*{file_extension}"
+        file_names = fs.glob(glob_pattern)
+        pattern = _filename_format_index_pattern(
+            filename_format, base_name, model_parallel_rank, file_extension
+        )
+    else:
+        checkpoint_prefix = f"{path}/{base_name}.{model_parallel_rank}"
+        file_names = fs.glob(checkpoint_prefix + "*" + file_extension)
+        pattern = re.compile(
+            rf"^{re.escape(base_name)}\.{model_parallel_rank}\.(\d+)"
+            rf"{re.escape(file_extension)}$"
+        )
+
+    if len(file_names) == 0:
+        return 0
+
+    file_idx = []
+    for fname in file_names:
+        file_stem = PurePath(fname).name
+        match = pattern.match(file_stem)
+        if match:
+            file_idx.append(int(match.group(1)))
+
+    if not file_idx:
+        return 0
+
+    file_idx.sort()
+    return file_idx[-1] + 1 if saving else file_idx[-1]
+
+
 def _get_checkpoint_filename(
     path: str,
     base_name: str = "checkpoint",
@@ -574,6 +650,7 @@ def _get_checkpoint_filename(
     saving: bool = False,
     model_type: str = "mdlus",
     distributed: bool = False,
+    filename_format: str | None = None,
 ) -> str:
     """
     Builds the filename for a numbered checkpoint.
@@ -600,6 +677,12 @@ def _get_checkpoint_filename(
         When ``True`` the model_parallel_rank component of the filename is
         forced to ``0`` because FSDP/DTensor distribution is handled by the
         DCP APIs, not per-rank files.  By default ``False``.
+    filename_format : str | None, optional
+        Optional ``str.format`` template for the checkpoint basename (without
+        directory or extension).  Supported fields are ``name`` (model or
+        checkpoint stem), ``epoch`` (checkpoint index), and ``mp_rank``.
+        Example: ``"{name}.{epoch:06d}"`` produces zero-padded epoch numbers.
+        When ``None``, the legacy ``{name}.{mp_rank}.{epoch}`` layout is used.
 
     Returns
     -------
@@ -631,47 +714,36 @@ def _get_checkpoint_filename(
     fs = fsspec.filesystem(protocol)
     if protocol == "file":
         path = str(Path(path).resolve())
-    checkpoint_filename = f"{path}/{base_name}.{model_parallel_rank}"
 
     # File extension for PhysicsNeMo models or PyTorch models
     file_extension = ".mdlus" if model_type == "mdlus" else ".pt"
 
-    # If epoch is provided load that file
-    if index is not None:
-        checkpoint_filename = checkpoint_filename + f".{index}"
-        checkpoint_filename += file_extension
-    # Otherwise try loading the latest epoch or rolling checkpoint
-    else:
-        file_names = [
-            fname for fname in fs.glob(checkpoint_filename + "*" + file_extension)
-        ]
+    resolved_index = _resolve_checkpoint_index(
+        fs,
+        path,
+        base_name,
+        model_parallel_rank,
+        file_extension,
+        index,
+        saving,
+        filename_format,
+    )
 
-        if len(file_names) > 0:
-            # If checkpoint from a null index save exists load that
-            # This is the most likely line to error since it will fail with
-            # invalid checkpoint names
+    if filename_format is not None:
+        try:
+            formatted_name = filename_format.format(
+                name=base_name,
+                epoch=resolved_index,
+                mp_rank=model_parallel_rank,
+            )
+        except KeyError as exc:
+            raise ValueError(
+                "filename_format contains unsupported placeholders. "
+                "Supported fields are: name, epoch, mp_rank."
+            ) from exc
+        return f"{path}/{formatted_name}{file_extension}"
 
-            file_idx = []
-
-            for fname in file_names:
-                fname_path = PurePath(fname)
-                file_stem = fname_path.name
-
-                pattern = rf"^{re.escape(base_name)}\.{model_parallel_rank}\.(\d+){re.escape(file_extension)}$"
-                match = re.match(pattern, file_stem)
-                if match:
-                    file_idx.append(int(match.group(1)))
-            file_idx.sort()
-            # If we are saving index by 1 to get the next free file name
-            if saving:
-                checkpoint_filename = checkpoint_filename + f".{file_idx[-1] + 1}"
-            else:
-                checkpoint_filename = checkpoint_filename + f".{file_idx[-1]}"
-            checkpoint_filename += file_extension
-        else:
-            checkpoint_filename += ".0" + file_extension
-
-    return checkpoint_filename
+    return f"{path}/{base_name}.{model_parallel_rank}.{resolved_index}{file_extension}"
 
 
 def _unique_model_names(
@@ -730,6 +802,7 @@ def save_checkpoint(
     epoch: int | None = None,
     metadata: dict[str, Any] | None = None,
     optimizer_model: torch.nn.Module | None = None,
+    filename_format: str | None = None,
 ) -> None:
     r"""Save a training checkpoint to disk (or a remote store).
 
@@ -784,6 +857,10 @@ def save_checkpoint(
         them is a distributed model (FSDP/ShardTensor). When ``None``, the
         first model in ``models`` is used.  Ignored when *not* in distributed
         mode.
+    filename_format : str | None, optional
+        Optional ``str.format`` template for model checkpoint basenames.
+        Supported fields: ``name``, ``epoch``, ``mp_rank``. When ``None``,
+        the legacy ``{name}.{mp_rank}.{epoch}`` naming is used.
 
     Examples
     --------
@@ -855,6 +932,7 @@ def save_checkpoint(
             saving=True,
             model_type=model_type,
             distributed=is_distributed,
+            filename_format=filename_format,
         )
 
         if _is_distributed_model(model):

--- a/physicsnemo/utils/checkpoint.py
+++ b/physicsnemo/utils/checkpoint.py
@@ -458,6 +458,40 @@ def _extract_mdlus_state_dict(
         )
 
 
+def _resolve_checkpoint_index(
+    fs,
+    path: str,
+    base_name: str,
+    model_parallel_rank: int,
+    file_extension: str,
+    index: int | None,
+    saving: bool,
+) -> int:
+    """Resolve the numeric checkpoint index when ``index`` is ``None``."""
+    if index is not None:
+        return index
+
+    checkpoint_prefix = f"{path}/{base_name}.{model_parallel_rank}"
+    file_names = [fname for fname in fs.glob(checkpoint_prefix + "*" + file_extension)]
+
+    if len(file_names) == 0:
+        return 0 if saving else 0
+
+    file_idx = []
+    pattern = rf"^{re.escape(base_name)}\.{model_parallel_rank}\.(\d+){re.escape(file_extension)}$"
+    for fname in file_names:
+        file_stem = PurePath(fname).name
+        match = re.match(pattern, file_stem)
+        if match:
+            file_idx.append(int(match.group(1)))
+
+    if not file_idx:
+        return 0
+
+    file_idx.sort()
+    return file_idx[-1] + 1 if saving else file_idx[-1]
+
+
 def _get_checkpoint_filename(
     path: str,
     base_name: str = "checkpoint",
@@ -465,6 +499,7 @@ def _get_checkpoint_filename(
     saving: bool = False,
     model_type: str = "mdlus",
     distributed: bool = False,
+    filename_format: str | None = None,
 ) -> str:
     r"""Build the filename for a numbered checkpoint.
 
@@ -499,6 +534,12 @@ def _get_checkpoint_filename(
         When ``True`` the model_parallel_rank component of the filename is
         forced to ``0`` because FSDP/DTensor distribution is handled by the
         DCP APIs, not per-rank files.  By default ``False``.
+    filename_format : str | None, optional
+        Optional ``str.format`` template for the checkpoint basename (without
+        directory or extension).  Supported fields are ``name`` (model or
+        checkpoint stem), ``epoch`` (checkpoint index), and ``mp_rank``.
+        Example: ``"{name}.{epoch:06d}"`` produces zero-padded epoch numbers.
+        When ``None``, the legacy ``{name}.{mp_rank}.{epoch}`` layout is used.
 
     Returns
     -------
@@ -534,6 +575,30 @@ def _get_checkpoint_filename(
 
     # File extension for PhysicsNeMo models or PyTorch models
     file_extension = ".mdlus" if model_type == "mdlus" else ".pt"
+
+    resolved_index = _resolve_checkpoint_index(
+        fs,
+        path,
+        base_name,
+        model_parallel_rank,
+        file_extension,
+        index,
+        saving,
+    )
+
+    if filename_format is not None:
+        try:
+            formatted_name = filename_format.format(
+                name=base_name,
+                epoch=resolved_index,
+                mp_rank=model_parallel_rank,
+            )
+        except KeyError as exc:
+            raise ValueError(
+                "filename_format contains unsupported placeholders. "
+                "Supported fields are: name, epoch, mp_rank."
+            ) from exc
+        return f"{path}/{formatted_name}{file_extension}"
 
     # If epoch is provided load that file
     if index is not None:
@@ -629,6 +694,7 @@ def save_checkpoint(
     epoch: int | None = None,
     metadata: dict[str, Any] | None = None,
     optimizer_model: torch.nn.Module | None = None,
+    filename_format: str | None = None,
 ) -> None:
     r"""Save a training checkpoint to disk (or a remote store).
 
@@ -683,6 +749,10 @@ def save_checkpoint(
         them is a distributed model (FSDP/ShardTensor). When ``None``, the
         first model in ``models`` is used.  Ignored when *not* in distributed
         mode.
+    filename_format : str | None, optional
+        Optional ``str.format`` template for model checkpoint basenames.
+        Supported fields: ``name``, ``epoch``, ``mp_rank``. When ``None``,
+        the legacy ``{name}.{mp_rank}.{epoch}`` naming is used.
 
     Examples
     --------
@@ -754,6 +824,7 @@ def save_checkpoint(
             saving=True,
             model_type=model_type,
             distributed=is_distributed,
+            filename_format=filename_format,
         )
 
         if _is_distributed_model(model):

--- a/physicsnemo/utils/checkpoint.py
+++ b/physicsnemo/utils/checkpoint.py
@@ -458,6 +458,34 @@ def _extract_mdlus_state_dict(
         )
 
 
+def _filename_format_index_pattern(
+    filename_format: str,
+    base_name: str,
+    model_parallel_rank: int,
+    file_extension: str,
+) -> re.Pattern[str]:
+    """Build a regex that matches formatted checkpoint filenames and captures epoch."""
+    token_pattern = re.compile(r"\{(name|mp_rank|epoch)(?::[^}]*)?\}")
+
+    regex_parts: list[str] = ["^"]
+    last_end = 0
+    for match in token_pattern.finditer(filename_format):
+        regex_parts.append(re.escape(filename_format[last_end : match.start()]))
+        field = match.group(1)
+        if field == "name":
+            regex_parts.append(re.escape(base_name))
+        elif field == "mp_rank":
+            regex_parts.append(re.escape(str(model_parallel_rank)))
+        elif field == "epoch":
+            regex_parts.append(r"(\d+)")
+        last_end = match.end()
+
+    regex_parts.append(re.escape(filename_format[last_end:]))
+    regex_parts.append(re.escape(file_extension))
+    regex_parts.append("$")
+    return re.compile("".join(regex_parts))
+
+
 def _resolve_checkpoint_index(
     fs,
     path: str,
@@ -466,22 +494,36 @@ def _resolve_checkpoint_index(
     file_extension: str,
     index: int | None,
     saving: bool,
+    filename_format: str | None = None,
 ) -> int:
     """Resolve the numeric checkpoint index when ``index`` is ``None``."""
     if index is not None:
         return index
 
-    checkpoint_prefix = f"{path}/{base_name}.{model_parallel_rank}"
-    file_names = [fname for fname in fs.glob(checkpoint_prefix + "*" + file_extension)]
+    if filename_format is not None:
+        if "{name}" in filename_format:
+            glob_pattern = f"{path}/{base_name}*{file_extension}"
+        else:
+            glob_pattern = f"{path}/*{file_extension}"
+        file_names = fs.glob(glob_pattern)
+        pattern = _filename_format_index_pattern(
+            filename_format, base_name, model_parallel_rank, file_extension
+        )
+    else:
+        checkpoint_prefix = f"{path}/{base_name}.{model_parallel_rank}"
+        file_names = fs.glob(checkpoint_prefix + "*" + file_extension)
+        pattern = re.compile(
+            rf"^{re.escape(base_name)}\.{model_parallel_rank}\.(\d+)"
+            rf"{re.escape(file_extension)}$"
+        )
 
     if len(file_names) == 0:
-        return 0 if saving else 0
+        return 0
 
     file_idx = []
-    pattern = rf"^{re.escape(base_name)}\.{model_parallel_rank}\.(\d+){re.escape(file_extension)}$"
     for fname in file_names:
         file_stem = PurePath(fname).name
-        match = re.match(pattern, file_stem)
+        match = pattern.match(file_stem)
         if match:
             file_idx.append(int(match.group(1)))
 
@@ -571,7 +613,6 @@ def _get_checkpoint_filename(
     fs = fsspec.filesystem(protocol)
     if protocol == "file":
         path = str(Path(path).resolve())
-    checkpoint_filename = f"{path}/{base_name}.{model_parallel_rank}"
 
     # File extension for PhysicsNeMo models or PyTorch models
     file_extension = ".mdlus" if model_type == "mdlus" else ".pt"
@@ -584,6 +625,7 @@ def _get_checkpoint_filename(
         file_extension,
         index,
         saving,
+        filename_format,
     )
 
     if filename_format is not None:
@@ -600,42 +642,7 @@ def _get_checkpoint_filename(
             ) from exc
         return f"{path}/{formatted_name}{file_extension}"
 
-    # If epoch is provided load that file
-    if index is not None:
-        checkpoint_filename = checkpoint_filename + f".{index}"
-        checkpoint_filename += file_extension
-    # Otherwise try loading the latest epoch or rolling checkpoint
-    else:
-        file_names = [
-            fname for fname in fs.glob(checkpoint_filename + "*" + file_extension)
-        ]
-
-        if len(file_names) > 0:
-            # If checkpoint from a null index save exists load that
-            # This is the most likely line to error since it will fail with
-            # invalid checkpoint names
-
-            file_idx = []
-
-            for fname in file_names:
-                fname_path = PurePath(fname)
-                file_stem = fname_path.name
-
-                pattern = rf"^{re.escape(base_name)}\.{model_parallel_rank}\.(\d+){re.escape(file_extension)}$"
-                match = re.match(pattern, file_stem)
-                if match:
-                    file_idx.append(int(match.group(1)))
-            file_idx.sort()
-            # If we are saving index by 1 to get the next free file name
-            if saving:
-                checkpoint_filename = checkpoint_filename + f".{file_idx[-1] + 1}"
-            else:
-                checkpoint_filename = checkpoint_filename + f".{file_idx[-1]}"
-            checkpoint_filename += file_extension
-        else:
-            checkpoint_filename += ".0" + file_extension
-
-    return checkpoint_filename
+    return f"{path}/{base_name}.{model_parallel_rank}.{resolved_index}{file_extension}"
 
 
 def _unique_model_names(

--- a/test/models/test_from_checkpoint.py
+++ b/test/models/test_from_checkpoint.py
@@ -131,3 +131,43 @@ def test_from_checkpoint_override(device):
         )
 
     Path("checkpoint.mdlus").unlink(missing_ok=False)
+
+
+def test_from_checkpoint_state_dict_mapper(device, tmp_path):
+    """Version-aware state-dict key remapping loads refactored checkpoints."""
+
+    class LegacyLinearModel(physicsnemo.core.Module):
+        __model_checkpoint_version__ = "0.1.0"
+
+        def __init__(self, features=4):
+            super().__init__()
+            self.features = features
+            self.layer = torch.nn.Linear(features, features)
+
+    class CurrentLinearModel(physicsnemo.core.Module):
+        __model_checkpoint_version__ = "0.2.0"
+        __supported_model_checkpoint_version__ = {
+            "0.1.0": "Loading legacy checkpoint with renamed layer keys."
+        }
+
+        def __init__(self, features=4):
+            super().__init__()
+            self.features = features
+            self.block = torch.nn.Linear(features, features)
+
+        @classmethod
+        def _backward_compat_state_dict_mapper(cls, version, state_dict):
+            if version == "0.1.0":
+                return {k.replace("layer.", "block."): v for k, v in state_dict.items()}
+            return state_dict
+
+    torch.manual_seed(0)
+    ckpt_path = tmp_path / "refactored.mdlus"
+    model = LegacyLinearModel().to(device)
+    layer_weight = model.layer.weight.detach().clone()
+    layer_bias = model.layer.bias.detach().clone()
+    model.save(ckpt_path)
+
+    loaded = CurrentLinearModel.from_checkpoint(ckpt_path).to(device)
+    assert torch.allclose(loaded.block.weight, layer_weight)
+    assert torch.allclose(loaded.block.bias, layer_bias)

--- a/test/models/test_from_checkpoint.py
+++ b/test/models/test_from_checkpoint.py
@@ -157,3 +157,43 @@ def test_checkpoint_archive_members_stay_within_destination(tmp_path):
         ]
 
     assert safe_names == ["model.pt"]
+
+
+def test_from_checkpoint_state_dict_mapper(device, tmp_path):
+    """Version-aware state-dict key remapping loads refactored checkpoints."""
+
+    class LegacyLinearModel(physicsnemo.core.Module):
+        __model_checkpoint_version__ = "0.1.0"
+
+        def __init__(self, features=4):
+            super().__init__()
+            self.features = features
+            self.layer = torch.nn.Linear(features, features)
+
+    class CurrentLinearModel(physicsnemo.core.Module):
+        __model_checkpoint_version__ = "0.2.0"
+        __supported_model_checkpoint_version__ = {
+            "0.1.0": "Loading legacy checkpoint with renamed layer keys."
+        }
+
+        def __init__(self, features=4):
+            super().__init__()
+            self.features = features
+            self.block = torch.nn.Linear(features, features)
+
+        @classmethod
+        def _backward_compat_state_dict_mapper(cls, version, state_dict):
+            if version == "0.1.0":
+                return {k.replace("layer.", "block."): v for k, v in state_dict.items()}
+            return state_dict
+
+    torch.manual_seed(0)
+    ckpt_path = tmp_path / "refactored.mdlus"
+    model = LegacyLinearModel().to(device)
+    layer_weight = model.layer.weight.detach().clone()
+    layer_bias = model.layer.bias.detach().clone()
+    model.save(ckpt_path)
+
+    loaded = CurrentLinearModel.from_checkpoint(ckpt_path).to(device)
+    assert torch.allclose(loaded.block.weight, layer_weight)
+    assert torch.allclose(loaded.block.bias, layer_bias)

--- a/test/utils/test_checkpoint.py
+++ b/test/utils/test_checkpoint.py
@@ -158,6 +158,55 @@ def test_model_checkpointing(
             shutil.rmtree(local_cache)
 
 
+def test_save_checkpoint_filename_format(tmp_path):
+    """Custom filename_format controls model checkpoint basename layout."""
+    from physicsnemo.utils import save_checkpoint
+
+    if not DistributedManager.is_initialized():
+        DistributedManager.initialize()
+
+    model = FullyConnected(in_features=4, out_features=4, num_layers=1, layer_size=4)
+    save_checkpoint(
+        tmp_path,
+        models=model,
+        epoch=42,
+        filename_format="{name}.{epoch:06d}",
+    )
+    assert (tmp_path / "FullyConnected.000042.mdlus").exists()
+
+
+def test_save_checkpoint_filename_format_auto_index(tmp_path):
+    """Custom filename_format auto-increments epoch when epoch is omitted."""
+    from physicsnemo.utils import save_checkpoint
+
+    if not DistributedManager.is_initialized():
+        DistributedManager.initialize()
+
+    model = FullyConnected(in_features=4, out_features=4, num_layers=1, layer_size=4)
+    fmt = "{name}.{epoch:06d}"
+    save_checkpoint(tmp_path, models=model, filename_format=fmt)
+    save_checkpoint(tmp_path, models=model, filename_format=fmt)
+    assert (tmp_path / "FullyConnected.000000.mdlus").exists()
+    assert (tmp_path / "FullyConnected.000001.mdlus").exists()
+
+
+def test_save_checkpoint_filename_format_invalid_placeholder(tmp_path):
+    """Unsupported filename_format placeholders raise a clear error."""
+    from physicsnemo.utils import save_checkpoint
+
+    if not DistributedManager.is_initialized():
+        DistributedManager.initialize()
+
+    model = FullyConnected(in_features=4, out_features=4, num_layers=1, layer_size=4)
+    with pytest.raises(ValueError, match="unsupported placeholders"):
+        save_checkpoint(
+            tmp_path,
+            models=model,
+            epoch=1,
+            filename_format="{name}.{step:06d}",
+        )
+
+
 def test_get_checkpoint_dir():
     from physicsnemo.utils import get_checkpoint_dir
 

--- a/test/utils/test_checkpoint.py
+++ b/test/utils/test_checkpoint.py
@@ -158,6 +158,40 @@ def test_model_checkpointing(
             shutil.rmtree(local_cache)
 
 
+def test_save_checkpoint_filename_format(tmp_path):
+    """Custom filename_format controls model checkpoint basename layout."""
+    from physicsnemo.utils import save_checkpoint
+
+    if not DistributedManager.is_initialized():
+        DistributedManager.initialize()
+
+    model = FullyConnected(in_features=4, out_features=4, num_layers=1, layer_size=4)
+    save_checkpoint(
+        tmp_path,
+        models=model,
+        epoch=42,
+        filename_format="{name}.{epoch:06d}",
+    )
+    assert (tmp_path / "FullyConnected.000042.mdlus").exists()
+
+
+def test_save_checkpoint_filename_format_invalid_placeholder(tmp_path):
+    """Unsupported filename_format placeholders raise a clear error."""
+    from physicsnemo.utils import save_checkpoint
+
+    if not DistributedManager.is_initialized():
+        DistributedManager.initialize()
+
+    model = FullyConnected(in_features=4, out_features=4, num_layers=1, layer_size=4)
+    with pytest.raises(ValueError, match="unsupported placeholders"):
+        save_checkpoint(
+            tmp_path,
+            models=model,
+            epoch=1,
+            filename_format="{name}.{step:06d}",
+        )
+
+
 def test_get_checkpoint_dir():
     from physicsnemo.utils import get_checkpoint_dir
 

--- a/test/utils/test_checkpoint.py
+++ b/test/utils/test_checkpoint.py
@@ -175,6 +175,21 @@ def test_save_checkpoint_filename_format(tmp_path):
     assert (tmp_path / "FullyConnected.000042.mdlus").exists()
 
 
+def test_save_checkpoint_filename_format_auto_index(tmp_path):
+    """Custom filename_format auto-increments epoch when epoch is omitted."""
+    from physicsnemo.utils import save_checkpoint
+
+    if not DistributedManager.is_initialized():
+        DistributedManager.initialize()
+
+    model = FullyConnected(in_features=4, out_features=4, num_layers=1, layer_size=4)
+    fmt = "{name}.{epoch:06d}"
+    save_checkpoint(tmp_path, models=model, filename_format=fmt)
+    save_checkpoint(tmp_path, models=model, filename_format=fmt)
+    assert (tmp_path / "FullyConnected.000000.mdlus").exists()
+    assert (tmp_path / "FullyConnected.000001.mdlus").exists()
+
+
 def test_save_checkpoint_filename_format_invalid_placeholder(tmp_path):
     """Unsupported filename_format placeholders raise a clear error."""
     from physicsnemo.utils import save_checkpoint


### PR DESCRIPTION
## Summary
- Add optional `filename_format` to `save_checkpoint` so model checkpoint basenames can use custom layouts (e.g. zero-padded epochs) while preserving legacy naming when unset.
- Add `Module._backward_compat_state_dict_mapper` and apply it in `from_checkpoint` before `load_state_dict`, mirroring the existing constructor-arg backward-compat hook for refactored parameter names.

Closes #1175
Closes #1173

## Test plan
- [x] `pytest test/utils/test_checkpoint.py::test_save_checkpoint_filename_format`
- [x] `pytest test/utils/test_checkpoint.py::test_save_checkpoint_filename_format_invalid_placeholder`
- [x] `pytest test/models/test_from_checkpoint.py::test_from_checkpoint_state_dict_mapper`
- [x] pre-commit on changed files