### PR TITLE
Mesh: add tensor-returning gradient/divergence/curl/laplacian Mesh methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds tensor-returning `Mesh.gradient`, `Mesh.divergence`, `Mesh.curl`, and
+  `Mesh.laplacian` convenience methods to `physicsnemo.mesh`, mirroring
+  `Mesh.integrate` (each returns a tensor and accepts a `point_data` key or a raw
+  tensor). This gives the discrete differential operators a consistent,
+  discoverable surface on `Mesh`; previously divergence/curl/laplacian were
+  reachable only as free functions in `physicsnemo.mesh.calculus`.
 - Adds `FourierPositionalEmbedding` to `physicsnemo.nn`, a deterministic
   axis-wise (NeRF-style) Fourier positional embedding for continuous
   coordinates with no learnable parameters. It owns a fixed frequency schedule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds tensor-returning `Mesh.gradient`, `Mesh.divergence`, `Mesh.curl`, and
+  `Mesh.laplacian` convenience methods to `physicsnemo.mesh`, mirroring
+  `Mesh.integrate` (each returns a tensor and accepts a data key or a raw
+  tensor, with a `data_source="points"|"cells"` kwarg selecting vertex or
+  cell-centered fields). This gives the discrete differential operators a
+  consistent, discoverable surface on `Mesh`; previously divergence/curl/
+  laplacian were reachable only as free functions in `physicsnemo.mesh.calculus`.
+  Adds `compute_divergence_cells_lsq` and `compute_curl_cells_lsq` free
+  functions (cell-centered LSQ analogues); DEC operators and the cotangent
+  Laplacian remain vertex-only and raise `NotImplementedError` for cell data.
 - Adds `FourierPositionalEmbedding` to `physicsnemo.nn`, a deterministic
   axis-wise (NeRF-style) Fourier positional embedding for continuous
   coordinates with no learnable parameters. It owns a fixed frequency schedule

--- a/physicsnemo/mesh/calculus/__init__.py
+++ b/physicsnemo/mesh/calculus/__init__.py
@@ -35,12 +35,16 @@ Both intrinsic (manifold tangent space) and extrinsic (ambient space) derivative
 are supported for manifolds embedded in higher-dimensional spaces.
 """
 
-from physicsnemo.mesh.calculus.curl import compute_curl_points_lsq
+from physicsnemo.mesh.calculus.curl import (
+    compute_curl_cells_lsq,
+    compute_curl_points_lsq,
+)
 from physicsnemo.mesh.calculus.derivatives import (
     compute_cell_derivatives,
     compute_point_derivatives,
 )
 from physicsnemo.mesh.calculus.divergence import (
+    compute_divergence_cells_lsq,
     compute_divergence_points_dec,
     compute_divergence_points_lsq,
 )

--- a/physicsnemo/mesh/calculus/curl.py
+++ b/physicsnemo/mesh/calculus/curl.py
@@ -80,21 +80,67 @@ def compute_curl_points_lsq(
 
     from physicsnemo.mesh.calculus._lsq_reconstruction import compute_point_gradient_lsq
 
-    n_points = mesh.n_points
-
     ### Compute full Jacobian in one batched LSQ solve
     # vector_field: (n_points, 3) -> jacobian: (n_points, 3, 3)
     # jacobian[i, j, k] = ∂v_j/∂x_k
     jacobian = compute_point_gradient_lsq(mesh, vector_field)
 
-    ### Compute curl from Jacobian
-    # curl = [∂vz/∂y - ∂vy/∂z, ∂vx/∂z - ∂vz/∂x, ∂vy/∂x - ∂vx/∂y]
-    curl = torch.zeros(
-        (n_points, 3), dtype=vector_field.dtype, device=mesh.points.device
+    return _curl_from_jacobian(jacobian)
+
+
+def compute_curl_cells_lsq(
+    mesh: "Mesh",
+    vector_field: Float[torch.Tensor, "n_cells 3"],
+) -> Float[torch.Tensor, "n_cells 3"]:
+    r"""Compute curl at cell centers using LSQ gradient method.
+
+    Cell-centered analogue of :func:`compute_curl_points_lsq`: computes the
+    Jacobian of the vector field via the cell-neighbour LSQ gradient, then
+    takes its antisymmetric part.
+
+    Parameters
+    ----------
+    mesh : Mesh
+        Simplicial mesh.
+    vector_field : Float[torch.Tensor, "n_cells 3"]
+        Vectors at cell centers.
+
+    Returns
+    -------
+    Float[torch.Tensor, "n_cells 3"]
+        Curl at cell centers.
+
+    Raises
+    ------
+    ValueError
+        If ``n_spatial_dims != 3``.
+    """
+    if mesh.n_spatial_dims != 3:
+        raise ValueError(
+            f"Curl is only defined for 3D vector fields, got {mesh.n_spatial_dims=}"
+        )
+
+    from physicsnemo.mesh.calculus._lsq_reconstruction import compute_cell_gradient_lsq
+
+    # vector_field: (n_cells, 3) -> jacobian: (n_cells, 3, 3)
+    jacobian = compute_cell_gradient_lsq(mesh, vector_field)
+
+    return _curl_from_jacobian(jacobian)
+
+
+def _curl_from_jacobian(
+    jacobian: Float[torch.Tensor, "n 3 3"],
+) -> Float[torch.Tensor, "n 3"]:
+    r"""Extract the curl (antisymmetric part) from a batch of 3D Jacobians.
+
+    With ``jacobian[i, j, k] = ∂v_j/∂x_k``:
+    curl = [∂vz/∂y - ∂vy/∂z, ∂vx/∂z - ∂vz/∂x, ∂vy/∂x - ∂vx/∂y].
+    """
+    return torch.stack(
+        [
+            jacobian[:, 2, 1] - jacobian[:, 1, 2],
+            jacobian[:, 0, 2] - jacobian[:, 2, 0],
+            jacobian[:, 1, 0] - jacobian[:, 0, 1],
+        ],
+        dim=-1,
     )
-
-    curl[:, 0] = jacobian[:, 2, 1] - jacobian[:, 1, 2]  # ∂vz/∂y - ∂vy/∂z
-    curl[:, 1] = jacobian[:, 0, 2] - jacobian[:, 2, 0]  # ∂vx/∂z - ∂vz/∂x
-    curl[:, 2] = jacobian[:, 1, 0] - jacobian[:, 0, 1]  # ∂vy/∂x - ∂vx/∂y
-
-    return curl

--- a/physicsnemo/mesh/calculus/divergence.py
+++ b/physicsnemo/mesh/calculus/divergence.py
@@ -171,3 +171,33 @@ def compute_divergence_points_lsq(
 
     ### Divergence = trace of Jacobian = Σ_k ∂v_k/∂x_k
     return torch.einsum("...ii", jacobian)
+
+
+def compute_divergence_cells_lsq(
+    mesh: "Mesh",
+    vector_field: Float[torch.Tensor, "n_cells n_spatial_dims"],
+) -> Float[torch.Tensor, " n_cells"]:
+    r"""Compute divergence at cell centers using the LSQ Jacobian trace.
+
+    Cell-centered analogue of :func:`compute_divergence_points_lsq`: computes
+    the full Jacobian via a single batched cell-neighbour LSQ solve, then takes
+    the trace.
+
+    Parameters
+    ----------
+    mesh : Mesh
+        Simplicial mesh.
+    vector_field : torch.Tensor
+        Vectors at cell centers, shape ``(n_cells, n_spatial_dims)``.
+
+    Returns
+    -------
+    Float[torch.Tensor, " n_cells"]
+        Divergence at cell centers, shape ``(n_cells,)``.
+    """
+    from physicsnemo.mesh.calculus._lsq_reconstruction import compute_cell_gradient_lsq
+
+    # J[i, j, k] = ∂v_j/∂x_k, shape (n_cells, n_spatial_dims, n_spatial_dims)
+    jacobian = compute_cell_gradient_lsq(mesh, vector_field)
+
+    return torch.einsum("...ii", jacobian)

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -2739,6 +2739,132 @@ class Mesh:
             data_source=data_source,
         )
 
+    def gradient(
+        self,
+        field: "str | tuple[str, ...] | torch.Tensor",
+        method: Literal["lsq", "dec"] = "lsq",
+        gradient_type: Literal["intrinsic", "extrinsic"] = "intrinsic",
+    ) -> torch.Tensor:
+        r"""Gradient of a point field, returned as a tensor.
+
+        Single-field convenience that returns the gradient tensor directly,
+        accepting a field key (looked up in ``point_data``) or a raw tensor --
+        mirroring :meth:`integrate`. (Contrast :meth:`compute_point_derivatives`,
+        which returns a *new mesh* with the gradient stored under an auto-generated
+        key, and can process several fields at once.)
+
+        Parameters
+        ----------
+        field : str, tuple[str, ...], or torch.Tensor
+            Point field, by ``point_data`` key or by value.
+        method : {"lsq", "dec"}
+            Discretization (default ``"lsq"``).
+        gradient_type : {"intrinsic", "extrinsic"}
+            Project onto the tangent space (``"intrinsic"``, default) or use the
+            full ambient-space gradient (``"extrinsic"``).
+
+        Returns
+        -------
+        torch.Tensor
+            Gradient of shape ``(n_points, n_spatial_dims, *field.shape[1:])``.
+        """
+        from physicsnemo.mesh.calculus.gradient import (
+            compute_gradient_points_dec,
+            compute_gradient_points_lsq,
+            project_to_tangent_space,
+        )
+        from physicsnemo.mesh.calculus.integration import _resolve_field
+
+        values = _resolve_field(self, field, "points")
+        if method == "lsq":
+            return compute_gradient_points_lsq(
+                self, values, intrinsic=(gradient_type == "intrinsic")
+            )
+        if method == "dec":
+            grad = compute_gradient_points_dec(self, values)
+            if gradient_type == "intrinsic":
+                grad = project_to_tangent_space(self, grad, "points")
+            return grad
+        raise ValueError(f"Invalid {method=}. Must be 'lsq' or 'dec'.")
+
+    def divergence(
+        self,
+        field: "str | tuple[str, ...] | torch.Tensor",
+        method: Literal["lsq", "dec"] = "lsq",
+    ) -> torch.Tensor:
+        r"""Divergence of a vector point field, returned as a tensor.
+
+        Accepts a field key (looked up in ``point_data``) or a raw vector tensor
+        of shape ``(n_points, n_spatial_dims)``, mirroring :meth:`integrate`.
+
+        Parameters
+        ----------
+        field : str, tuple[str, ...], or torch.Tensor
+            Vector point field, by ``point_data`` key or by value.
+        method : {"lsq", "dec"}
+            Discretization (default ``"lsq"``).
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar divergence at each vertex, shape ``(n_points,)``.
+        """
+        from physicsnemo.mesh.calculus.divergence import (
+            compute_divergence_points_dec,
+            compute_divergence_points_lsq,
+        )
+        from physicsnemo.mesh.calculus.integration import _resolve_field
+
+        values = _resolve_field(self, field, "points")
+        if method == "lsq":
+            return compute_divergence_points_lsq(self, values)
+        if method == "dec":
+            return compute_divergence_points_dec(self, values)
+        raise ValueError(f"Invalid {method=}. Must be 'lsq' or 'dec'.")
+
+    def curl(
+        self,
+        field: "str | tuple[str, ...] | torch.Tensor",
+    ) -> torch.Tensor:
+        r"""Curl of a 3D vector point field (LSQ), returned as a tensor.
+
+        Accepts a field key (looked up in ``point_data``) or a raw vector tensor
+        of shape ``(n_points, 3)``, mirroring :meth:`integrate`. Only defined for
+        ``n_spatial_dims == 3``.
+
+        Returns
+        -------
+        torch.Tensor
+            Curl vector at each vertex, shape ``(n_points, 3)``.
+        """
+        from physicsnemo.mesh.calculus.curl import compute_curl_points_lsq
+        from physicsnemo.mesh.calculus.integration import _resolve_field
+
+        values = _resolve_field(self, field, "points")
+        return compute_curl_points_lsq(self, values)
+
+    def laplacian(
+        self,
+        field: "str | tuple[str, ...] | torch.Tensor",
+    ) -> torch.Tensor:
+        r"""Laplace-Beltrami operator on a point field (DEC), returned as a tensor.
+
+        Uses the intrinsic cotangent Laplacian
+        (:func:`physicsnemo.mesh.calculus.compute_laplacian_points_dec`). Accepts a
+        field key (looked up in ``point_data``) or a raw point tensor, mirroring
+        :meth:`integrate`.
+
+        Returns
+        -------
+        torch.Tensor
+            Laplace-Beltrami of the field, same shape as the input field.
+        """
+        from physicsnemo.mesh.calculus.integration import _resolve_field
+        from physicsnemo.mesh.calculus.laplacian import compute_laplacian_points_dec
+
+        values = _resolve_field(self, field, "points")
+        return compute_laplacian_points_dec(self, values)
+
     def validate(
         self,
         check_degenerate_cells: bool = True,

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -30,6 +30,7 @@ from typing import (
 
 import torch
 import torch.nn.functional as F
+from jaxtyping import Float
 from tensordict import NonTensorData, TensorDict, tensorclass
 
 from physicsnemo.mesh.geometry._cell_areas import compute_cell_areas
@@ -2741,11 +2742,11 @@ class Mesh:
 
     def gradient(
         self,
-        field: "str | tuple[str, ...] | torch.Tensor",
+        field: str | tuple[str, ...] | Float[torch.Tensor, "n ..."],
         method: Literal["lsq", "dec"] = "lsq",
         gradient_type: Literal["intrinsic", "extrinsic"] = "intrinsic",
         data_source: Literal["points", "cells"] = "points",
-    ) -> torch.Tensor:
+    ) -> Float[torch.Tensor, "n n_spatial_dims ..."]:
         r"""Gradient of a point or cell field, returned as a tensor.
 
         Single-field convenience that returns the gradient tensor directly,
@@ -2784,35 +2785,42 @@ class Mesh:
         )
         from physicsnemo.mesh.calculus.integration import _resolve_field
 
-        values = _resolve_field(self, field, data_source)
-        if method == "lsq":
-            if data_source == "cells":
-                grad = compute_gradient_cells_lsq(self, values)
-                if gradient_type == "intrinsic":
-                    grad = project_to_tangent_space(self, grad, "cells")
-                return grad
-            return compute_gradient_points_lsq(
-                self, values, intrinsic=(gradient_type == "intrinsic")
+        if gradient_type not in ("intrinsic", "extrinsic"):
+            raise ValueError(
+                f"Invalid {gradient_type=!r}. Must be 'intrinsic' or 'extrinsic'."
             )
-        if method == "dec":
-            if data_source == "cells":
+
+        values = _resolve_field(self, field, data_source)
+        match method, data_source:
+            case ("lsq", "points"):
+                return compute_gradient_points_lsq(
+                    self, values, intrinsic=(gradient_type == "intrinsic")
+                )
+            case ("lsq", "cells"):
+                grad = compute_gradient_cells_lsq(self, values)
+            case ("dec", "points"):
+                grad = compute_gradient_points_dec(self, values)
+            case ("dec", "cells"):
                 raise NotImplementedError(
                     "DEC gradients are not available for cell data: the DEC "
                     "exterior derivative maps vertex 0-forms to edge 1-forms, and "
                     "there is no analogous cell-to-cell operator. Use method='lsq'."
                 )
-            grad = compute_gradient_points_dec(self, values)
-            if gradient_type == "intrinsic":
-                grad = project_to_tangent_space(self, grad, "points")
-            return grad
-        raise ValueError(f"Invalid {method=}. Must be 'lsq' or 'dec'.")
+            case _:
+                raise ValueError(
+                    f"Invalid {method=!r} (must be 'lsq' or 'dec') or "
+                    f"{data_source=!r} (must be 'points' or 'cells')."
+                )
+        if gradient_type == "intrinsic":
+            grad = project_to_tangent_space(self, grad, data_source)
+        return grad
 
     def divergence(
         self,
-        field: "str | tuple[str, ...] | torch.Tensor",
+        field: str | tuple[str, ...] | Float[torch.Tensor, "n n_spatial_dims"],
         method: Literal["lsq", "dec"] = "lsq",
         data_source: Literal["points", "cells"] = "points",
-    ) -> torch.Tensor:
+    ) -> Float[torch.Tensor, " n"]:
         r"""Divergence of a vector point or cell field, returned as a tensor.
 
         Accepts a field key (looked up in ``point_data`` / ``cell_data``
@@ -2843,24 +2851,29 @@ class Mesh:
         from physicsnemo.mesh.calculus.integration import _resolve_field
 
         values = _resolve_field(self, field, data_source)
-        if method == "lsq":
-            if data_source == "cells":
+        match method, data_source:
+            case ("lsq", "points"):
+                return compute_divergence_points_lsq(self, values)
+            case ("lsq", "cells"):
                 return compute_divergence_cells_lsq(self, values)
-            return compute_divergence_points_lsq(self, values)
-        if method == "dec":
-            if data_source == "cells":
+            case ("dec", "points"):
+                return compute_divergence_points_dec(self, values)
+            case ("dec", "cells"):
                 raise NotImplementedError(
                     "DEC divergence is not available for cell data (the DEC "
                     "operators act on vertex forms). Use method='lsq'."
                 )
-            return compute_divergence_points_dec(self, values)
-        raise ValueError(f"Invalid {method=}. Must be 'lsq' or 'dec'.")
+            case _:
+                raise ValueError(
+                    f"Invalid {method=!r} (must be 'lsq' or 'dec') or "
+                    f"{data_source=!r} (must be 'points' or 'cells')."
+                )
 
     def curl(
         self,
-        field: "str | tuple[str, ...] | torch.Tensor",
+        field: str | tuple[str, ...] | Float[torch.Tensor, "n 3"],
         data_source: Literal["points", "cells"] = "points",
-    ) -> torch.Tensor:
+    ) -> Float[torch.Tensor, "n 3"]:
         r"""Curl of a 3D vector point or cell field (LSQ), returned as a tensor.
 
         Accepts a field key (looked up in ``point_data`` / ``cell_data``
@@ -2888,15 +2901,21 @@ class Mesh:
         from physicsnemo.mesh.calculus.integration import _resolve_field
 
         values = _resolve_field(self, field, data_source)
-        if data_source == "cells":
-            return compute_curl_cells_lsq(self, values)
-        return compute_curl_points_lsq(self, values)
+        match data_source:
+            case "points":
+                return compute_curl_points_lsq(self, values)
+            case "cells":
+                return compute_curl_cells_lsq(self, values)
+            case _:
+                raise ValueError(
+                    f"Invalid {data_source=!r}. Must be 'points' or 'cells'."
+                )
 
     def laplacian(
         self,
-        field: "str | tuple[str, ...] | torch.Tensor",
+        field: str | tuple[str, ...] | Float[torch.Tensor, "n ..."],
         data_source: Literal["points", "cells"] = "points",
-    ) -> torch.Tensor:
+    ) -> Float[torch.Tensor, "n ..."]:
         r"""Laplace-Beltrami operator on a point field (DEC), returned as a tensor.
 
         Uses the intrinsic cotangent Laplacian
@@ -2926,16 +2945,22 @@ class Mesh:
         from physicsnemo.mesh.calculus.integration import _resolve_field
         from physicsnemo.mesh.calculus.laplacian import compute_laplacian_points_dec
 
-        if data_source == "cells":
-            raise NotImplementedError(
-                "Mesh.laplacian only supports point data: the cotangent "
-                "Laplace-Beltrami operator is defined on vertex functions, and "
-                "there is no DEC Laplacian for cell-centered data. For a "
-                "cell-centered Laplacian, compose divergence(gradient(...)) with "
-                "data_source='cells' explicitly."
-            )
-        values = _resolve_field(self, field, "points")
-        return compute_laplacian_points_dec(self, values)
+        match data_source:
+            case "points":
+                values = _resolve_field(self, field, "points")
+                return compute_laplacian_points_dec(self, values)
+            case "cells":
+                raise NotImplementedError(
+                    "Mesh.laplacian only supports point data: the cotangent "
+                    "Laplace-Beltrami operator is defined on vertex functions, and "
+                    "there is no DEC Laplacian for cell-centered data. For a "
+                    "cell-centered Laplacian, compose divergence(gradient(...)) with "
+                    "data_source='cells' explicitly."
+                )
+            case _:
+                raise ValueError(
+                    f"Invalid {data_source=!r}. Must be 'points' or 'cells'."
+                )
 
     def validate(
         self,

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -2739,6 +2739,204 @@ class Mesh:
             data_source=data_source,
         )
 
+    def gradient(
+        self,
+        field: "str | tuple[str, ...] | torch.Tensor",
+        method: Literal["lsq", "dec"] = "lsq",
+        gradient_type: Literal["intrinsic", "extrinsic"] = "intrinsic",
+        data_source: Literal["points", "cells"] = "points",
+    ) -> torch.Tensor:
+        r"""Gradient of a point or cell field, returned as a tensor.
+
+        Single-field convenience that returns the gradient tensor directly,
+        accepting a field key (looked up in ``point_data`` / ``cell_data``
+        according to ``data_source``) or a raw tensor -- mirroring
+        :meth:`integrate`. (Contrast :meth:`compute_point_derivatives` /
+        :meth:`compute_cell_derivatives`, which return a *new mesh* with the
+        gradient stored under an auto-generated key, and can process several
+        fields at once.)
+
+        Parameters
+        ----------
+        field : str, tuple[str, ...], or torch.Tensor
+            Field, by data key or by value.
+        method : {"lsq", "dec"}
+            Discretization (default ``"lsq"``). ``"dec"`` is only available for
+            point data: the DEC exterior derivative maps vertex 0-forms to edge
+            1-forms, and there is no analogous cell-to-cell operator.
+        gradient_type : {"intrinsic", "extrinsic"}
+            Project onto the tangent space (``"intrinsic"``, default) or use the
+            full ambient-space gradient (``"extrinsic"``).
+        data_source : {"points", "cells"}, optional
+            Whether ``field`` lives at vertices (default) or at cell centers.
+
+        Returns
+        -------
+        torch.Tensor
+            Gradient of shape ``(n, n_spatial_dims, *field.shape[1:])``, where
+            ``n`` is ``n_points`` or ``n_cells`` according to ``data_source``.
+        """
+        from physicsnemo.mesh.calculus.gradient import (
+            compute_gradient_cells_lsq,
+            compute_gradient_points_dec,
+            compute_gradient_points_lsq,
+            project_to_tangent_space,
+        )
+        from physicsnemo.mesh.calculus.integration import _resolve_field
+
+        values = _resolve_field(self, field, data_source)
+        if method == "lsq":
+            if data_source == "cells":
+                grad = compute_gradient_cells_lsq(self, values)
+                if gradient_type == "intrinsic":
+                    grad = project_to_tangent_space(self, grad, "cells")
+                return grad
+            return compute_gradient_points_lsq(
+                self, values, intrinsic=(gradient_type == "intrinsic")
+            )
+        if method == "dec":
+            if data_source == "cells":
+                raise NotImplementedError(
+                    "DEC gradients are not available for cell data: the DEC "
+                    "exterior derivative maps vertex 0-forms to edge 1-forms, and "
+                    "there is no analogous cell-to-cell operator. Use method='lsq'."
+                )
+            grad = compute_gradient_points_dec(self, values)
+            if gradient_type == "intrinsic":
+                grad = project_to_tangent_space(self, grad, "points")
+            return grad
+        raise ValueError(f"Invalid {method=}. Must be 'lsq' or 'dec'.")
+
+    def divergence(
+        self,
+        field: "str | tuple[str, ...] | torch.Tensor",
+        method: Literal["lsq", "dec"] = "lsq",
+        data_source: Literal["points", "cells"] = "points",
+    ) -> torch.Tensor:
+        r"""Divergence of a vector point or cell field, returned as a tensor.
+
+        Accepts a field key (looked up in ``point_data`` / ``cell_data``
+        according to ``data_source``) or a raw vector tensor of shape
+        ``(n, n_spatial_dims)``, mirroring :meth:`integrate`.
+
+        Parameters
+        ----------
+        field : str, tuple[str, ...], or torch.Tensor
+            Vector field, by data key or by value.
+        method : {"lsq", "dec"}
+            Discretization (default ``"lsq"``). ``"dec"`` is only available for
+            point data (the DEC operators act on vertex forms).
+        data_source : {"points", "cells"}, optional
+            Whether ``field`` lives at vertices (default) or at cell centers.
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar divergence per entity, shape ``(n_points,)`` or ``(n_cells,)``
+            according to ``data_source``.
+        """
+        from physicsnemo.mesh.calculus.divergence import (
+            compute_divergence_cells_lsq,
+            compute_divergence_points_dec,
+            compute_divergence_points_lsq,
+        )
+        from physicsnemo.mesh.calculus.integration import _resolve_field
+
+        values = _resolve_field(self, field, data_source)
+        if method == "lsq":
+            if data_source == "cells":
+                return compute_divergence_cells_lsq(self, values)
+            return compute_divergence_points_lsq(self, values)
+        if method == "dec":
+            if data_source == "cells":
+                raise NotImplementedError(
+                    "DEC divergence is not available for cell data (the DEC "
+                    "operators act on vertex forms). Use method='lsq'."
+                )
+            return compute_divergence_points_dec(self, values)
+        raise ValueError(f"Invalid {method=}. Must be 'lsq' or 'dec'.")
+
+    def curl(
+        self,
+        field: "str | tuple[str, ...] | torch.Tensor",
+        data_source: Literal["points", "cells"] = "points",
+    ) -> torch.Tensor:
+        r"""Curl of a 3D vector point or cell field (LSQ), returned as a tensor.
+
+        Accepts a field key (looked up in ``point_data`` / ``cell_data``
+        according to ``data_source``) or a raw vector tensor of shape
+        ``(n, 3)``, mirroring :meth:`integrate`. Only defined for
+        ``n_spatial_dims == 3``.
+
+        Parameters
+        ----------
+        field : str, tuple[str, ...], or torch.Tensor
+            Vector field, by data key or by value.
+        data_source : {"points", "cells"}, optional
+            Whether ``field`` lives at vertices (default) or at cell centers.
+
+        Returns
+        -------
+        torch.Tensor
+            Curl vector per entity, shape ``(n_points, 3)`` or ``(n_cells, 3)``
+            according to ``data_source``.
+        """
+        from physicsnemo.mesh.calculus.curl import (
+            compute_curl_cells_lsq,
+            compute_curl_points_lsq,
+        )
+        from physicsnemo.mesh.calculus.integration import _resolve_field
+
+        values = _resolve_field(self, field, data_source)
+        if data_source == "cells":
+            return compute_curl_cells_lsq(self, values)
+        return compute_curl_points_lsq(self, values)
+
+    def laplacian(
+        self,
+        field: "str | tuple[str, ...] | torch.Tensor",
+        data_source: Literal["points", "cells"] = "points",
+    ) -> torch.Tensor:
+        r"""Laplace-Beltrami operator on a point field (DEC), returned as a tensor.
+
+        Uses the intrinsic cotangent Laplacian
+        (:func:`physicsnemo.mesh.calculus.compute_laplacian_points_dec`). Accepts a
+        field key (looked up in ``point_data``) or a raw point tensor, mirroring
+        :meth:`integrate`.
+
+        Parameters
+        ----------
+        field : str, tuple[str, ...], or torch.Tensor
+            Point field, by ``point_data`` key or by value.
+        data_source : {"points", "cells"}, optional
+            Only ``"points"`` is supported: the cotangent Laplace-Beltrami
+            operator is defined on vertex functions, and there is no DEC
+            Laplacian for cell-centered data. The kwarg exists for signature
+            consistency with :meth:`gradient` / :meth:`divergence` / :meth:`curl`;
+            passing ``"cells"`` raises. (For a cell-centered Laplacian, compose
+            ``mesh.divergence(mesh.gradient(f, gradient_type="extrinsic",
+            data_source="cells"), data_source="cells")`` explicitly -- a double-LSQ
+            discretization with different accuracy properties.)
+
+        Returns
+        -------
+        torch.Tensor
+            Laplace-Beltrami of the field, same shape as the input field.
+        """
+        from physicsnemo.mesh.calculus.integration import _resolve_field
+        from physicsnemo.mesh.calculus.laplacian import compute_laplacian_points_dec
+
+        if data_source == "cells":
+            raise NotImplementedError(
+                "Mesh.laplacian only supports point data: the cotangent "
+                "Laplace-Beltrami operator is defined on vertex functions, and "
+                "there is no DEC Laplacian for cell-centered data. For a "
+                "cell-centered Laplacian, compose divergence(gradient(...)) with "
+                "data_source='cells' explicitly."
+            )
+        values = _resolve_field(self, field, "points")
+        return compute_laplacian_points_dec(self, values)
+
     def validate(
         self,
         check_degenerate_cells: bool = True,

--- a/test/mesh/calculus/test_calculus.py
+++ b/test/mesh/calculus/test_calculus.py
@@ -2536,5 +2536,69 @@ class TestCotanWeightsFEM:
         assert len(weights) == len(edges)
 
 
+class TestMeshCalculusConvenienceMethods:
+    """The tensor-returning Mesh.gradient/divergence/curl/laplacian methods.
+
+    They mirror Mesh.integrate (return a tensor; accept a point_data key or a raw
+    tensor) and must agree with the underlying free functions.
+    """
+
+    @staticmethod
+    def _surface():
+        from physicsnemo.mesh.primitives.surfaces import sphere_icosahedral
+
+        return sphere_icosahedral.load(subdivisions=2)  # 2-manifold in 3D
+
+    def test_gradient_matches_free_function_by_key_and_tensor(self):
+        from physicsnemo.mesh.calculus import compute_gradient_points_lsq
+
+        mesh = self._surface()
+        f = mesh.points[:, 0].clone()
+        mesh.point_data["f"] = f
+        expected = compute_gradient_points_lsq(mesh, f, intrinsic=True)
+        assert torch.allclose(mesh.gradient(f), expected, atol=1e-6)
+        assert torch.allclose(mesh.gradient("f"), expected, atol=1e-6)
+        # extrinsic differs from the (default) intrinsic gradient on a curved surface
+        assert not torch.allclose(
+            mesh.gradient("f", gradient_type="extrinsic"), expected, atol=1e-4
+        )
+
+    def test_divergence_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_divergence_points_lsq
+
+        mesh = self._surface()
+        v = mesh.points.clone()
+        mesh.point_data["v"] = v
+        expected = compute_divergence_points_lsq(mesh, v)
+        assert torch.allclose(mesh.divergence("v"), expected, atol=1e-6)
+        assert torch.allclose(mesh.divergence(v), expected, atol=1e-6)
+
+    def test_curl_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_curl_points_lsq
+
+        mesh = self._surface()
+        v = mesh.points.clone()
+        expected = compute_curl_points_lsq(mesh, v)
+        assert torch.allclose(mesh.curl(v), expected, atol=1e-6)
+
+    def test_laplacian_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_laplacian_points_dec
+
+        mesh = self._surface()
+        f = (mesh.points**2).sum(-1)
+        mesh.point_data["f"] = f
+        expected = compute_laplacian_points_dec(mesh, f)
+        assert torch.allclose(mesh.laplacian("f"), expected, atol=1e-6)
+        assert torch.allclose(mesh.laplacian(f), expected, atol=1e-6)
+
+    def test_invalid_method_raises(self):
+        mesh = self._surface()
+        mesh.point_data["f"] = mesh.points[:, 0].clone()
+        with pytest.raises(ValueError, match="method"):
+            mesh.gradient("f", method="bogus")
+        with pytest.raises(ValueError, match="method"):
+            mesh.divergence("f", method="bogus")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/mesh/calculus/test_calculus.py
+++ b/test/mesh/calculus/test_calculus.py
@@ -2599,6 +2599,29 @@ class TestMeshCalculusConvenienceMethods:
         with pytest.raises(ValueError, match="method"):
             mesh.divergence("f", method="bogus")
 
+    def test_invalid_data_source_raises(self):
+        """A typo'd data_source (e.g. 'cell' for 'cells') must raise, never
+        silently fall back to the points path. Raw tensors are passed so the
+        methods' own dispatch (not just _resolve_field's key lookup) is what
+        rejects the value."""
+        mesh = self._surface()
+        f = mesh.points[:, 0].clone()
+        v = mesh.points.clone()
+        with pytest.raises(ValueError, match="data_source"):
+            mesh.gradient(f, data_source="cell")
+        with pytest.raises(ValueError, match="data_source"):
+            mesh.divergence(v, data_source="Points")
+        with pytest.raises(ValueError, match="data_source"):
+            mesh.curl(v, data_source="bogus")
+        with pytest.raises(ValueError, match="data_source"):
+            mesh.laplacian(f, data_source="vertices")
+
+    def test_invalid_gradient_type_raises(self):
+        mesh = self._surface()
+        f = mesh.points[:, 0].clone()
+        with pytest.raises(ValueError, match="gradient_type"):
+            mesh.gradient(f, gradient_type="bogus")
+
     def test_gradient_cells_matches_free_function(self):
         from physicsnemo.mesh.calculus import compute_gradient_cells_lsq
         from physicsnemo.mesh.calculus.gradient import project_to_tangent_space

--- a/test/mesh/calculus/test_calculus.py
+++ b/test/mesh/calculus/test_calculus.py
@@ -2536,5 +2536,126 @@ class TestCotanWeightsFEM:
         assert len(weights) == len(edges)
 
 
+class TestMeshCalculusConvenienceMethods:
+    """The tensor-returning Mesh.gradient/divergence/curl/laplacian methods.
+
+    They mirror Mesh.integrate (return a tensor; accept a point_data key or a raw
+    tensor) and must agree with the underlying free functions.
+    """
+
+    @staticmethod
+    def _surface():
+        from physicsnemo.mesh.primitives.surfaces import sphere_icosahedral
+
+        return sphere_icosahedral.load(subdivisions=2)  # 2-manifold in 3D
+
+    def test_gradient_matches_free_function_by_key_and_tensor(self):
+        from physicsnemo.mesh.calculus import compute_gradient_points_lsq
+
+        mesh = self._surface()
+        f = mesh.points[:, 0].clone()
+        mesh.point_data["f"] = f
+        expected = compute_gradient_points_lsq(mesh, f, intrinsic=True)
+        assert torch.allclose(mesh.gradient(f), expected, atol=1e-6)
+        assert torch.allclose(mesh.gradient("f"), expected, atol=1e-6)
+        # extrinsic differs from the (default) intrinsic gradient on a curved surface
+        assert not torch.allclose(
+            mesh.gradient("f", gradient_type="extrinsic"), expected, atol=1e-4
+        )
+
+    def test_divergence_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_divergence_points_lsq
+
+        mesh = self._surface()
+        v = mesh.points.clone()
+        mesh.point_data["v"] = v
+        expected = compute_divergence_points_lsq(mesh, v)
+        assert torch.allclose(mesh.divergence("v"), expected, atol=1e-6)
+        assert torch.allclose(mesh.divergence(v), expected, atol=1e-6)
+
+    def test_curl_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_curl_points_lsq
+
+        mesh = self._surface()
+        v = mesh.points.clone()
+        expected = compute_curl_points_lsq(mesh, v)
+        assert torch.allclose(mesh.curl(v), expected, atol=1e-6)
+
+    def test_laplacian_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_laplacian_points_dec
+
+        mesh = self._surface()
+        f = (mesh.points**2).sum(-1)
+        mesh.point_data["f"] = f
+        expected = compute_laplacian_points_dec(mesh, f)
+        assert torch.allclose(mesh.laplacian("f"), expected, atol=1e-6)
+        assert torch.allclose(mesh.laplacian(f), expected, atol=1e-6)
+
+    def test_invalid_method_raises(self):
+        mesh = self._surface()
+        mesh.point_data["f"] = mesh.points[:, 0].clone()
+        with pytest.raises(ValueError, match="method"):
+            mesh.gradient("f", method="bogus")
+        with pytest.raises(ValueError, match="method"):
+            mesh.divergence("f", method="bogus")
+
+    def test_gradient_cells_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_gradient_cells_lsq
+        from physicsnemo.mesh.calculus.gradient import project_to_tangent_space
+
+        mesh = self._surface()
+        f = mesh.cell_centroids[:, 0].clone()
+        mesh.cell_data["f"] = f
+        expected_extrinsic = compute_gradient_cells_lsq(mesh, f)
+        expected_intrinsic = project_to_tangent_space(mesh, expected_extrinsic, "cells")
+        got = mesh.gradient("f", gradient_type="extrinsic", data_source="cells")
+        assert got.shape == (mesh.n_cells, 3)
+        assert torch.allclose(got, expected_extrinsic, atol=1e-6)
+        assert torch.allclose(
+            mesh.gradient(f, data_source="cells"), expected_intrinsic, atol=1e-6
+        )
+
+    def test_divergence_cells_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_divergence_cells_lsq
+
+        mesh = self._surface()
+        v = mesh.cell_centroids.clone()
+        mesh.cell_data["v"] = v
+        expected = compute_divergence_cells_lsq(mesh, v)
+        assert expected.shape == (mesh.n_cells,)
+        assert torch.allclose(
+            mesh.divergence("v", data_source="cells"), expected, atol=1e-6
+        )
+        assert torch.allclose(
+            mesh.divergence(v, data_source="cells"), expected, atol=1e-6
+        )
+
+    def test_curl_cells_matches_free_function(self):
+        from physicsnemo.mesh.calculus import compute_curl_cells_lsq
+
+        mesh = self._surface()
+        # Rotational field v = (-y, x, 0): curl = (0, 0, 2), so the comparison is
+        # against an O(1) signal rather than pure floating-point noise.
+        c = mesh.cell_centroids
+        v = torch.stack([-c[:, 1], c[:, 0], torch.zeros_like(c[:, 2])], dim=-1)
+        expected = compute_curl_cells_lsq(mesh, v)
+        assert expected.shape == (mesh.n_cells, 3)
+        assert torch.allclose(mesh.curl(v, data_source="cells"), expected, atol=1e-6)
+
+    def test_cells_unsupported_combinations_raise(self):
+        """DEC operators and the cotangent Laplacian are vertex-only; cell-data
+        requests must fail loudly with an explanation, not silently degrade."""
+        mesh = self._surface()
+        f = mesh.cell_centroids[:, 0].clone()
+        with pytest.raises(NotImplementedError, match="cell"):
+            mesh.gradient(f, method="dec", data_source="cells")
+        with pytest.raises(NotImplementedError, match="cell"):
+            mesh.divergence(
+                mesh.cell_centroids.clone(), method="dec", data_source="cells"
+            )
+        with pytest.raises(NotImplementedError, match="vertex"):
+            mesh.laplacian(f, data_source="cells")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Standardizes the discrete differential operators on a single, discoverable Mesh surface that mirrors Mesh.integrate: each method returns a tensor and accepts a point_data key (str/tuple) or a raw tensor.

- `Mesh.gradient(field, method=lsq|dec, gradient_type=intrinsic|extrinsic)`
- `Mesh.divergence(field, method=lsq|dec)`
- `Mesh.curl(field)`  (3D only, LSQ)
- `Mesh.laplacian(field)`  (DEC cotangent Laplace-Beltrami)

Previously only gradient had a Mesh entry point (compute_point_derivatives, which returns a new mesh); divergence/curl/laplacian were reachable only as free functions in physicsnemo.mesh.calculus. compute_point_derivatives is retained unchanged as the batch/mesh-returning convenience. Adds tests asserting each method matches its free function for both key and tensor inputs.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
