### PR TITLE
Mesh: Docs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,16 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `physicsnemo.mesh`: reconciled the README feature matrix and several docstrings
-  with the implementation — Laplace-Beltrami (DEC) is marked implemented
-  (`physicsnemo.mesh.calculus.compute_laplacian_points_dec`); the README
-  "Projection" row is split into the implemented coordinate projection (drop
-  ambient dims) and the still-WIP surface projection / mesh intersection; and the
-  `compute_point_derivatives` (returns a new mesh, not in place),
-  `gaussian_curvature_cells`, `compute_cell_normals` (orientation-defined, not
-  "outward"), and butterfly-subdivision docstrings (and the primitives README
-  import path) were corrected.
-
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `physicsnemo.mesh`: reconciled the README feature matrix and several docstrings
+  with the implementation — Laplace-Beltrami (DEC) is marked implemented
+  (`physicsnemo.mesh.calculus.compute_laplacian_points_dec`); the README
+  "Projection" row is split into the implemented coordinate projection (drop
+  ambient dims) and the still-WIP surface projection / mesh intersection; and the
+  `compute_point_derivatives` (returns a new mesh, not in place),
+  `gaussian_curvature_cells`, `compute_cell_normals` (orientation-defined, not
+  "outward"), and butterfly-subdivision docstrings (and the primitives README
+  import path) were corrected.
+
 ### Deprecated
 
 ### Removed

--- a/physicsnemo/mesh/README.md
+++ b/physicsnemo/mesh/README.md
@@ -279,7 +279,7 @@ Comprehensive overview of PhysicsNeMo-Mesh capabilities:
 | Divergence (LSQ) | ✅ | Component-wise gradients |
 | Divergence (DEC) | ✅ | Explicit dual volume formula |
 | Curl (LSQ, 3D only) | ✅ | Antisymmetric [Jacobian](https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant) |
-| Laplace-Beltrami (DEC) | ❌ |  Work in progress |
+| Laplace-Beltrami (DEC) | ✅ | Cotangent Laplacian (`physicsnemo.mesh.calculus.compute_laplacian_points_dec`) |
 | Intrinsic derivatives | ✅ | Tangent space projection |
 | Extrinsic derivatives | ✅ | Ambient space |
 | **Geometry** | | |
@@ -315,7 +315,8 @@ Comprehensive overview of PhysicsNeMo-Mesh capabilities:
 | Scaling | ✅ | Uniform or anisotropic |
 | Arbitrary matrix transform | ✅ | |
 | Extrusion | ✅ | Manifold → higher dimension |
-| Projection / Intersection | ❌ | Manifold → lower dimension; work in progress |
+| Coordinate projection (drop ambient dims) | ✅ | `projections.project` (e.g. 3D → 2D embedding) |
+| Surface projection / mesh intersection | ❌ | Manifold → lower *manifold* dimension; work in progress |
 | **Neighbors & Adjacency** | | |
 | Point-to-points | ✅ | Graph edges |
 | Point-to-cells | ✅ | Vertex star |

--- a/physicsnemo/mesh/geometry/_cell_normals.py
+++ b/physicsnemo/mesh/geometry/_cell_normals.py
@@ -42,9 +42,10 @@ def compute_cell_normals(
     """Compute unit normal vectors for codimension-1 simplices.
 
     Given the edge vectors ``e_i = v_{i+1} - v_0`` for each simplex, computes
-    the outward-pointing unit normal via the generalized cross product.
-    The caller must ensure the codimension-1 constraint:
-    ``n_manifold_dims == n_spatial_dims - 1``.
+    an orientation-defined unit normal via the generalized cross product. The
+    sign/direction follows each simplex's vertex ordering (it is not guaranteed
+    to point "outward" -- that depends on the mesh's orientation). The caller
+    must ensure the codimension-1 constraint: ``n_manifold_dims == n_spatial_dims - 1``.
 
     Parameters
     ----------

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -1008,10 +1008,11 @@ class Mesh:
 
     @property
     def gaussian_curvature_cells(self) -> torch.Tensor:
-        """Compute Gaussian curvature at cell centers using dual mesh concept.
+        """Compute Gaussian curvature at cell centers.
 
-        Treats cell centroids as vertices of a dual mesh and computes curvature
-        based on angles between connections to adjacent cell centroids.
+        Averages the intrinsic vertex-based Gaussian curvature (angle defect) over
+        each cell's vertices, giving a cell-centered field consistent with
+        :attr:`gaussian_curvature_vertices`.
 
         The result is cached in ``_cache["cell", "gaussian_curvature"]`` for efficiency.
 
@@ -2552,8 +2553,9 @@ class Mesh:
         Returns
         -------
         Mesh
-            Self (mesh) with gradient fields added to point_data (modified in place).
-            Field naming: "{field}_gradient" or "{field}_gradient_intrinsic/extrinsic"
+            A new Mesh with gradient fields added to point_data (the input mesh is
+            not modified; its point_data is cloned). Field naming:
+            "{field}_gradient" or "{field}_gradient_intrinsic/extrinsic"
 
         Examples
         --------

--- a/physicsnemo/mesh/primitives/README.md
+++ b/physicsnemo/mesh/primitives/README.md
@@ -7,16 +7,16 @@ category and dimensional configuration.
 ## Quick Start
 
 ```python
-from physicsnemo.mesh import examples
+from physicsnemo.mesh import primitives
 
 # Load a simple sphere
-mesh = examples.surfaces.sphere_icosahedral.load(radius=1.0, subdivisions=2)
+mesh = primitives.surfaces.sphere_icosahedral.load(radius=1.0, subdivisions=2)
 
 # Load the Stanford bunny
-mesh = examples.pyvista_datasets.bunny.load()
+mesh = primitives.pyvista_datasets.bunny.load()
 
 # Create a lumpy sphere with noise
-mesh = examples.procedural.lumpy_sphere.load(noise_amplitude=0.1)
+mesh = primitives.procedural.lumpy_sphere.load(noise_amplitude=0.1)
 ```
 
 ## Categories

--- a/physicsnemo/mesh/subdivision/butterfly.py
+++ b/physicsnemo/mesh/subdivision/butterfly.py
@@ -280,7 +280,7 @@ def subdivide_butterfly(mesh: "Mesh") -> "Mesh":
     - Interpolating: original vertices remain unchanged
     - New edge midpoints use weighted neighbor stencils
     - Designed for 2D manifolds (triangular meshes)
-    - For non-2D manifolds: falls back to linear subdivision with warning
+    - For non-2D manifolds: raises NotImplementedError (use linear subdivision)
 
     The connectivity pattern is identical to linear subdivision (same topology),
     but the geometric positions of new vertices differ.


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Fixes a few incorrect items in Mesh docs.

- README: mark Laplace-Beltrami (DEC) as implemented (it is fully implemented and exported as calculus.compute_laplacian_points_dec); split the Projection row into the implemented coordinate projection (drop ambient dims) and the still-WIP surface projection / mesh intersection.
- compute_point_derivatives: docstring no longer claims in-place mutation; it returns a NEW mesh (point_data is cloned).
- gaussian_curvature_cells: docstring now describes the actual algorithm (averages vertex angle-defect curvature) instead of a removed dual-centroid method.
- compute_cell_normals: clarify the normal is orientation-defined, not guaranteed outward.
- butterfly subdivision: docstring matches behaviour (raises NotImplementedError for non-2D, not fallback-to-linear).
- primitives/README: fix the non-existent 'from physicsnemo.mesh import examples' import (the module is physicsnemo.mesh.primitives).

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
