### PR TITLE
Fixes Coverage CI Error on Stale Cache

### DIFF
--- a/.github/workflows/github-nightly-uv.yml
+++ b/.github/workflows/github-nightly-uv.yml
@@ -355,10 +355,13 @@ jobs:
     - name: Merge coverage reports
       run: |
         uv run --no-sync coverage combine
-        uv run --no-sync coverage report --show-missing --omit="*test*" --omit="*internal*" --omit="*experimental*" --fail-under=45
-        uv run --no-sync coverage html
+        # -i / --ignore-errors downgrades coverage's fatal "No source for
+        # code" error to a warning, matching the PR workflow.  Kept in
+        # lockstep with github-pr.yml per .github/CACHE_CONTRACT.md.
+        uv run --no-sync coverage report -i --show-missing --omit="*test*" --omit="*internal*" --omit="*experimental*" --fail-under=45
+        uv run --no-sync coverage html -i
         # Also create an XML report for potential CI integrations
-        uv run --no-sync coverage xml -o coverage.xml
+        uv run --no-sync coverage xml -i -o coverage.xml
 
     - name: Upload coverage HTML report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/github-pr.yml
+++ b/.github/workflows/github-pr.yml
@@ -227,9 +227,13 @@ jobs:
 
         uv run --no-sync coverage combine
 
-        uv run --no-sync coverage report --show-missing --omit="*test*" --omit="*internal*" --omit="*experimental*" --fail-under=45
-        uv run --no-sync coverage html
-        uv run --no-sync coverage xml -o coverage.xml
+        # -i / --ignore-errors downgrades coverage's fatal "No source for
+        # code" error to a warning.  The restored nightly baseline can
+        # reference files this PR has moved or deleted (e.g. a renamed
+        # module); without -i the combined report aborts on the stale path.
+        uv run --no-sync coverage report -i --show-missing --omit="*test*" --omit="*internal*" --omit="*experimental*" --fail-under=45
+        uv run --no-sync coverage html -i
+        uv run --no-sync coverage xml -i -o coverage.xml
 
     - name: Upload coverage HTML report
       uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ pytest-internal:
 
 coverage:
 	coverage combine && \
-		coverage report --show-missing --omit=*test* --omit=*internal* --omit=*experimental* --fail-under=60 && \
-		coverage html
+		coverage report -i --show-missing --omit=*test* --omit=*internal* --omit=*experimental* --fail-under=60 && \
+		coverage html -i
 
 all-ci: get-data setup-ci black interrogate lint license install pytest doctest coverage
 

--- a/test/get_coverage.sh
+++ b/test/get_coverage.sh
@@ -11,10 +11,10 @@ coverage run \
 --doctest-modules ../physicsnemo/
 
 coverage combine --data-file=.coverage
-coverage report --omit=*test*
+coverage report -i --omit=*test*
 
 # if you wish to view the report in HTML format uncomment below
-# coverage html --omit=*test*
+# coverage html -i --omit=*test*
 
 # cleanup
 rm .coverage


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

When a PR moves or deletes a module, the `Coverage` CI job fails at the report step:

```text
No source for code: '.../physicsnemo/experimental/models/globe/cluster_tree.py'
##[error]Process completed with exit code 1.
```

The job restores the nightly coverage baseline from cache, which still records the file's *old* path. After `coverage combine`, the report step runs `coverage report` with no `--rcfile` (so `ignore_errors` defaults to `False`), tries to read the stale path's source, can't find it, and aborts. `--omit="*experimental*"` does not help: `NoSource` is raised while analyzing the file, before omit filtering applies.

Observed on #1710, which moves `cluster_tree.py`.

## Fix

Add coverage's `-i` / `--ignore-errors` to the report-generating commands (`report`, `html`, `xml`). This downgrades the fatal error to a non-fatal `CoverageWarning (couldnt-parse)` and drops the stale path, while leaving the `--fail-under` gate intact. `coverage combine` is unchanged (it does not read source).

- `.github/workflows/github-pr.yml` - the failing job
- `.github/workflows/github-nightly-uv.yml` - identical merge step, kept in lockstep
- `Makefile`, `test/get_coverage.sh` - local-dev parity

## Why this is safe

`-i` only affects report rendering, which runs after and separately from the test step (which has no `-i`). It does not touch:

- the test run - real test/import/syntax failures still fail CI;
- the `--fail-under` gate - a separate code path with its own exit code;
- `NoDataError` - a "measured nothing" run still fails loudly.

Every suppressed case still prints a `CoverageWarning` in the log.

## Test plan

- Reproduced the exact `NoSource` failure locally (combine a shard referencing a since-deleted file, then `coverage report`).
- Confirmed the patched sequence (`report -i` / `html -i` / `xml -i`, with `--fail-under=45`) exits 0 with only a warning.


## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
