### PR TITLE
Fix CorrDiff plot_multiple_samples CLI entrypoint

### DIFF
--- a/examples/weather/corrdiff/inference/plot_multiple_samples.py
+++ b/examples/weather/corrdiff/inference/plot_multiple_samples.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import joblib
 import argparse
+import os
 
+import joblib
 import matplotlib.pyplot as plt
 import xarray
 
@@ -69,4 +70,4 @@ if __name__ == "__main__":
     parser.add_argument("--n-samples", help="Number of samples", default=5, type=int)
     # Parse the arguments
     args = parser.parse_args()
-    main(args.netcdf_file, args.output_dir, args.n_samples)
+    plot_samples(args.netcdf_file, args.output_dir, args.n_samples)


### PR DESCRIPTION
## Summary
- Import `os` before calling `os.makedirs`.
- Call `plot_samples(...)` from the CLI entrypoint instead of the undefined `main(...)`.

## Validation
- `git diff --check`
- `python3 -B -c "from pathlib import Path; p=Path('examples/weather/corrdiff/inference/plot_multiple_samples.py'); compile(p.read_text(), str(p), 'exec')"`\n- Stubbed CLI smoke test for the script entrypoint with in-memory stand-ins for plotting dependencies