### PR TITLE
Add support for StereoRoPE positional embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   geometry-latent kNN distance as a continuous score for downstream
   consumers (e.g. AL acquisition) without the boolean thresholding /
   warning emission of `OODGuard.check()`.
+- Adds rotary position embedding (RoPE) modules to `phyiscsnemo.nn` and
+  integrates support for 2D RoPE in the neighborhood attention backend
+  of `DiT` layers.
+- Adds support for RoPE, invalid token masking, and a new `ConvDetokenizer`
+  in `phyiscsnemo.models.DiT`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds a stereographic 2D rotary position embedding to `physicsnemo.nn`
+  (`StereographicRotaryPositionEmbedding2D`) for tokens on a sphere:
+  latitude/longitude are mapped to a local tangent plane via a stereographic
+  projection and the resulting continuous coordinates drive a 2D RoPE that
+  composes with the existing `apply_rotary_pos_emb`. Also adds
+  `build_rope_cos_sin_1d_continuous` and `build_axial_rope_cos_sin_continuous`
+  (the continuous-coordinate generalizations of `build_rope_cos_sin_1d` and
+  `build_axial_rope_cos_sin`), `stereographic_projection`, and `spherical_centroid`
+  to `physicsnemo.nn.module.rope`.
 - Adds Point-Transformer local vector-attention blocks to `physicsnemo.nn`.
 - FSDP2 checkpoint support: full save/load round-trip for
   ``torch.distributed.fsdp`` v2 models, including DTensor edge cases,

--- a/examples/weather/stormcast/utils/parallel.py
+++ b/examples/weather/stormcast/utils/parallel.py
@@ -406,12 +406,19 @@ def shard_dim_selector(param_name: str) -> int | None:
         Shard dimension for param_name, or None if the tensor corresponding to
         param_name should not be sharded.
     """
-    # this should find the spatial parameters for SongUNet and DiT
-    sharded_params = ["pos_embed", "pos_embd", "spatial_emb"]
-    if any(sharded_param in param_name for sharded_param in sharded_params):
+    # Spatial parameters/buffers laid out as (1, H*W, C): shard the flattened
+    # spatial axis (dim 1). Covers SongUNet and DiT positional embeddings.
+    sharded_dim1 = ["pos_embed", "pos_embd", "spatial_emb"]
+    if any(name in param_name for name in sharded_dim1):
         return 1
-    else:
-        return None
+    # Spatial buffers laid out with height first: (h_lat, w_lat) for the DiT
+    # invalid-token mask, (h_lat, w_lat, head_dim) for the RoPE cos/sin tables.
+    # Sharding dim 0 (height) gives each rank globally-correct rows with no
+    # explicit rank offset needed in model code.
+    sharded_dim0 = ["invalid_token_mask", "rope_cos", "rope_sin"]
+    if any(name in param_name for name in sharded_dim0):
+        return 0
+    return None
 
 
 def partition_model_selective(
@@ -449,3 +456,23 @@ def partition_model_selective(
         submodule.register_parameter(
             key, torch.nn.Parameter(dt, requires_grad=param.requires_grad)
         )
+
+    # Buffers are handled explicitly too: spatial buffers (RoPE cos/sin tables,
+    # the DiT invalid-token mask) are sharded so each rank holds its local rows
+    # with globally-correct values; all others are replicated. Doing this here
+    # (rather than relying on distribute_module's internal replication) lets us
+    # shard the spatial ones and preserves each buffer's persistent/state_dict
+    # status.
+    for key, buffer in submodule._buffers.items():
+        if buffer is None:
+            continue
+        if (shard_dim := shard_dim_selector(key)) is not None:
+            dt = distribute_tensor(
+                buffer, device_mesh=device_mesh, placements=[Shard(shard_dim)]
+            )
+        else:
+            dt = distribute_tensor(
+                buffer, device_mesh=device_mesh, placements=[Replicate()]
+            )
+        persistent = key not in submodule._non_persistent_buffers_set
+        submodule.register_buffer(key, dt, persistent=persistent)

--- a/examples/weather/stormcast/utils/trainer.py
+++ b/examples/weather/stormcast/utils/trainer.py
@@ -145,6 +145,11 @@ class Trainer:
         # Load regression net if needed
         self.regression_net = self._load_regression_net()
 
+        # Install the static invalid-token mask, if the model was built with
+        # NaN-mask tokens. Must happen before distribute_model: once the mask
+        # buffer becomes a DTensor it can no longer be replaced.
+        self._install_nan_pixel_mask()
+
         # Sharding and FSDP wrapping
         if self.use_shard_tensor:
             self.logger.info(
@@ -427,6 +432,43 @@ class Trainer:
             raise ValueError("model.architecture must be 'unet' or 'dit'")
 
         return net
+
+    def _install_nan_pixel_mask(self) -> None:
+        r"""Install the static invalid-token mask on the network, if enabled.
+
+        No-op unless the model was constructed with ``use_nan_mask_tokens=True``
+        (set in ``model.hyperparameters``). When enabled, the full pixel-level
+        invalid mask is read from the training dataset (attribute
+        ``sensor_nan_mask``, a ``(H, W)`` bool array/tensor) and converted to a
+        patch-level mask via the model's ``set_nan_pixel_mask``. Must be called
+        before ``distribute_model``.
+        """
+        use_nan_mask_tokens = bool(
+            self.cfg.model.hyperparameters.get("use_nan_mask_tokens", False)
+        )
+        if not use_nan_mask_tokens:
+            return
+
+        # Find the (possibly wrapped) submodule exposing set_nan_pixel_mask.
+        target = next(
+            (m for m in self.net.modules() if hasattr(m, "set_nan_pixel_mask")),
+            None,
+        )
+        if target is None:
+            raise RuntimeError(
+                "model.hyperparameters.use_nan_mask_tokens is True but the "
+                "network exposes no set_nan_pixel_mask method"
+            )
+
+        pixel_mask = getattr(self.dataset_train, "sensor_nan_mask", None)
+        if pixel_mask is None:
+            raise ValueError(
+                "use_nan_mask_tokens is True but the training dataset provides "
+                "no 'sensor_nan_mask' (H, W) invalid-pixel mask"
+            )
+
+        target.set_nan_pixel_mask(pixel_mask)
+        self.logger.info("Installed static invalid-token (NaN) mask on the model")
 
     def _load_regression_net(self) -> Module | None:
         r"""

--- a/physicsnemo/models/dit/dit.py
+++ b/physicsnemo/models/dit/dit.py
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional, Tuple, Union
 
+import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from jaxtyping import Float
 
 from physicsnemo.core.meta import ModelMetaData
@@ -82,8 +85,8 @@ class DiT(Module):
         The number of attention heads.
     mlp_ratio : float, optional, default=4.0
         The ratio of the MLP hidden dimension to the embedding dimension.
-    attention_backend : Literal["timm", "transformer_engine", "natten2d"], optional, default="timm"
-        The attention backend to use. See :class:`~physicsnemo.nn.DiTBlock` for a description of each built-in backend.
+    attention_backend : Literal["timm", "transformer_engine", "natten2d", "natten2d_rope"], optional, default="timm"
+        The attention backend to use. See :class:`~physicsnemo.nn.DiTBlock` for a description of each built-in backend. ``"natten2d_rope"`` applies axial 2D rotary position embeddings inside NATTEN; selecting it forces ``pos_embed="none"`` in the tokenizer (additive positional embedding is disabled to avoid double-counting position) and emits a warning if a conflicting ``pos_embed`` was explicitly passed.
     layernorm_backend : Literal["apex", "torch"], optional, default="torch"
         If ``"apex"``, uses FusedLayerNorm from apex. If ``"torch"``, uses :class:`torch.nn.LayerNorm`. Also passed to :class:`~physicsnemo.nn.Natten2DSelfAttention` when ``qk_norm=True``.
     condition_dim : int, optional, default=None
@@ -106,6 +109,8 @@ class DiT(Module):
         DropPath (stochastic depth) rates, one per block. Must have length equal to ``depth``. If ``None``, no drop path is applied.
     force_tokenization_fp32 : bool, optional, default=False
         If ``True``, forces tokenization and de-tokenization to run in fp32.
+    use_nan_mask_tokens : bool, optional, default=False
+        If ``True``, every NATTEN block overwrites invalid spatial tokens with a per-block learned ``mask_token`` immediately before the QKV projection, so the neighborhood window mixes in a single learned feature instead of corrupted (e.g. NaN-padded) signal. Requires a NATTEN attention backend (``"natten2d"`` or ``"natten2d_rope"``). The static invalid pattern is supplied after construction via :meth:`set_nan_pixel_mask`; until then all tokens are treated as valid and behavior is identical to ``use_nan_mask_tokens=False``.
 
     Forward
     -------
@@ -131,6 +136,13 @@ class DiT(Module):
     -----
     Reference: Peebles, W., & Xie, S. (2023). Scalable diffusion models with transformers.
     In Proceedings of the IEEE/CVF International Conference on Computer Vision (pp. 4195-4205).
+
+    Under domain parallelism (the model wrapped with ``distribute_module``), the
+    spatial input ``x`` is a sharded ``ShardTensor`` while the model's buffers and
+    parameters are ``DTensor``s. The non-spatial inputs ``t`` and ``condition``
+    must therefore be passed as ``Replicate`` ``DTensor``s on the same mesh (rather
+    than plain tensors), so they compose with the distributed buffers/parameters
+    (e.g. the timestep embedder's ``freqs``).
 
     Examples
     --------
@@ -197,7 +209,9 @@ class DiT(Module):
         depth: int = 12,
         num_heads: int = 8,
         mlp_ratio: float = 4.0,
-        attention_backend: Literal["timm", "transformer_engine", "natten2d"] = "timm",
+        attention_backend: Literal[
+            "timm", "transformer_engine", "natten2d", "natten2d_rope"
+        ] = "timm",
         layernorm_backend: Literal["apex", "torch"] = "torch",
         condition_dim: Optional[int] = None,
         conditioning_embedder: Literal["dit", "edm", "zero"]
@@ -210,6 +224,7 @@ class DiT(Module):
         attn_kwargs: Dict[str, Any] = {},
         drop_path_rates: list[float] | None = None,
         force_tokenization_fp32: bool = False,
+        use_nan_mask_tokens: bool = False,
     ):
         super().__init__(meta=MetaData())
         self.input_size = (
@@ -229,23 +244,69 @@ class DiT(Module):
         )
         self.num_heads = num_heads
         self.condition_dim = condition_dim
-        if attention_backend == "natten2d":
-            latent_hw = (
-                self.input_size[0] // self.patch_size[0],
-                self.input_size[1] // self.patch_size[1],
-            )
-            self.attn_kwargs_forward = {"latent_hw": latent_hw}
-        else:
-            self.attn_kwargs_forward = {}
 
         # Input validation
-        if attention_backend not in ["timm", "transformer_engine", "natten2d"]:
+        if attention_backend not in [
+            "timm",
+            "transformer_engine",
+            "natten2d",
+            "natten2d_rope",
+        ]:
             raise ValueError(
-                "attention_backend must be one of 'timm', 'transformer_engine', 'natten2d'"
+                "attention_backend must be one of 'timm', 'transformer_engine', 'natten2d', 'natten2d_rope'"
             )
 
         if layernorm_backend not in ["apex", "torch"]:
             raise ValueError("layernorm_backend must be one of 'apex', 'torch'")
+
+        is_natten = attention_backend in ("natten2d", "natten2d_rope")
+
+        # Latent (token) grid size, used by the NATTEN backends.
+        self._latent_h = self.input_size[0] // self.patch_size[0]
+        self._latent_w = self.input_size[1] // self.patch_size[1]
+        latent_hw = (self._latent_h, self._latent_w)
+
+        # Keyword arguments threaded into every attention module's forward.
+        if is_natten:
+            self.attn_kwargs_forward = {"latent_hw": latent_hw}
+        else:
+            self.attn_kwargs_forward = {}
+
+        # NaN-mask-token handling: replace invalid spatial tokens with a learned
+        # per-block mask token before NATTEN. Only valid with a NATTEN backend.
+        self._use_nan_mask_tokens = use_nan_mask_tokens
+        if use_nan_mask_tokens and not is_natten:
+            raise ValueError(
+                "use_nan_mask_tokens=True requires a NATTEN attention backend "
+                "('natten2d' or 'natten2d_rope')"
+            )
+
+        # Constructor-time attention kwargs (copied so the caller's dict is not
+        # mutated). RoPE attention needs the latent grid at construction so its
+        # cos/sin tables can be precomputed; the mask-token backends need to
+        # allocate their learned mask parameter.
+        attn_kwargs = dict(attn_kwargs)
+        if attention_backend == "natten2d_rope":
+            attn_kwargs["latent_hw"] = latent_hw
+        if use_nan_mask_tokens:
+            attn_kwargs["use_mask_token"] = True
+
+        # Using RoPE alongside an additive positional embedding double-counts
+        # position. Force the (patch-based) tokenizer's pos_embed to "none",
+        # warning if a conflicting value was explicitly requested.
+        if attention_backend == "natten2d_rope" and tokenizer == "patch_embed_2d":
+            tokenizer_kwargs = dict(tokenizer_kwargs)
+            requested_pos_embed = tokenizer_kwargs.get("pos_embed", None)
+            if requested_pos_embed not in (None, "none"):
+                warnings.warn(
+                    "attention_backend='natten2d_rope' uses rotary position "
+                    "embeddings; overriding the requested "
+                    f"pos_embed={requested_pos_embed!r} with 'none' to avoid "
+                    "double-counting the positional signal.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            tokenizer_kwargs["pos_embed"] = "none"
 
         if isinstance(tokenizer, str) and tokenizer not in [
             "patch_embed_2d",
@@ -341,6 +402,21 @@ class DiT(Module):
         if dit_initialization:
             self.initialize_weights()
 
+        # Static patch-level invalid mask used by the NaN-mask-token blocks. A
+        # single copy is kept on the model (not per-block) and passed to every
+        # block in forward. Registered as persistent=False so it is not saved in
+        # checkpoints by default (it is sensor/domain geometry, re-installed via
+        # set_nan_pixel_mask); set_nan_pixel_mask can opt into persistence.
+        # Initialized to all-valid (False) so behavior matches the unmasked path
+        # until a real mask is installed. Built at the global latent size so
+        # distribute_module can shard it if domain parallelism is used.
+        if use_nan_mask_tokens:
+            self.register_buffer(
+                "invalid_token_mask",
+                torch.zeros(self._latent_h, self._latent_w, dtype=torch.bool),
+                persistent=False,
+            )
+
         self.force_tokenization_fp32 = force_tokenization_fp32
         self.register_load_state_dict_pre_hook(self._migrate_legacy_checkpoint)
 
@@ -433,6 +509,80 @@ class DiT(Module):
         for block in self.blocks:
             block.initialize_weights()
 
+    @torch.no_grad()
+    def set_nan_pixel_mask(
+        self,
+        pixel_mask: Float[torch.Tensor, "height width"],
+        persistent: bool = False,
+    ) -> None:
+        r"""Install the static invalid-token mask for the NaN-mask-token blocks.
+
+        Converts a pixel-level ``(H, W)`` boolean mask to a patch-level
+        ``(h_lat, w_lat)`` mask: a patch is marked invalid if *any* pixel within
+        its ``patch_size`` block is invalid. The result replaces the
+        ``invalid_token_mask`` buffer.
+
+        This must be called **before** the model is wrapped for domain
+        parallelism (e.g. ``distribute_module``), so that the buffer can be
+        sharded along height; once the buffer is a DTensor it can no longer be
+        replaced via ``register_buffer``.
+
+        Parameters
+        ----------
+        pixel_mask : torch.Tensor
+            Boolean tensor of shape :math:`(H, W)`, ``True`` where the input
+            pixel is invalid (e.g. NaN-padded / outside sensor coverage). The
+            pattern is treated as static across samples.
+        persistent : bool, optional, default=False
+            Whether the resulting patch-level mask is saved in the model's
+            ``state_dict``. The default (``False``) resets the mask to all-valid
+            on checkpoint load, so a stale mask from a different domain cannot be
+            used accidentally; the trainer reinstalls it via this method. Set
+            ``True`` to keep the mask in the checkpoint as an audit trail.
+        """
+        if not self._use_nan_mask_tokens:
+            raise RuntimeError(
+                "set_nan_pixel_mask called on a DiT constructed with "
+                "use_nan_mask_tokens=False"
+            )
+        if isinstance(pixel_mask, np.ndarray):
+            pixel_mask = torch.from_numpy(pixel_mask)
+        pixel_mask = pixel_mask.to(dtype=torch.bool)
+        if pixel_mask.ndim != 2:
+            raise ValueError(
+                f"pixel_mask must be (H, W); got shape {tuple(pixel_mask.shape)}"
+            )
+        if tuple(pixel_mask.shape) != tuple(self.input_size):
+            raise ValueError(
+                f"pixel_mask shape {tuple(pixel_mask.shape)} does not match the "
+                f"DiT input resolution {tuple(self.input_size)}"
+            )
+
+        # Keep the new buffer on the same device as the existing one.
+        target_device = self.invalid_token_mask.device
+        pix = pixel_mask.to(target_device)
+
+        # Aggregate to patch granularity: any invalid pixel -> invalid patch.
+        patch_mask = (
+            F.max_pool2d(
+                pix.float().unsqueeze(0).unsqueeze(0),
+                kernel_size=self.patch_size,
+                stride=self.patch_size,
+            )
+            .squeeze(0)
+            .squeeze(0)
+            > 0
+        )
+        if tuple(patch_mask.shape) != (self._latent_h, self._latent_w):
+            raise ValueError(
+                f"derived patch mask shape {tuple(patch_mask.shape)} != "
+                f"({self._latent_h}, {self._latent_w})"
+            )
+
+        self.register_buffer(
+            "invalid_token_mask", patch_mask.to(torch.bool), persistent=persistent
+        )
+
     def forward(
         self,
         x: Float[torch.Tensor, "batch in_channels *spatial_dims"],
@@ -455,12 +605,20 @@ class DiT(Module):
         # Compute conditioning embedding
         c = self.conditioning_embedder(t, condition=condition)  # (B, D)
 
+        block_attn_kwargs = {**self.attn_kwargs_forward, **attn_kwargs}
+        if self._use_nan_mask_tokens:
+            # (h_lat, w_lat) -> (L,); after Shard(0) this is the rank-local
+            # (h_local * w_lat,) flattened mask, aligned with the local tokens.
+            block_attn_kwargs.setdefault(
+                "invalid_token_mask", self.invalid_token_mask.reshape(-1)
+            )
+
         for block in self.blocks:
             x = block(
                 x,
                 c,
                 p_dropout=p_dropout,
-                attn_kwargs={**self.attn_kwargs_forward, **attn_kwargs},
+                attn_kwargs=block_attn_kwargs,
             )  # (B, L, D)
 
         # De-tokenize: (B, L, D) -> (B, C, H, W)

--- a/physicsnemo/models/dit/dit.py
+++ b/physicsnemo/models/dit/dit.py
@@ -72,8 +72,8 @@ class DiT(Module):
     tokenizer : Union[Literal["patch_embed_2d", "hpx_patch_embed"], Module], optional, default="patch_embed_2d"
         The tokenizer to use. Either a string in ``{"patch_embed_2d", "hpx_patch_embed"}`` or an instantiated PhysicsNeMo :class:`~physicsnemo.core.Module` implementing
         :class:`~physicsnemo.nn.TokenizerModuleBase`, with forward accepting input of shape :math:`(B, C, *\text{spatial\_dims})` and returning :math:`(B, L, D)`.
-    detokenizer : Union[Literal["proj_reshape_2d", "hpx_patch_detokenizer"], Module], optional, default="proj_reshape_2d"
-        The detokenizer to use. Either a string in ``{"proj_reshape_2d", "hpx_patch_detokenizer"}`` or an instantiated PhysicsNeMo :class:`~physicsnemo.core.Module` implementing
+    detokenizer : Union[Literal["proj_reshape_2d", "proj_reshape_2d_conv", "hpx_patch_detokenizer"], Module], optional, default="proj_reshape_2d"
+        The detokenizer to use. Either a string in ``{"proj_reshape_2d", "proj_reshape_2d_conv", "hpx_patch_detokenizer"}`` or an instantiated PhysicsNeMo :class:`~physicsnemo.core.Module` implementing
         :class:`~physicsnemo.nn.DetokenizerModuleBase`, with forward accepting :math:`(B, L, D)` and :math:`(B, D)` and returning :math:`(B, C, *\text{spatial\_dims})`.
     out_channels : Union[None, int], optional, default=None
         The number of output channels. If ``None``, set to ``in_channels``.
@@ -202,7 +202,8 @@ class DiT(Module):
             Literal["patch_embed_2d", "hpx_patch_embed"], Module
         ] = "patch_embed_2d",
         detokenizer: Union[
-            Literal["proj_reshape_2d", "hpx_patch_detokenizer"], Module
+            Literal["proj_reshape_2d", "proj_reshape_2d_conv", "hpx_patch_detokenizer"],
+            Module,
         ] = "proj_reshape_2d",
         out_channels: Optional[int] = None,
         hidden_size: int = 384,
@@ -316,10 +317,11 @@ class DiT(Module):
 
         if isinstance(detokenizer, str) and detokenizer not in [
             "proj_reshape_2d",
+            "proj_reshape_2d_conv",
             "hpx_patch_detokenizer",
         ]:
             raise ValueError(
-                "detokenizer must be 'proj_reshape_2d' or 'hpx_patch_detokenizer'"
+                "detokenizer must be 'proj_reshape_2d', 'proj_reshape_2d_conv', or 'hpx_patch_detokenizer'"
             )
 
         # Tokenizer module: accept string or pre-instantiated PhysicsNeMo Module

--- a/physicsnemo/nn/__init__.py
+++ b/physicsnemo/nn/__init__.py
@@ -67,6 +67,7 @@ from .module.conv_layers import (
 from .module.dgm_layers import DGMLayer
 from .module.dit_layers import (
     AttentionModuleBase,
+    ConvDetokenizer,
     DetokenizerModuleBase,
     DiTBlock,
     Natten2DSelfAttention,
@@ -74,6 +75,7 @@ from .module.dit_layers import (
     PerSampleDropout,
     ProjLayer,
     ProjReshape2DDetokenizer,
+    RopeNatten2DSelfAttention,
     TESelfAttention,
     TimmSelfAttention,
     TokenizerModuleBase,
@@ -133,6 +135,14 @@ from .module.resample_layers import (
     DownSample3D,
     UpSample2D,
     UpSample3D,
+)
+from .module.rope import (
+    RotaryPositionEmbedding1D,
+    RotaryPositionEmbedding2D,
+    apply_rotary_pos_emb,
+    build_axial_rope_cos_sin,
+    build_rope_cos_sin_1d,
+    rotate_half_pairs,
 )
 from .module.running_norm import RunningNorm
 from .module.siren_layers import SirenLayer, SirenLayerType

--- a/physicsnemo/nn/__init__.py
+++ b/physicsnemo/nn/__init__.py
@@ -139,10 +139,15 @@ from .module.resample_layers import (
 from .module.rope import (
     RotaryPositionEmbedding1D,
     RotaryPositionEmbedding2D,
+    StereographicRotaryPositionEmbedding2D,
     apply_rotary_pos_emb,
     build_axial_rope_cos_sin,
+    build_axial_rope_cos_sin_continuous,
     build_rope_cos_sin_1d,
+    build_rope_cos_sin_1d_continuous,
     rotate_half_pairs,
+    spherical_centroid,
+    stereographic_projection,
 )
 from .module.running_norm import RunningNorm
 from .module.siren_layers import SirenLayer, SirenLayerType

--- a/physicsnemo/nn/module/__init__.py
+++ b/physicsnemo/nn/module/__init__.py
@@ -43,6 +43,7 @@ from .conv_layers import ConvBlock, CubeEmbedding
 from .dgm_layers import DGMLayer
 from .dit_layers import (
     AttentionModuleBase,
+    ConvDetokenizer,
     DetokenizerModuleBase,
     DiTBlock,
     Natten2DSelfAttention,
@@ -50,6 +51,7 @@ from .dit_layers import (
     PerSampleDropout,
     ProjLayer,
     ProjReshape2DDetokenizer,
+    RopeNatten2DSelfAttention,
     TESelfAttention,
     TimmSelfAttention,
     TokenizerModuleBase,
@@ -103,6 +105,14 @@ from .resample_layers import (
     DownSample3D,
     UpSample2D,
     UpSample3D,
+)
+from .rope import (
+    RotaryPositionEmbedding1D,
+    RotaryPositionEmbedding2D,
+    apply_rotary_pos_emb,
+    build_axial_rope_cos_sin,
+    build_rope_cos_sin_1d,
+    rotate_half_pairs,
 )
 from .siren_layers import SirenLayer, SirenLayerType
 from .spectral_layers import (

--- a/physicsnemo/nn/module/__init__.py
+++ b/physicsnemo/nn/module/__init__.py
@@ -109,10 +109,15 @@ from .resample_layers import (
 from .rope import (
     RotaryPositionEmbedding1D,
     RotaryPositionEmbedding2D,
+    StereographicRotaryPositionEmbedding2D,
     apply_rotary_pos_emb,
     build_axial_rope_cos_sin,
+    build_axial_rope_cos_sin_continuous,
     build_rope_cos_sin_1d,
+    build_rope_cos_sin_1d_continuous,
     rotate_half_pairs,
+    spherical_centroid,
+    stereographic_projection,
 )
 from .siren_layers import SirenLayer, SirenLayerType
 from .spectral_layers import (

--- a/physicsnemo/nn/module/dit_layers.py
+++ b/physicsnemo/nn/module/dit_layers.py
@@ -34,6 +34,7 @@ from physicsnemo.nn.module.hpx.tokenizer import (
     HEALPixPatchTokenizer,
 )
 from physicsnemo.nn.module.mlp_layers import Mlp
+from physicsnemo.nn.module.rope import apply_rotary_pos_emb, build_axial_rope_cos_sin
 from physicsnemo.nn.module.utils import PatchEmbed2D
 
 timm_v1_0_16 = check_version_spec("timm", "1.0.16", hard_fail=False)
@@ -91,7 +92,9 @@ def get_layer_norm(
 def get_attention(
     hidden_size: int,
     num_heads: int,
-    attention_backend: Literal["transformer_engine", "timm", "natten2d"],
+    attention_backend: Literal[
+        "transformer_engine", "timm", "natten2d", "natten2d_rope"
+    ],
     attn_drop_rate: float = 0.0,
     proj_drop_rate: float = 0.0,
     **attn_kwargs: Any,
@@ -104,8 +107,8 @@ def get_attention(
         The embedding dimension.
     num_heads : int
         Number of attention heads.
-    attention_backend : Literal["transformer_engine", "timm", "natten2d"]
-        One of ``"timm"``, ``"transformer_engine"``, or ``"natten2d"`` to select between pre-defined attention modules.
+    attention_backend : Literal["transformer_engine", "timm", "natten2d", "natten2d_rope"]
+        One of ``"timm"``, ``"transformer_engine"``, ``"natten2d"``, or ``"natten2d_rope"`` to select between pre-defined attention modules. ``"natten2d_rope"`` is :class:`Natten2DSelfAttention` with axial 2D rotary position embeddings (see :class:`RopeNatten2DSelfAttention`) and requires ``latent_hw`` in ``attn_kwargs``.
     attn_drop_rate : float, optional, default=0.0
         The dropout rate for the attention operation.
     proj_drop_rate : float, optional, default=0.0
@@ -142,8 +145,16 @@ def get_attention(
             proj_drop_rate=proj_drop_rate,
             **attn_kwargs,
         )
+    if attention_backend == "natten2d_rope":
+        return RopeNatten2DSelfAttention(
+            hidden_size,
+            num_heads,
+            attn_drop_rate=attn_drop_rate,
+            proj_drop_rate=proj_drop_rate,
+            **attn_kwargs,
+        )
     raise ValueError(
-        "attention_backend must be one of 'timm', 'transformer_engine', 'natten2d' if using pre-defined attention modules."
+        "attention_backend must be one of 'timm', 'transformer_engine', 'natten2d', 'natten2d_rope' if using pre-defined attention modules."
     )
 
 
@@ -366,6 +377,8 @@ class Natten2DSelfAttention(AttentionModuleBase):
         The layer normalization backend for QK norm when ``qk_norm=True``. When used inside :class:`~physicsnemo.nn.module.dit_layers.DiTBlock` with ``attention_backend="natten2d"``, this is set from the block's ``layernorm_backend``.
     na2d_kwargs : Dict[str, Any], optional, default=None
         Optional keyword arguments forwarded to :func:`physicsnemo.nn.functional.na2d` for performance tuning (e.g. ``dilation``, ``is_causal``, ``scale``). If ``None``, an empty dict is used.
+    use_mask_token : bool, optional, default=False
+        If ``True``, allocate a per-block learned ``mask_token`` parameter of shape :math:`(1, 1, D)`. Spatial tokens flagged by the ``invalid_token_mask`` passed to ``forward`` are replaced by this learned token immediately before the QKV projection, so the neighborhood window mixes in a single learned feature instead of corrupted (e.g. NaN-padded) signal. Initialized to zero so the first forward is numerically identical to the unmasked path.
 
     References
     ----------
@@ -378,6 +391,8 @@ class Natten2DSelfAttention(AttentionModuleBase):
         Input tensor of shape :math:`(B, L, D)`.
     latent_hw : Tuple[int, int]
         The height and width of the 2D latent space for reshaping. Sequence length must equal ``latent_hw[0] * latent_hw[1]``.
+    invalid_token_mask : torch.Tensor, optional
+        Boolean (or float) mask of shape :math:`(L,)`, ``True`` (or ``1``) at spatial token positions to overwrite with the learned ``mask_token`` before QKV. Ignored when ``use_mask_token=False`` or when ``None``.
 
     Returns
     -------
@@ -406,6 +421,7 @@ class Natten2DSelfAttention(AttentionModuleBase):
         proj_drop_rate: float = 0.0,
         norm_layer: Literal["apex", "torch"] = "torch",
         na2d_kwargs: Optional[Dict[str, Any]] = None,
+        use_mask_token: bool = False,
     ):
         super().__init__()
         if hidden_size % num_heads != 0:
@@ -420,6 +436,13 @@ class Natten2DSelfAttention(AttentionModuleBase):
         self.attn_kernel = attn_kernel
         self.na2d_kwargs = na2d_kwargs if na2d_kwargs is not None else {}
 
+        # Per-block learned token used to overwrite invalid spatial tokens
+        # immediately before QKV. Init to zero so the first forward matches the
+        # unmasked path and only diverges as gradients shape the token.
+        self.mask_token = (
+            nn.Parameter(torch.zeros(1, 1, hidden_size)) if use_mask_token else None
+        )
+
         self.qkv = nn.Linear(hidden_size, hidden_size * 3, bias=qkv_bias)
         if qk_norm:
             self.q_norm = get_layer_norm(self.head_dim, norm_layer)
@@ -433,10 +456,32 @@ class Natten2DSelfAttention(AttentionModuleBase):
         self.attn_drop = nn.Dropout(attn_drop_rate)
         self.proj_drop = nn.Dropout(proj_drop_rate)
 
+    def _apply_mask_token(
+        self,
+        x: Float[torch.Tensor, "batch sequence hidden_size"],
+        invalid_token_mask: Optional[Float[torch.Tensor, " sequence"]],
+    ) -> Float[torch.Tensor, "batch sequence hidden_size"]:
+        r"""Replace invalid spatial tokens with the learned ``mask_token``.
+
+        Implemented as ``x * (1 - alpha) + mask_token * alpha`` rather than
+        :func:`torch.where`. For a boolean mask (``alpha`` in :math:`\{0, 1\}`)
+        the result is bit-identical to ``torch.where`` but uses only elementwise
+        multiply/add. This keeps every operand on the same tensor type, which is
+        what makes it safe under domain-parallel sharding: when ``mask_token`` is
+        a replicated DTensor and ``x``/``invalid_token_mask`` are sharded
+        tensors, the arithmetic stays entirely within DTensor dispatch and never
+        triggers a mixed plain-tensor / DTensor op.
+        """
+        if self.mask_token is None or invalid_token_mask is None:
+            return x
+        alpha = invalid_token_mask.to(dtype=x.dtype).view(1, -1, 1)
+        return x * (1.0 - alpha) + self.mask_token.to(x.dtype) * alpha
+
     def forward(
         self,
         x: Float[torch.Tensor, "batch sequence hidden_size"],
         latent_hw: Tuple[int, int],
+        invalid_token_mask: Optional[Float[torch.Tensor, " sequence"]] = None,
     ) -> Float[torch.Tensor, "batch sequence hidden_size"]:
         B, N, C = x.shape
         h, w = latent_hw
@@ -445,6 +490,9 @@ class Natten2DSelfAttention(AttentionModuleBase):
             raise ValueError(
                 f"Sequence length must be {h * w} based on latent_hw={latent_hw}, but got {N}"
             )
+
+        # Overwrite invalid spatial tokens with the learned mask token before QKV.
+        x = self._apply_mask_token(x, invalid_token_mask)
 
         # Project to query, key, value and split into heads
         qkv = self.qkv(x)
@@ -460,6 +508,142 @@ class Natten2DSelfAttention(AttentionModuleBase):
             [q, k, v],
         )
         x = _na2d_func(q, k, v, kernel_size=self.attn_kernel, **self.na2d_kwargs)
+        x = self.attn_drop(x)
+        x = rearrange(x, "b h w head c -> b (h w) (head c)")
+
+        x = self.proj_drop(self.proj(x))
+        return x
+
+
+class RopeNatten2DSelfAttention(Natten2DSelfAttention):
+    r"""NATTEN 2D self-attention with axial 2D rotary position embeddings (RoPE) on Q, K.
+
+    Subclass of :class:`Natten2DSelfAttention` that replaces an additive
+    positional embedding with relative rotary embeddings applied to the query
+    and key inside each attention block. Position is encoded purely as a
+    relative rotation between query and key, making attention output
+    translation-equivariant within each NATTEN window. When this backend is
+    used, the model should disable any additive positional embedding to avoid
+    double-counting the position signal.
+
+    The cos/sin tables are precomputed at construction so that
+    :func:`torch.compile` sees a stable forward graph. They are stored as
+    ``persistent=False`` buffers because they are deterministically rebuilt from
+    ``(latent_hw, head_dim, rope_theta)``; for domain-parallel training they are
+    built at the global spatial size and sharded along height by
+    ``distribute_module``, so each rank holds the rows with globally-correct
+    frequencies and no explicit rank offset is needed in model code.
+
+    Parameters
+    ----------
+    latent_hw : Tuple[int, int]
+        Spatial size :math:`(h, w)` of the token grid used to precompute the
+        cos/sin tables. For inference at a different shape, :meth:`forward`
+        rebuilds the tables in place (off the ``torch.compile`` path).
+    rope_theta : float, optional, default=10000.0
+        Base used for the RoPE frequency schedule.
+    *args, **kwargs
+        Forwarded to :class:`Natten2DSelfAttention` (e.g. ``attn_kernel``,
+        ``qk_norm``, ``use_mask_token``).
+
+    Forward
+    -------
+    x : torch.Tensor
+        Input tensor of shape :math:`(B, L, D)`.
+    latent_hw : Tuple[int, int]
+        The height and width of the 2D latent space for reshaping.
+    invalid_token_mask : torch.Tensor, optional
+        See :class:`Natten2DSelfAttention`.
+
+    Returns
+    -------
+    torch.Tensor
+        Output tensor of shape :math:`(B, L, D)`.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        latent_hw: Tuple[int, int],
+        rope_theta: float = 10000.0,
+        **kwargs: Any,
+    ):
+        super().__init__(*args, **kwargs)
+        if self.head_dim % 4 != 0:
+            raise ValueError(
+                f"head_dim={self.head_dim} must be divisible by 4 for axial 2D RoPE."
+            )
+        self.rope_theta = float(rope_theta)
+        self._latent_hw: Tuple[int, int] = (int(latent_hw[0]), int(latent_hw[1]))
+
+        cos, sin = build_axial_rope_cos_sin(
+            *self._latent_hw, self.head_dim, theta=self.rope_theta
+        )
+        # persistent=False: not in state_dict (rebuilt deterministically at
+        # __init__ from latent_hw + head_dim + theta), so checkpoints stay lean.
+        self.register_buffer("rope_cos", cos, persistent=False)  # (h, w, head_dim)
+        self.register_buffer("rope_sin", sin, persistent=False)  # (h, w, head_dim)
+
+    def _rebuild_for_shape(self, h: int, w: int) -> None:
+        r"""Rebuild the RoPE buffers for a new latent shape.
+
+        Reached only when :meth:`forward` is called with a ``latent_hw`` that
+        differs from construction (e.g. variable-resolution inference); not part
+        of the training-time hot path.
+        """
+        target_dtype = self.rope_cos.dtype
+        target_device = self.rope_cos.device
+        cos, sin = build_axial_rope_cos_sin(
+            h, w, self.head_dim, theta=self.rope_theta, device=target_device
+        )
+        self.register_buffer("rope_cos", cos.to(dtype=target_dtype), persistent=False)
+        self.register_buffer("rope_sin", sin.to(dtype=target_dtype), persistent=False)
+        self._latent_hw = (int(h), int(w))
+
+    def forward(
+        self,
+        x: Float[torch.Tensor, "batch sequence hidden_size"],
+        latent_hw: Tuple[int, int],
+        invalid_token_mask: Optional[Float[torch.Tensor, " sequence"]] = None,
+    ) -> Float[torch.Tensor, "batch sequence hidden_size"]:
+        B, N, C = x.shape
+        h, w = int(latent_hw[0]), int(latent_hw[1])
+        if N != h * w:
+            raise ValueError(
+                f"Sequence length must be {h * w} based on latent_hw={latent_hw}, but got {N}"
+            )
+        if (h, w) != self._latent_hw:
+            self._rebuild_for_shape(h, w)
+
+        # Overwrite invalid spatial tokens with the learned mask token before QKV.
+        x = self._apply_mask_token(x, invalid_token_mask)
+
+        qkv = self.qkv(x)
+        qkv = qkv.reshape(B, N, 3, self.num_heads, self.head_dim).permute(
+            2, 0, 3, 1, 4
+        )  # (3, B, num_heads, N, head_dim)
+        q, k, v = qkv.unbind(0)
+        q, k = self.q_norm(q), self.k_norm(k)
+
+        # Reshape Q, K to spatial layout for RoPE indexing.
+        q_2d = q.reshape(B, self.num_heads, h, w, self.head_dim)
+        k_2d = k.reshape(B, self.num_heads, h, w, self.head_dim)
+
+        # cos/sin: (h, w, head_dim) -> (1, 1, h, w, head_dim) broadcasts over
+        # batch and head axes. apply_rotary_pos_emb rotates in fp32 internally.
+        cos = self.rope_cos.unsqueeze(0).unsqueeze(0)
+        sin = self.rope_sin.unsqueeze(0).unsqueeze(0)
+        q_rot = apply_rotary_pos_emb(q_2d, cos, sin)
+        k_rot = apply_rotary_pos_emb(k_2d, cos, sin)
+
+        # NATTEN expects (B, h, w, num_heads, head_dim).
+        q_nat = q_rot.permute(0, 2, 3, 1, 4).contiguous()
+        k_nat = k_rot.permute(0, 2, 3, 1, 4).contiguous()
+        v_nat = rearrange(v, "b head (h w) c -> b h w head c", h=h)
+
+        x = _na2d_func(
+            q_nat, k_nat, v_nat, kernel_size=self.attn_kernel, **self.na2d_kwargs
+        )
         x = self.attn_drop(x)
         x = rearrange(x, "b h w head c -> b (h w) (head c)")
 
@@ -607,7 +791,7 @@ class DiTBlock(nn.Module):
         hidden_size: int,
         num_heads: int,
         attention_backend: Union[
-            Literal["transformer_engine", "timm", "natten2d"], Module
+            Literal["transformer_engine", "timm", "natten2d", "natten2d_rope"], Module
         ] = "timm",
         layernorm_backend: Literal["apex", "torch"] = "torch",
         norm_eps: float = 1e-6,
@@ -627,8 +811,8 @@ class DiTBlock(nn.Module):
             self.attention = attention_backend
         else:
             attn_kwargs_final = dict(attn_kwargs)
-            # Ensure Natten2DSelfAttention uses the same LayerNorm backend as the block when qk_norm is used
-            if attention_backend == "natten2d":
+            # Ensure the NATTEN attention modules use the same LayerNorm backend as the block when qk_norm is used
+            if attention_backend in ("natten2d", "natten2d_rope"):
                 attn_kwargs_final.setdefault("norm_layer", layernorm_backend)
             self.attention = get_attention(
                 hidden_size=hidden_size,
@@ -1099,13 +1283,111 @@ class ProjReshape2DDetokenizer(DetokenizerModuleBase):
         return x
 
 
+class ConvDetokenizer(DetokenizerModuleBase):
+    r"""``proj_reshape_2d`` detokenizer extended with a zero-initialized residual conv smoothing head.
+
+    The stock :class:`ProjReshape2DDetokenizer` maps each token independently to a
+    ``patch x patch`` output block and therefore cannot couple across patch seams, which
+    produces checkerboard artifacts — most visible on spiky output channels such as
+    precipitation. This module wraps it and adds a small residual convolutional head
+    over the full ``(B, C_{out}, H, W)`` image so that information can flow across
+    patch boundaries.
+
+    The final conv layer is zero-initialized, so at construction the residual output is
+    exactly zero and the module is numerically identical to :class:`ProjReshape2DDetokenizer`.
+    This means it can be swapped in for an existing ``proj_reshape_2d`` run without
+    perturbing training dynamics. The head is fully convolutional, so the
+    re-instantiate-at-target-resolution + ``load_state_dict`` recipe for variable
+    inference grids continues to work.
+
+    Parameters
+    ----------
+    input_size : Tuple[int, int]
+        The size of the input image.
+    patch_size : Tuple[int, int]
+        The size of the patch.
+    out_channels : int
+        The number of output channels.
+    hidden_size : int
+        The size of the transformer latent space to project from.
+    layernorm_backend : Literal["apex", "torch"], optional, default="torch"
+        The layer normalization implementation.
+    conv_layers : int, optional, default=2
+        Number of conv layers in the smoothing head.
+    conv_hidden : int, optional, default=64
+        Number of feature maps in intermediate conv layers.
+    conv_kernel : int, optional, default=3
+        Spatial kernel size (same-padding is applied).
+
+    Forward
+    -------
+    x_tokens : torch.Tensor
+        Token sequence of shape :math:`(B, L, D_{in})`.
+    c : torch.Tensor
+        Conditioning tensor of shape :math:`(B, D)`.
+
+    Outputs
+    -------
+    torch.Tensor
+        Output tensor of shape :math:`(B, C_{out}, H, W)`.
+    """
+
+    def __init__(
+        self,
+        input_size: Tuple[int, int],
+        patch_size: Tuple[int, int],
+        out_channels: int,
+        hidden_size: int,
+        layernorm_backend: Literal["apex", "torch"] = "torch",
+        conv_layers: int = 2,
+        conv_hidden: int = 64,
+        conv_kernel: int = 3,
+    ):
+        super().__init__()
+        self.proj = ProjReshape2DDetokenizer(
+            input_size=input_size,
+            patch_size=patch_size,
+            out_channels=out_channels,
+            hidden_size=hidden_size,
+            layernorm_backend=layernorm_backend,
+        )
+        pad = conv_kernel // 2
+        layers: list[nn.Module] = []
+        c_in = out_channels
+        n = int(conv_layers)
+        for i in range(n):
+            last = i == n - 1
+            c_out = out_channels if last else conv_hidden
+            layers.append(nn.Conv2d(c_in, c_out, conv_kernel, padding=pad))
+            if not last:
+                layers.append(nn.GELU())
+            c_in = c_out
+        self.conv_head = nn.Sequential(*layers)
+
+    def initialize_weights(self) -> None:
+        """Initialize weights; zero the last conv so the residual starts at zero."""
+        self.proj.initialize_weights()
+        convs = [m for m in self.conv_head if isinstance(m, nn.Conv2d)]
+        nn.init.zeros_(convs[-1].weight)
+        if convs[-1].bias is not None:
+            nn.init.zeros_(convs[-1].bias)
+
+    def forward(
+        self,
+        x_tokens: Float[torch.Tensor, "batch sequence hidden_size"],
+        c: Float[torch.Tensor, "batch hidden_size"],
+    ) -> Float[torch.Tensor, "batch out_channels height width"]:
+        img = self.proj(x_tokens, c)
+        return img + self.conv_head(img)
+
+
 def get_detokenizer(
     input_size: Union[int, Tuple[int]],
     patch_size: Union[int, Tuple[int]],
     out_channels: int,
     hidden_size: int,
     detokenizer: Literal[
-        "proj_reshape_2d", "hpx_patch_detokenizer"
+        "proj_reshape_2d", "proj_reshape_2d_conv", "hpx_patch_detokenizer"
     ] = "proj_reshape_2d",
     **detokenizer_kwargs: Any,
 ) -> Union[DetokenizerModuleBase, nn.Module]:
@@ -1126,16 +1408,20 @@ def get_detokenizer(
         The number of output channels.
     hidden_size : int
         The size of the transformer latent space to project from.
-    detokenizer : Literal["proj_reshape_2d", "hpx_patch_detokenizer"], optional, default="proj_reshape_2d"
+    detokenizer : Literal["proj_reshape_2d", "proj_reshape_2d_conv", "hpx_patch_detokenizer"], optional, default="proj_reshape_2d"
         The detokenizer to use.
         - ``"proj_reshape_2d"`` -- Uses a standard DiT ProjLayer and reshapes the sequence back to an
-        image based on ``input_size`` and ``patch_size``.
+          image based on ``input_size`` and ``patch_size``.
+        - ``"proj_reshape_2d_conv"`` -- Same as ``"proj_reshape_2d"`` followed by a zero-initialized
+          residual conv smoothing head (:class:`ConvDetokenizer`). Reduces checkerboard artifacts on
+          spiky output channels. Accepts ``conv_layers``, ``conv_hidden``, and ``conv_kernel`` in
+          ``detokenizer_kwargs``.
         - ``"hpx_patch_detokenizer"`` -- HEALPix patch detokenizer from
-            ``physicsnemo.nn.module.hpx.tokenizer``. Requires ``earth2grid`` and determines the patch size from
-            ``level_coarse`` and ``level_fine`` in ``detokenizer_kwargs``.
+          ``physicsnemo.nn.module.hpx.tokenizer``. Requires ``earth2grid`` and determines the patch size
+          from ``level_coarse`` and ``level_fine`` in ``detokenizer_kwargs``.
 
     **detokenizer_kwargs : Any
-        Additional keyword arguments for the detokenizer module.
+        Additional keyword arguments forwarded to the detokenizer constructor.
 
     Returns
     -------
@@ -1150,6 +1436,14 @@ def get_detokenizer(
             hidden_size=hidden_size,
             **detokenizer_kwargs,
         )
+    if detokenizer == "proj_reshape_2d_conv":
+        return ConvDetokenizer(
+            input_size=input_size,
+            patch_size=patch_size,
+            out_channels=out_channels,
+            hidden_size=hidden_size,
+            **detokenizer_kwargs,
+        )
     if detokenizer == "hpx_patch_detokenizer":
         return HEALPixPatchDetokenizer(
             hidden_size=hidden_size,
@@ -1157,5 +1451,5 @@ def get_detokenizer(
             **detokenizer_kwargs,
         )
     raise ValueError(
-        "detokenizer must be 'proj_reshape_2d' or 'hpx_patch_detokenizer'."
+        "detokenizer must be 'proj_reshape_2d', 'proj_reshape_2d_conv', or 'hpx_patch_detokenizer'."
     )

--- a/physicsnemo/nn/module/dit_layers.py
+++ b/physicsnemo/nn/module/dit_layers.py
@@ -1351,6 +1351,8 @@ class ConvDetokenizer(DetokenizerModuleBase):
             hidden_size=hidden_size,
             layernorm_backend=layernorm_backend,
         )
+        if conv_layers < 1:
+            raise ValueError(f"conv_layers must be >= 1; got {conv_layers}")
         pad = conv_kernel // 2
         layers: list[nn.Module] = []
         c_in = out_channels

--- a/physicsnemo/nn/module/dit_layers.py
+++ b/physicsnemo/nn/module/dit_layers.py
@@ -1365,7 +1365,17 @@ class ConvDetokenizer(DetokenizerModuleBase):
         self.conv_head = nn.Sequential(*layers)
 
     def initialize_weights(self) -> None:
-        """Initialize weights; zero the last conv so the residual starts at zero."""
+        r"""Initialize weights; zero the last conv so the residual starts at zero.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+            Modifies module parameters in-place.
+        """
         self.proj.initialize_weights()
         convs = [m for m in self.conv_head if isinstance(m, nn.Conv2d)]
         nn.init.zeros_(convs[-1].weight)

--- a/physicsnemo/nn/module/rope.py
+++ b/physicsnemo/nn/module/rope.py
@@ -1,0 +1,412 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Rotary position embedding (RoPE) primitives.
+
+Parameter-free helpers for axial 2D RoPE, shared by attention modules (e.g.
+:class:`~physicsnemo.nn.module.dit_layers.RopeNatten2DSelfAttention`). RoPE
+encodes position as a relative rotation between query and key, so attention
+becomes translation-equivariant within a window.
+
+Math (axial 2D RoPE)
+--------------------
+``head_dim`` is split in half: the first half rotates by row index, the second
+by column index. Each axis has ``head_dim/4`` rotation pairs sharing a frequency
+:math:`\theta_k = \text{base}^{-2k/(head\_dim/2)}` for
+:math:`k = 0 \ldots head\_dim/4 - 1`. For an adjacent channel pair
+:math:`(x_a, x_b)` at angle :math:`\phi`, the rotation is
+:math:`(x_a \cos\phi - x_b \sin\phi,\ x_a \sin\phi + x_b \cos\phi)`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+
+def build_axial_rope_cos_sin(
+    h: int,
+    w: int,
+    head_dim: int,
+    theta: float = 10000.0,
+    device: Optional[torch.device] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Precompute axial 2D RoPE cos/sin tables for an :math:`h \times w` token grid.
+
+    The first ``head_dim/2`` channels are rotated by the row index, the last
+    ``head_dim/2`` by the column index. Within each axis-half, frequency
+    :math:`\theta_k = \text{theta}^{-2k/(head\_dim/2)}` drives the adjacent
+    channel pair ``(2k, 2k+1)``.
+
+    Parameters
+    ----------
+    h : int
+        Token grid height.
+    w : int
+        Token grid width.
+    head_dim : int
+        Per-head channel dimension. Must be divisible by 4 (half per axis, then
+        adjacent pairs within each half).
+    theta : float, optional, default=10000.0
+        Base used for the RoPE frequency schedule.
+    device : torch.device, optional
+        Device for the generated tables.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(cos, sin)``, each of shape :math:`(h, w, head\_dim)` in fp32.
+    """
+    if head_dim % 4 != 0:
+        raise ValueError(
+            f"head_dim={head_dim} must be divisible by 4 for axial 2D RoPE "
+            f"(half per axis, then adjacent pairs within each half)."
+        )
+    half = head_dim // 2  # channels per axis
+
+    # Frequencies for one axis: head_dim/4 unique values, each shared across an
+    # adjacent channel pair via repeat_interleave below.
+    k = torch.arange(0, half, 2, dtype=torch.float32, device=device)
+    freqs = theta ** (-k / half)  # (head_dim/4,)
+
+    row_idx = torch.arange(h, dtype=torch.float32, device=device)
+    row_ang = row_idx[:, None] * freqs[None, :]  # (h, head_dim/4)
+    col_idx = torch.arange(w, dtype=torch.float32, device=device)
+    col_ang = col_idx[:, None] * freqs[None, :]  # (w, head_dim/4)
+
+    # repeat_interleave(2) sends [a, b, c, ...] -> [a, a, b, b, c, c, ...] so that
+    # the adjacent channel pair (2k, 2k+1) shares frequency theta_k.
+    cos_row = row_ang.cos().repeat_interleave(2, dim=-1)  # (h, half)
+    sin_row = row_ang.sin().repeat_interleave(2, dim=-1)
+    cos_col = col_ang.cos().repeat_interleave(2, dim=-1)  # (w, half)
+    sin_col = col_ang.sin().repeat_interleave(2, dim=-1)
+
+    cos = torch.cat(
+        [
+            cos_row[:, None, :].expand(h, w, half),
+            cos_col[None, :, :].expand(h, w, half),
+        ],
+        dim=-1,
+    )  # (h, w, head_dim)
+    sin = torch.cat(
+        [
+            sin_row[:, None, :].expand(h, w, half),
+            sin_col[None, :, :].expand(h, w, half),
+        ],
+        dim=-1,
+    )
+    return cos.contiguous(), sin.contiguous()
+
+
+def build_rope_cos_sin_1d(
+    seq_len: int,
+    head_dim: int,
+    theta: float = 10000.0,
+    device: Optional[torch.device] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Precompute 1D RoPE cos/sin tables for a length-``seq_len`` sequence.
+
+    The standard sequence RoPE: every channel rotates by the token position,
+    with ``head_dim/2`` frequencies :math:`\theta_k = \text{theta}^{-2k/head\_dim}`
+    for :math:`k = 0 \ldots head\_dim/2 - 1`, each driving the adjacent channel
+    pair ``(2k, 2k+1)``.
+
+    Parameters
+    ----------
+    seq_len : int
+        Number of positions in the sequence.
+    head_dim : int
+        Per-head channel dimension. Must be even (rotation acts on adjacent
+        channel pairs).
+    theta : float, optional, default=10000.0
+        Base used for the RoPE frequency schedule.
+    device : torch.device, optional
+        Device for the generated tables.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(cos, sin)``, each of shape :math:`(seq\_len, head\_dim)` in fp32.
+    """
+    if head_dim % 2 != 0:
+        raise ValueError(
+            f"head_dim={head_dim} must be even for 1D RoPE "
+            f"(rotation acts on adjacent channel pairs)."
+        )
+
+    # head_dim/2 unique frequencies, each shared across an adjacent channel pair
+    # via repeat_interleave below.
+    k = torch.arange(0, head_dim, 2, dtype=torch.float32, device=device)
+    freqs = theta ** (-k / head_dim)  # (head_dim/2,)
+
+    pos = torch.arange(seq_len, dtype=torch.float32, device=device)
+    ang = pos[:, None] * freqs[None, :]  # (seq_len, head_dim/2)
+
+    cos = ang.cos().repeat_interleave(2, dim=-1)  # (seq_len, head_dim)
+    sin = ang.sin().repeat_interleave(2, dim=-1)
+    return cos.contiguous(), sin.contiguous()
+
+
+def rotate_half_pairs(x: torch.Tensor) -> torch.Tensor:
+    r"""Swap adjacent channel pairs with a sign flip.
+
+    Maps ``(x0, x1, x2, x3, ...) -> (-x1, x0, -x3, x2, ...)``. Used to compute
+    ``q * cos + rotate_half_pairs(q) * sin``, the standard formulation of a 2D
+    rotation on adjacent-pair channel encoding.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Tensor whose last dimension is the (even) channel dimension.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of the same shape as ``x`` with adjacent pairs rotated.
+    """
+    x_even = x[..., 0::2]
+    x_odd = x[..., 1::2]
+    return torch.stack((-x_odd, x_even), dim=-1).flatten(-2)
+
+
+def apply_rotary_pos_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    r"""Apply a rotary position embedding to ``x`` given precomputed tables.
+
+    Computes ``x * cos + rotate_half_pairs(x) * sin`` in fp32 (the sign-flipped
+    term can accumulate error in low precision) and casts back to ``x``'s dtype.
+    ``cos`` and ``sin`` must broadcast against ``x`` over its trailing
+    ``(..., positions, head_dim)`` dimensions.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Query or key tensor of shape :math:`(\ldots, \text{positions}, head\_dim)`.
+    cos, sin : torch.Tensor
+        Rotation tables broadcastable to ``x`` (e.g. shape
+        :math:`(\text{positions}, head\_dim)`), as produced by
+        :func:`build_axial_rope_cos_sin`.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotated tensor of the same shape and dtype as ``x``.
+    """
+    in_dtype = x.dtype
+    x = x.float()
+    return (x * cos + rotate_half_pairs(x) * sin).to(in_dtype)
+
+
+class RotaryPositionEmbedding2D(nn.Module):
+    r"""Axial 2D rotary position embedding as a reusable module.
+
+    Precomputes cos/sin tables for an :math:`(h, w)` token grid and rotates
+    query/key tensors shaped :math:`(\ldots, \text{seq}, head\_dim)` with
+    ``seq == h * w`` in row-major order (height varies slowest). This is the
+    standard :math:`(B, \text{heads}, N, head\_dim)` attention layout, so the
+    module is a drop-in for any attention operating on a flattened 2D token
+    sequence (e.g. a vision transformer).
+
+    For NATTEN windowed attention, which operates on spatial
+    :math:`(B, h, w, \text{heads}, head\_dim)` tensors, use
+    :class:`~physicsnemo.nn.module.dit_layers.RopeNatten2DSelfAttention` instead.
+
+    The cos/sin tables are stored as ``persistent=False`` buffers (they are
+    deterministically rebuilt from ``(latent_hw, head_dim, theta)``). Building
+    them at the global grid size lets ``distribute_module`` shard them along
+    height for domain parallelism, with no explicit rank offset in model code.
+
+    Parameters
+    ----------
+    head_dim : int
+        Per-head channel dimension. Must be divisible by 4.
+    latent_hw : Tuple[int, int]
+        Spatial size :math:`(h, w)` of the token grid.
+    theta : float, optional, default=10000.0
+        Base used for the RoPE frequency schedule.
+
+    Forward
+    -------
+    q, k : torch.Tensor
+        Query and key tensors of shape :math:`(\ldots, h \cdot w, head\_dim)`.
+    latent_hw : Tuple[int, int], optional
+        If given and different from the construction-time grid, the tables are
+        rebuilt in place before rotating (off the ``torch.compile`` path).
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        The rotated ``(q, k)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from physicsnemo.nn.module.rope import RotaryPositionEmbedding2D
+    >>> rope = RotaryPositionEmbedding2D(head_dim=16, latent_hw=(4, 4))
+    >>> q = torch.randn(2, 8, 16, 16)  # (B, heads, h*w, head_dim)
+    >>> k = torch.randn(2, 8, 16, 16)
+    >>> q_rot, k_rot = rope(q, k)
+    >>> q_rot.shape
+    torch.Size([2, 8, 16, 16])
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        latent_hw: Tuple[int, int],
+        theta: float = 10000.0,
+    ):
+        super().__init__()
+        if head_dim % 4 != 0:
+            raise ValueError(
+                f"head_dim={head_dim} must be divisible by 4 for axial 2D RoPE."
+            )
+        self.head_dim = int(head_dim)
+        self.theta = float(theta)
+        self._latent_hw: Tuple[int, int] = (int(latent_hw[0]), int(latent_hw[1]))
+        cos, sin = build_axial_rope_cos_sin(
+            *self._latent_hw, self.head_dim, theta=self.theta
+        )
+        # Flatten the spatial axes to (h*w, head_dim) so the tables broadcast
+        # against any (..., seq, head_dim) attention layout.
+        self.register_buffer("cos", cos.reshape(-1, self.head_dim), persistent=False)
+        self.register_buffer("sin", sin.reshape(-1, self.head_dim), persistent=False)
+
+    def _rebuild_for_shape(self, h: int, w: int) -> None:
+        """Rebuild the cos/sin tables for a new latent shape (off the hot path)."""
+        target_dtype = self.cos.dtype
+        target_device = self.cos.device
+        cos, sin = build_axial_rope_cos_sin(
+            h, w, self.head_dim, theta=self.theta, device=target_device
+        )
+        self.register_buffer(
+            "cos", cos.reshape(-1, self.head_dim).to(target_dtype), persistent=False
+        )
+        self.register_buffer(
+            "sin", sin.reshape(-1, self.head_dim).to(target_dtype), persistent=False
+        )
+        self._latent_hw = (int(h), int(w))
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        latent_hw: Optional[Tuple[int, int]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if latent_hw is not None and (
+            (int(latent_hw[0]), int(latent_hw[1])) != self._latent_hw
+        ):
+            self._rebuild_for_shape(int(latent_hw[0]), int(latent_hw[1]))
+
+        n = self.cos.shape[0]
+        if q.shape[-2] != n or k.shape[-2] != n:
+            raise ValueError(
+                f"q/k sequence length must be h*w={n} (latent_hw={self._latent_hw}), "
+                f"but got q={q.shape[-2]}, k={k.shape[-2]}"
+            )
+        return apply_rotary_pos_emb(q, self.cos, self.sin), apply_rotary_pos_emb(
+            k, self.cos, self.sin
+        )
+
+
+class RotaryPositionEmbedding1D(nn.Module):
+    r"""1D rotary position embedding as a reusable module.
+
+    The standard sequence RoPE used by most autoregressive / encoder
+    transformers. Precomputes cos/sin tables for a length-``max_seq_len``
+    sequence and rotates query/key tensors shaped
+    :math:`(\ldots, \text{seq}, head\_dim)` (e.g. the
+    :math:`(B, \text{heads}, N, head\_dim)` attention layout). Inputs shorter
+    than ``max_seq_len`` are rotated with the leading positions, so a single
+    module can serve any sequence length up to ``max_seq_len`` without a rebuild.
+
+    The cos/sin tables are stored as ``persistent=False`` buffers (they are
+    deterministically rebuilt from ``(max_seq_len, head_dim, theta)``).
+
+    Parameters
+    ----------
+    head_dim : int
+        Per-head channel dimension. Must be even.
+    max_seq_len : int
+        Maximum sequence length for which to precompute tables.
+    theta : float, optional, default=10000.0
+        Base used for the RoPE frequency schedule.
+
+    Forward
+    -------
+    q, k : torch.Tensor
+        Query and key tensors of shape :math:`(\ldots, \text{seq}, head\_dim)`
+        with ``seq <= max_seq_len``.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        The rotated ``(q, k)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from physicsnemo.nn.module.rope import RotaryPositionEmbedding1D
+    >>> rope = RotaryPositionEmbedding1D(head_dim=16, max_seq_len=128)
+    >>> q = torch.randn(2, 8, 100, 16)  # (B, heads, seq, head_dim)
+    >>> k = torch.randn(2, 8, 100, 16)
+    >>> q_rot, k_rot = rope(q, k)
+    >>> q_rot.shape
+    torch.Size([2, 8, 100, 16])
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        max_seq_len: int,
+        theta: float = 10000.0,
+    ):
+        super().__init__()
+        if head_dim % 2 != 0:
+            raise ValueError(f"head_dim={head_dim} must be even for 1D RoPE.")
+        self.head_dim = int(head_dim)
+        self.theta = float(theta)
+        self.max_seq_len = int(max_seq_len)
+        cos, sin = build_rope_cos_sin_1d(
+            self.max_seq_len, self.head_dim, theta=self.theta
+        )
+        self.register_buffer("cos", cos, persistent=False)  # (max_seq_len, head_dim)
+        self.register_buffer("sin", sin, persistent=False)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        seq_len = q.shape[-2]
+        if k.shape[-2] != seq_len:
+            raise ValueError(
+                f"q and k must share a sequence length; got q={seq_len}, "
+                f"k={k.shape[-2]}"
+            )
+        if seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {seq_len} exceeds max_seq_len={self.max_seq_len}"
+            )
+        # Slice the leading positions so the module serves any length <= max.
+        cos = self.cos[:seq_len]
+        sin = self.sin[:seq_len]
+        return apply_rotary_pos_emb(q, cos, sin), apply_rotary_pos_emb(k, cos, sin)

--- a/physicsnemo/nn/module/rope.py
+++ b/physicsnemo/nn/module/rope.py
@@ -410,3 +410,389 @@ class RotaryPositionEmbedding1D(nn.Module):
         cos = self.cos[:seq_len]
         sin = self.sin[:seq_len]
         return apply_rotary_pos_emb(q, cos, sin), apply_rotary_pos_emb(k, cos, sin)
+
+
+# --- Stereographic 2D RoPE (continuous spherical coordinates) ---
+#
+# A 2D RoPE for tokens that live on a sphere. Token latitude/longitude are mapped
+# to a local tangent plane with a stereographic projection, and the resulting
+# *continuous* (x, y) coordinates drive the same adjacent-pair rotation as the
+# axial RoPE above (via :func:`apply_rotary_pos_emb`). The only new ingredient is
+# a table builder for continuous positions
+# (:func:`build_axial_rope_cos_sin_continuous`); :func:`build_axial_rope_cos_sin`
+# is its integer-grid special case.
+
+
+def stereographic_projection(
+    lat: torch.Tensor,
+    lon: torch.Tensor,
+    lat0: torch.Tensor,
+    lon0: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Project latitude / longitude onto a local tangent plane.
+
+    Stereographic projection of points :math:`(\text{lat}, \text{lon})` onto the
+    plane tangent to the sphere at the center :math:`(\text{lat}_0, \text{lon}_0)`,
+    with axes oriented so ``y`` points North and ``x`` points East. All inputs are
+    in radians and may broadcast against each other (e.g. ``lat`` of shape
+    :math:`(B, H, W)` with ``lat0`` of shape :math:`(B, 1, 1)`).
+
+    Parameters
+    ----------
+    lat : torch.Tensor
+        Latitude in radians, of shape :math:`(\ldots, H, W)`.
+    lon : torch.Tensor
+        Longitude in radians, of shape :math:`(\ldots, H, W)`.
+    lat0 : torch.Tensor
+        Center latitude in radians, broadcastable to ``lat``.
+    lon0 : torch.Tensor
+        Center longitude in radians, broadcastable to ``lon``.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        The projected ``(x, y)`` coordinates on the tangent plane (``x`` East,
+        ``y`` North), each of the broadcasted shape of the inputs.
+
+    Notes
+    -----
+    The projection diverges at the antipode of the center (:math:`\cos c = -1`).
+    The denominator is clamped so outputs stay finite there (large but not
+    infinite); this is intended for tiles local to the center, not whole-sphere use.
+    """
+    dlon = lon - lon0
+    # cos_c: cosine of the great-circle angle to the center; k: stereographic scale.
+    cos_c = torch.sin(lat0) * torch.sin(lat) + torch.cos(lat0) * torch.cos(
+        lat
+    ) * torch.cos(dlon)
+    # Guard the antipodal singularity (cos_c = -1, the point opposite the center),
+    # where the projection diverges: clamp the denominator so coordinates stay
+    # finite for tiles that approach it.
+    k = 2.0 / (1.0 + cos_c).clamp_min(1e-6)
+    x = k * torch.cos(lat) * torch.sin(dlon)
+    y = k * (
+        torch.cos(lat0) * torch.sin(lat)
+        - torch.sin(lat0) * torch.cos(lat) * torch.cos(dlon)
+    )
+    return x, y
+
+
+def spherical_centroid(
+    lat: torch.Tensor,
+    lon: torch.Tensor,
+    reduce_dims: Tuple[int, ...] = (-2, -1),
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Robust center :math:`(\text{lat}_0, \text{lon}_0)` of points on the sphere.
+
+    Each ``(lat, lon)`` is lifted to a 3D unit vector
+    :math:`(\cos\text{lat}\cos\text{lon},\ \cos\text{lat}\sin\text{lon},\ \sin\text{lat})`,
+    the vectors are averaged over ``reduce_dims``, and the mean direction is read
+    back as ``(lat0, lon0)``. Averaging in 3D — rather than per-axis on the
+    angles — is correct at the poles (where the plain mean of latitude undershoots
+    :math:`\pm\pi/2` and longitude is degenerate) and across the
+    :math:`0 / 2\pi` longitude seam. The reduced dimensions are kept (size 1) for
+    broadcasting.
+
+    Parameters
+    ----------
+    lat : torch.Tensor
+        Latitude in radians, of shape :math:`(\ldots, H, W)`.
+    lon : torch.Tensor
+        Longitude in radians, of shape :math:`(\ldots, H, W)`.
+    reduce_dims : Tuple[int, ...], optional, default=(-2, -1)
+        Dimensions to average over.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(lat0, lon0)`` in radians (``lat0`` in :math:`[-\pi/2, \pi/2]`, ``lon0``
+        in :math:`(-\pi, \pi]`), with the reduced dimensions kept as size 1.
+
+    Notes
+    -----
+    The mean direction is ill-defined only when the points nearly cancel (an
+    antipodal / whole-sphere spread), which is outside this module's local-tile
+    scope (see :class:`StereographicRotaryPositionEmbedding2D`).
+    """
+    cos_lat = lat.cos()
+    x = (cos_lat * lon.cos()).mean(dim=reduce_dims, keepdim=True)
+    y = (cos_lat * lon.sin()).mean(dim=reduce_dims, keepdim=True)
+    z = lat.sin().mean(dim=reduce_dims, keepdim=True)
+    lat0 = torch.atan2(z, torch.hypot(x, y))
+    lon0 = torch.atan2(y, x)
+    return lat0, lon0
+
+
+def build_rope_cos_sin_1d_continuous(
+    positions: torch.Tensor,
+    dim: int,
+    theta: float = 10000.0,
+    device: Optional[torch.device] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Build 1D RoPE cos/sin tables from arbitrary continuous positions.
+
+    The continuous-position analog of :func:`build_rope_cos_sin_1d` (which takes an
+    integer ``seq_len`` and generates positions :math:`0 \ldots seq\_len - 1`): here
+    the positions are supplied explicitly and may be any real values. All ``dim``
+    channels rotate by the position, with ``dim/2`` frequencies
+    :math:`\theta_k = \text{theta}^{-2k/dim}`, each driving the adjacent channel pair
+    ``(2k, 2k+1)`` so the result composes with :func:`apply_rotary_pos_emb`.
+
+    This is the shared building block for continuous RoPE in higher dimensions:
+    :func:`build_axial_rope_cos_sin_continuous` calls it once per axis over
+    ``head_dim/2`` channels.
+
+    Parameters
+    ----------
+    positions : torch.Tensor
+        Continuous positions of shape :math:`(\ldots, N)`.
+    dim : int
+        Number of channels rotated by ``positions``. Must be even. For standalone
+        1D use this is ``head_dim``; per axis of a 2D embedding it is ``head_dim/2``.
+    theta : float, optional, default=10000.0
+        Base used for the RoPE frequency schedule.
+    device : torch.device, optional
+        Device to place the positions and returned tables on. If ``None``, follows
+        ``positions.device``.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(cos, sin)``, each of shape :math:`(\ldots, N, dim)`.
+    """
+    if dim % 2 != 0:
+        raise ValueError(
+            f"dim={dim} must be even (rotation acts on adjacent channel pairs)."
+        )
+    # Move positions to the requested device (if any) so positions, frequencies,
+    # and the returned tables all share one device; otherwise follow positions.
+    if device is not None:
+        positions = positions.to(device)
+    k = torch.arange(0, dim, 2, dtype=torch.float32, device=positions.device)
+    freqs = theta ** (-k / dim)  # (dim/2,)
+
+    # Outer product of positions and frequencies -> per-token angles.
+    ang = positions.to(torch.float32).unsqueeze(-1) * freqs  # (..., N, dim/2)
+    # repeat_interleave(2) makes the adjacent channel pair (2k, 2k+1) share theta_k.
+    cos = ang.cos().repeat_interleave(2, dim=-1)  # (..., N, dim)
+    sin = ang.sin().repeat_interleave(2, dim=-1)
+    return cos.contiguous(), sin.contiguous()
+
+
+def build_axial_rope_cos_sin_continuous(
+    x_pos: torch.Tensor,
+    y_pos: torch.Tensor,
+    head_dim: int,
+    theta: float = 10000.0,
+    device: Optional[torch.device] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Build axial 2D RoPE cos/sin tables from arbitrary continuous coordinates.
+
+    The continuous-coordinate analog of :func:`build_axial_rope_cos_sin` (which takes
+    integer grid sizes ``h, w`` and generates row/column indices): here the per-token
+    ``(x, y)`` coordinates are supplied explicitly and may be any real values.
+    ``head_dim`` is split in half — the first half rotates by ``x_pos``, the second by
+    ``y_pos`` — each half built with :func:`build_rope_cos_sin_1d_continuous` over
+    ``head_dim/2`` channels, so the result composes with :func:`apply_rotary_pos_emb`.
+    Passing integer row / column indices reproduces :func:`build_axial_rope_cos_sin`
+    (flattened over the grid).
+
+    Parameters
+    ----------
+    x_pos : torch.Tensor
+        First-axis coordinates of shape :math:`(\ldots, N)`.
+    y_pos : torch.Tensor
+        Second-axis coordinates of shape :math:`(\ldots, N)` (same shape as ``x_pos``).
+    head_dim : int
+        Per-head channel dimension. Must be divisible by 4 (half per axis, then
+        adjacent pairs within each half).
+    theta : float, optional, default=10000.0
+        Base used for the RoPE frequency schedule.
+    device : torch.device, optional
+        Device to place the coordinates and returned tables on. If ``None``, follows
+        ``x_pos.device``.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(cos, sin)``, each of shape :math:`(\ldots, N, head\_dim)`.
+    """
+    if head_dim % 4 != 0:
+        raise ValueError(
+            f"head_dim={head_dim} must be divisible by 4 for axial 2D RoPE "
+            f"(half per axis, then adjacent pairs within each half)."
+        )
+    half = head_dim // 2  # channels per axis
+    cos_x, sin_x = build_rope_cos_sin_1d_continuous(
+        x_pos, half, theta=theta, device=device
+    )
+    cos_y, sin_y = build_rope_cos_sin_1d_continuous(
+        y_pos, half, theta=theta, device=device
+    )
+    cos = torch.cat([cos_x, cos_y], dim=-1)  # (..., N, head_dim)
+    sin = torch.cat([sin_x, sin_y], dim=-1)
+    return cos, sin
+
+
+class StereographicRotaryPositionEmbedding2D(nn.Module):
+    r"""Stereographic 2D rotary position embedding for tokens on a sphere.
+
+    The continuous-coordinate counterpart of :class:`RotaryPositionEmbedding2D`.
+    Token positions, given as latitude / longitude, are mapped to a local tangent
+    plane via :func:`stereographic_projection`, and the resulting continuous
+    ``(x, y)`` coordinates drive a 2D RoPE on the query / key tensors (via
+    :func:`build_axial_rope_cos_sin_continuous` + :func:`apply_rotary_pos_emb`). Because the
+    positions depend on the input geometry, the cos/sin tables are built per
+    forward rather than cached as buffers, so the module is parameter-free and
+    stateless beyond its ``head_dim`` / ``theta`` configuration.
+
+    Parameters
+    ----------
+    head_dim : int
+        Per-head channel dimension. Must be divisible by 4.
+    theta : float, optional, default=10000.0
+        Base used for the RoPE frequency schedule.
+
+    Forward
+    -------
+    q, k : torch.Tensor
+        Query / key tensors of shape :math:`(\ldots, N, head\_dim)`.
+    x_pos, y_pos : torch.Tensor
+        Continuous tangent-plane coordinates of shape :math:`(N,)` (shared across
+        the batch) or :math:`(B, N)` (per sample), e.g. from :meth:`project`. For
+        the standard :math:`(B, \text{heads}, N, head\_dim)` ``q`` / ``k`` layout a
+        heads axis is inserted automatically so per-sample tables broadcast over heads.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        The rotated ``(q, k)``.
+
+    Notes
+    -----
+    The stereographic projection is singular at the antipode of its center and its
+    distortion grows with distance from that center. This embedding is therefore
+    intended for tokens that are *local* to a single center -- i.e. a regional grid,
+    where one :meth:`project` call (its center defaults to the grid's mean lat/lon)
+    is enough. It is **not** meant for a single projection of a whole-sphere / very
+    large global grid, where the far-field distortion breaks the relative-position
+    interpretation. Covering a global field would require splitting it into local
+    windows/tiles and projecting each around its own center -- which the caller must
+    arrange; this module only provides the per-tile projection primitive.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from physicsnemo.nn.module.rope import StereographicRotaryPositionEmbedding2D
+    >>> rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    >>> q = torch.randn(2, 4, 6, 16)  # (B, heads, N, head_dim)
+    >>> k = torch.randn(2, 4, 6, 16)
+    >>> x = torch.randn(6)            # continuous per-token coordinates
+    >>> y = torch.randn(6)
+    >>> q_rot, k_rot = rope(q, k, x, y)
+    >>> q_rot.shape
+    torch.Size([2, 4, 6, 16])
+    """
+
+    def __init__(self, head_dim: int, theta: float = 10000.0):
+        super().__init__()
+        if head_dim % 4 != 0:
+            raise ValueError(
+                f"head_dim={head_dim} must be divisible by 4 for stereographic 2D RoPE."
+            )
+        self.head_dim = int(head_dim)
+        self.theta = float(theta)
+
+    def project(
+        self,
+        lat: torch.Tensor,
+        lon: torch.Tensor,
+        length_scale: float,
+        lat0: Optional[torch.Tensor] = None,
+        lon0: Optional[torch.Tensor] = None,
+        reduce_dims: Tuple[int, ...] = (-2, -1),
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        r"""Map latitude / longitude to stereographic tangent-plane coordinates.
+
+        When ``lat0`` / ``lon0`` are not given, the projection center is the
+        :func:`spherical_centroid` of the inputs (a 3D unit-vector mean), which is
+        robust at the poles and across the longitude seam.
+
+        Parameters
+        ----------
+        lat : torch.Tensor
+            Latitude in radians, of shape :math:`(\ldots, H, W)`.
+        lon : torch.Tensor
+            Longitude in radians, of shape :math:`(\ldots, H, W)`.
+        length_scale : float
+            Positive divisor applied to the projected coordinates, bringing them to
+            roughly token-spacing units so the RoPE frequencies behave like the
+            integer-grid case. Required and with no default: a sensible value cannot
+            be inferred from the data, so the caller must choose it explicitly.
+        lat0 : torch.Tensor, optional
+            Center latitude in radians; if ``None``, taken from the
+            :func:`spherical_centroid` of ``(lat, lon)`` over ``reduce_dims``.
+        lon0 : torch.Tensor, optional
+            Center longitude in radians; if ``None``, taken from the
+            :func:`spherical_centroid` of ``(lat, lon)`` over ``reduce_dims``.
+        reduce_dims : Tuple[int, ...], optional, default=(-2, -1)
+            Dimensions used to compute the center when ``lat0`` / ``lon0`` are not given.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor]
+            The tangent-plane ``(x, y)`` coordinates (East, North), of the shape of ``lat``.
+        """
+        if length_scale <= 0:
+            raise ValueError(f"length_scale must be > 0, got {length_scale}")
+        if lat0 is None or lon0 is None:
+            c_lat, c_lon = spherical_centroid(lat, lon, reduce_dims=reduce_dims)
+            if lat0 is None:
+                lat0 = c_lat
+            if lon0 is None:
+                lon0 = c_lon
+        x, y = stereographic_projection(lat, lon, lat0, lon0)
+        return x / length_scale, y / length_scale
+
+    def build_tables(
+        self,
+        x_pos: torch.Tensor,
+        y_pos: torch.Tensor,
+        device: Optional[torch.device] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        r"""Build the ``(cos, sin)`` RoPE tables for continuous coordinates.
+
+        Thin wrapper over :func:`build_axial_rope_cos_sin_continuous` using this
+        module's ``head_dim`` and ``theta``.
+
+        Parameters
+        ----------
+        x_pos, y_pos : torch.Tensor
+            Continuous coordinates of shape :math:`(\ldots, N)`.
+        device : torch.device, optional
+            Device for the frequency table.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor]
+            ``(cos, sin)``, each of shape :math:`(\ldots, N, head\_dim)`.
+        """
+        return build_axial_rope_cos_sin_continuous(
+            x_pos, y_pos, self.head_dim, theta=self.theta, device=device
+        )
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        x_pos: torch.Tensor,
+        y_pos: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        cos, sin = self.build_tables(x_pos, y_pos, device=q.device)
+        # Per-sample (batched) coordinates give tables with one fewer dim than
+        # q/k (no heads axis); insert it so they broadcast over the heads dim of
+        # the standard (..., heads, N, head_dim) attention layout.
+        if cos.ndim == q.ndim - 1:
+            cos = cos.unsqueeze(-3)
+            sin = sin.unsqueeze(-3)
+        return apply_rotary_pos_emb(q, cos, sin), apply_rotary_pos_emb(k, cos, sin)

--- a/test/domain_parallel/models/test_dit.py
+++ b/test/domain_parallel/models/test_dit.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domain-parallel tests for the DiT 2D-RoPE + NaN-mask-token features.
+
+These exercise the exact distribution configuration used by the StormCast
+recipe: a 2-D ``(ddp, domain)`` device mesh where the model is sharded along the
+height (``Shard(0)``) of its spatial buffers via ``distribute_module`` on the
+domain mesh and then ``fully_shard`` (FSDP2) on the ddp mesh, with the spatial
+input sharded along H on the domain mesh.
+
+The key property under test is the "shard-the-buffer" design: building the RoPE
+cos/sin tables and the invalid-token mask at the global spatial size and
+sharding them along height gives each rank globally-correct rows with no
+explicit ``h_offset`` arithmetic, so the distributed forward is numerically
+equivalent to a single-GPU forward on the full input (NATTEN halo exchange
+handles the window boundaries).
+
+Run with, e.g.::
+
+    torchrun --nproc-per-node 4 -m pytest --multigpu-static \
+        test/domain_parallel/models/test_dit.py -x
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.distributed.tensor import distribute_module, distribute_tensor
+from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.distributed.fsdp import fully_shard
+
+from physicsnemo.distributed import DistributedManager
+from physicsnemo.domain_parallel import scatter_tensor
+from physicsnemo.models.dit import DiT
+from physicsnemo.nn.module.rope import build_axial_rope_cos_sin
+from test.conftest import requires_module
+
+# Latent grid is 4x4; with a domain mesh of size 2 each rank owns 2 rows.
+INPUT_SIZE = (16, 16)
+PATCH_SIZE = 4
+HIDDEN_SIZE = 64
+NUM_HEADS = 4  # head_dim = 16 (divisible by 4, required for axial 2D RoPE)
+DEPTH = 2
+ATTN_KERNEL = 3
+IN_CHANNELS = 4
+
+
+def _shard_dim_for(name: str) -> int | None:
+    """Mirror of StormCast's ``shard_dim_selector`` for the buffers under test."""
+    if any(s in name for s in ("pos_embed", "pos_embd", "spatial_emb")):
+        return 1
+    if any(s in name for s in ("invalid_token_mask", "rope_cos", "rope_sin")):
+        return 0
+    return None
+
+
+def _partition_dit(name, submodule, device_mesh):
+    """Local copy of StormCast's ``partition_model_selective``.
+
+    Shards the spatial buffers along height and replicates everything else,
+    handling both parameters and buffers explicitly.
+    """
+    for key, param in submodule._parameters.items():
+        if param is None:
+            continue
+        shard_dim = _shard_dim_for(key)
+        placement = Shard(shard_dim) if shard_dim is not None else Replicate()
+        dt = distribute_tensor(param, device_mesh=device_mesh, placements=[placement])
+        submodule.register_parameter(
+            key, nn.Parameter(dt, requires_grad=param.requires_grad)
+        )
+    for key, buffer in submodule._buffers.items():
+        if buffer is None:
+            continue
+        shard_dim = _shard_dim_for(key)
+        placement = Shard(shard_dim) if shard_dim is not None else Replicate()
+        dt = distribute_tensor(buffer, device_mesh=device_mesh, placements=[placement])
+        persistent = key not in submodule._non_persistent_buffers_set
+        submodule.register_buffer(key, dt, persistent=persistent)
+
+
+def _build_dit(device, attention_backend: str, use_nan_mask_tokens: bool) -> DiT:
+    """Construct a small NATTEN DiT with identical init across ranks (seeded).
+
+    ``attention_backend`` selects the vanilla ``"natten2d"`` or the RoPE
+    ``"natten2d_rope"`` variant; the RoPE variant has the DiT inject ``latent_hw``
+    into the attention constructor automatically.
+    """
+    torch.manual_seed(0)
+    model = DiT(
+        input_size=INPUT_SIZE,
+        in_channels=IN_CHANNELS,
+        out_channels=IN_CHANNELS,
+        patch_size=PATCH_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        depth=DEPTH,
+        num_heads=NUM_HEADS,
+        attention_backend=attention_backend,
+        attn_kwargs={"attn_kernel": ATTN_KERNEL},
+        use_nan_mask_tokens=use_nan_mask_tokens,
+    )
+    return model.to(device).eval()
+
+
+def _make_pixel_mask(device) -> torch.Tensor:
+    """A static invalid region: the whole top-left patch + one interior pixel."""
+    pixel_mask = torch.zeros(*INPUT_SIZE, dtype=torch.bool, device=device)
+    pixel_mask[0:PATCH_SIZE, 0:PATCH_SIZE] = True  # -> patch (0, 0)
+    pixel_mask[9, 9] = True  # -> patch (2, 2)
+    return pixel_mask
+
+
+@requires_module(["natten"])
+@pytest.mark.multigpu_static
+@pytest.mark.parametrize("attention_backend", ["natten2d", "natten2d_rope"])
+@pytest.mark.parametrize("use_nan_mask_tokens", [False, True])
+def test_dit_natten_distributed_matches_single_gpu(
+    distributed_mesh_2d, attention_backend, use_nan_mask_tokens
+):
+    """Distributed (ddp x domain, FSDP2) forward equals the single-GPU forward.
+
+    Covers both the vanilla ``natten2d`` and the RoPE ``natten2d_rope`` backends
+    so that any failure shared by both (e.g. in the QKV projection on a
+    sequence-sharded ``ShardTensor``) is distinguishable from a RoPE-specific
+    one. For ``natten2d_rope`` it also validates that sharding the RoPE tables
+    along height delivers globally-correct rows per rank with no ``h_offset``;
+    with ``use_nan_mask_tokens`` it validates the mask-token splice is
+    sharding-safe.
+    """
+    dm = DistributedManager()
+    if dm.world_size != 4:
+        pytest.skip("Requires exactly 4 ranks for the (ddp=2, domain=2) mesh")
+
+    ddp_mesh = distributed_mesh_2d["axis1"]
+    domain_mesh = distributed_mesh_2d["axis2"]
+
+    _run_dit_distributed_check(
+        dm, ddp_mesh, domain_mesh, dm.device, attention_backend, use_nan_mask_tokens
+    )
+
+
+def _run_dit_distributed_check(
+    dm, ddp_mesh, domain_mesh, device, attention_backend, use_nan_mask_tokens
+):
+    # Local (per-rank) batch size 1: this matches every domain-parallel config
+    # the StormCast recipe runs. A 3-D F.linear on a sequence-sharded ShardTensor
+    # folds the leading dims; with local batch 1 the size-1 batch dim is dropped
+    # (no flatten of the sharded sequence dim), whereas local batch >= 2 would
+    # flatten (B, N) with N sharded and hit DTensor's strict_view restriction --
+    # a base ShardTensor/F.linear limitation independent of RoPE / NaN-masking.
+    B = 1
+    # Identical inputs on every rank so the gathered output can be compared to a
+    # single reference computed from the full input.
+    torch.manual_seed(123)
+    x_full = torch.randn(B, IN_CHANNELS, *INPUT_SIZE, device=device)
+    t = torch.rand(B, device=device)
+
+    model = _build_dit(device, attention_backend, use_nan_mask_tokens)
+    if use_nan_mask_tokens:
+        model.set_nan_pixel_mask(_make_pixel_mask(device))
+        # Give the learned mask tokens a non-trivial value so masking actually
+        # changes the result (init is zero); seeded for cross-rank consistency.
+        torch.manual_seed(7)
+        for m in model.modules():
+            if getattr(m, "mask_token", None) is not None:
+                nn.init.normal_(m.mask_token)
+
+    # --- single-GPU reference on the full input (before distribution) ---
+    with torch.no_grad():
+        ref_out = model(x_full, t).detach().clone()
+
+    # --- distribute exactly as the StormCast recipe does ---
+    model = distribute_module(
+        model, device_mesh=domain_mesh, partition_fn=_partition_dit
+    )
+    with torch.no_grad():
+        for p in model.parameters():
+            if not p.is_contiguous():
+                p.data = p.data.contiguous()
+    fully_shard(model, mesh=ddp_mesh)
+
+    # ------------------------------------------------------------------
+    # Run ALL collective operations first, BEFORE any assertion. A failing
+    # assert on a subset of ranks would otherwise leave the others blocked on
+    # the next collective (manifesting as a SIGTERM hang), so every collective
+    # below is executed unconditionally and symmetrically on all ranks.
+    # ------------------------------------------------------------------
+    # Source must be a rank within the domain submesh: use this group's local
+    # rank-0 global rank (rank 0 for the {0,1} group, rank 2 for {2,3}). x_full
+    # is identical on every rank, so both groups receive the same shards.
+    domain_src = torch.distributed.get_global_rank(domain_mesh.get_group(), 0)
+    x_sharded = scatter_tensor(
+        x_full, domain_src, domain_mesh, (Shard(2),), requires_grad=False
+    )
+    # Scalars/conditions must be replicated DTensors on the domain mesh so they
+    # compose with the now-DTensor model buffers (e.g. the timestep embedder's
+    # `freqs`); this mirrors StormCast's ParallelHelper.replicate_tensor.
+    t_dt = distribute_tensor(t, domain_mesh, [Replicate()])
+    with torch.no_grad():
+        out = model(x_sharded, t_dt)
+    gathered = out.full_tensor()  # collective: gather H-shards over domain mesh
+
+    # Reassemble the sharded RoPE table and invalid mask globally (collectives),
+    # so correctness of the per-rank row bands can be checked symmetrically.
+    rope_cos_global = None
+    rope_cos_local_shape = None
+    for m in model.modules():
+        if hasattr(m, "rope_cos") and hasattr(m.rope_cos, "full_tensor"):
+            rope_cos_local_shape = tuple(m.rope_cos.to_local().shape)
+            rope_cos_global = m.rope_cos.full_tensor()
+            break
+    mask_global = (
+        model.invalid_token_mask.full_tensor() if use_nan_mask_tokens else None
+    )
+
+    # ------------------------------------------------------------------
+    # Assertions (no further collectives): these evaluate identically on every
+    # rank, so a failure fails the whole job cleanly rather than hanging.
+    # ------------------------------------------------------------------
+    latent_h = INPUT_SIZE[0] // PATCH_SIZE
+    latent_w = INPUT_SIZE[1] // PATCH_SIZE
+    head_dim = HIDDEN_SIZE // NUM_HEADS
+    h_local = latent_h // domain_mesh.size()
+
+    assert out.shape == (B, IN_CHANNELS, *INPUT_SIZE)
+    # Output stays sharded along H on the domain mesh.
+    assert any(p.is_shard() for p in out._spec.placements)
+
+    # Distributed forward must match the single-GPU reference: this is the
+    # end-to-end proof that the sharded RoPE rows and mask are globally correct.
+    torch.testing.assert_close(gathered, ref_out, atol=1e-4, rtol=1e-4)
+
+    # For the RoPE backend, the table is sharded (each rank owns h_local rows)
+    # and reassembles to the canonical global table.
+    if attention_backend == "natten2d_rope":
+        assert rope_cos_global is not None, "no RoPE attention module found"
+        assert rope_cos_local_shape == (h_local, latent_w, head_dim)
+        full_cos, _ = build_axial_rope_cos_sin(latent_h, latent_w, head_dim)
+        torch.testing.assert_close(
+            rope_cos_global, full_cos.to(device), atol=1e-5, rtol=1e-5
+        )
+    else:
+        assert rope_cos_global is None
+
+    if use_nan_mask_tokens:
+        full_pixel = _make_pixel_mask(device)
+        full_patch = (
+            torch.nn.functional.max_pool2d(
+                full_pixel.float().unsqueeze(0).unsqueeze(0),
+                kernel_size=PATCH_SIZE,
+                stride=PATCH_SIZE,
+            ).squeeze()
+            > 0
+        )
+        assert mask_global.shape == (latent_h, latent_w)
+        assert torch.equal(mask_global, full_patch)

--- a/test/domain_parallel/models/test_dit.py
+++ b/test/domain_parallel/models/test_dit.py
@@ -38,9 +38,9 @@ Run with, e.g.::
 import pytest
 import torch
 import torch.nn as nn
+from torch.distributed.fsdp import fully_shard
 from torch.distributed.tensor import distribute_module, distribute_tensor
 from torch.distributed.tensor.placement_types import Replicate, Shard
-from torch.distributed.fsdp import fully_shard
 
 from physicsnemo.distributed import DistributedManager
 from physicsnemo.domain_parallel import scatter_tensor

--- a/test/models/dit/test_dit.py
+++ b/test/models/dit/test_dit.py
@@ -118,6 +118,83 @@ def test_dit_constructor(device):
     assert output.shape == (batch_size, out_channels, *input_size)
 
 
+def test_dit_rope_disables_pos_embed_and_warns(device):
+    """Selecting the RoPE NATTEN backend forces pos_embed='none' on the patch
+    tokenizer and warns if a conflicting value was explicitly requested.
+
+    Construction does not run the NATTEN kernel, so this is CPU-friendly.
+    """
+    with pytest.warns(UserWarning, match="rotary"):
+        model = DiT(
+            input_size=(16, 16),
+            patch_size=4,
+            in_channels=3,
+            hidden_size=64,
+            depth=2,
+            num_heads=4,
+            attention_backend="natten2d_rope",
+            attn_kwargs={"attn_kernel": 3},
+            tokenizer_kwargs={"pos_embed": "learnable"},
+        ).to(device)
+    # Additive positional embedding is disabled.
+    assert model.tokenizer.pos_embed == 0.0
+    # The RoPE tables were precomputed at the latent grid size.
+    head_dim = 64 // 4
+    assert model.blocks[0].attention.rope_cos.shape == (4, 4, head_dim)
+
+
+def test_dit_set_nan_pixel_mask(device):
+    """set_nan_pixel_mask aggregates a pixel mask to patch granularity and
+    installs it as the model buffer; it errors when the feature is disabled."""
+    model = DiT(
+        input_size=(16, 16),
+        patch_size=4,
+        in_channels=3,
+        hidden_size=64,
+        depth=2,
+        num_heads=4,
+        attention_backend="natten2d",
+        attn_kwargs={"attn_kernel": 3},
+        use_nan_mask_tokens=True,
+    ).to(device)
+
+    # Default buffer is all-valid and patch-shaped.
+    assert model.invalid_token_mask.shape == (4, 4)
+    assert not model.invalid_token_mask.any()
+    # Each NATTEN block allocated a learned mask token.
+    assert model.blocks[0].attention.mask_token is not None
+
+    # A patch is invalid if ANY pixel inside it is invalid.
+    pixel_mask = torch.zeros(16, 16, dtype=torch.bool, device=device)
+    pixel_mask[0:4, 0:4] = True  # entire top-left patch
+    pixel_mask[5, 5] = True  # single pixel inside patch (1, 1)
+    model.set_nan_pixel_mask(pixel_mask)
+
+    expected = torch.zeros(4, 4, dtype=torch.bool, device=device)
+    expected[0, 0] = True
+    expected[1, 1] = True
+    assert torch.equal(model.invalid_token_mask, expected)
+
+    # Wrong resolution is rejected.
+    with pytest.raises(ValueError):
+        model.set_nan_pixel_mask(torch.zeros(8, 8, dtype=torch.bool, device=device))
+
+    # Calling on a model built without the feature is an error.
+    plain = DiT(
+        input_size=(16, 16),
+        patch_size=4,
+        in_channels=3,
+        hidden_size=64,
+        depth=2,
+        num_heads=4,
+        attention_backend="natten2d",
+        attn_kwargs={"attn_kernel": 3},
+    ).to(device)
+    assert not hasattr(plain, "invalid_token_mask")
+    with pytest.raises(RuntimeError):
+        plain.set_nan_pixel_mask(pixel_mask)
+
+
 class CustomTokenizer(TokenizerModuleBase):
     """Simple N C H W -> N L D mapping."""
 

--- a/test/nn/module/test_dit_layers.py
+++ b/test/nn/module/test_dit_layers.py
@@ -17,7 +17,13 @@
 import pytest
 import torch
 
-from physicsnemo.nn.module.dit_layers import DiTBlock
+from physicsnemo.nn.module.dit_layers import (
+    ConvDetokenizer,
+    DiTBlock,
+    Natten2DSelfAttention,
+    ProjReshape2DDetokenizer,
+)
+from physicsnemo.nn.module.rope import build_axial_rope_cos_sin, rotate_half_pairs
 from test import common
 from test.conftest import requires_module
 
@@ -91,6 +97,59 @@ def test_ditblock_forward_accuracy_natten(device, pytestconfig):
         y,
         file_name="nn/module/data/ditblock_natten_output.pth",
     )
+
+
+@torch.no_grad()
+@requires_module(["natten"])
+def test_ditblock_natten_rope_and_mask_token_forward(device, pytestconfig):
+    """natten2d_rope runs through DiTBlock; the mask token alters only the
+    masked tokens' contribution and is a no-op when no tokens are invalid."""
+    if device == "cpu":
+        pytest.skip("natten not available on CPU")
+
+    torch.manual_seed(0)
+    hidden_size, num_heads = 64, 4
+    B, H, W = 2, 8, 8
+    T = H * W
+
+    block = (
+        DiTBlock(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            attention_backend="natten2d_rope",
+            layernorm_backend="torch",
+            attn_kernel=3,
+            latent_hw=(H, W),
+            use_mask_token=True,
+        )
+        .to(device)
+        .eval()
+    )
+    # Confirm the RoPE backend was selected and exposes its precomputed tables.
+    assert hasattr(block.attention, "rope_cos")
+    assert block.attention.rope_cos.shape == (H, W, hidden_size // num_heads)
+
+    x = torch.randn(B, T, hidden_size, device=device)
+    c = torch.randn(B, hidden_size, device=device)
+
+    # An all-valid mask must match passing no mask at all (mask token init zero
+    # would also match, but we trained none here; pass explicit zeros).
+    all_valid = torch.zeros(T, dtype=torch.bool, device=device)
+    y_none = block(x, c, attn_kwargs={"latent_hw": (H, W)})
+    y_valid = block(
+        x, c, attn_kwargs={"latent_hw": (H, W), "invalid_token_mask": all_valid}
+    )
+    assert y_none.shape == (B, T, hidden_size)
+    assert torch.allclose(y_none, y_valid, atol=1e-5)
+
+    # Marking tokens invalid (with a non-zero mask token) must change the output.
+    torch.nn.init.normal_(block.attention.mask_token)
+    invalid = all_valid.clone()
+    invalid[[0, 9, 33]] = True
+    y_masked = block(
+        x, c, attn_kwargs={"latent_hw": (H, W), "invalid_token_mask": invalid}
+    )
+    assert not torch.allclose(y_none, y_masked, atol=1e-5)
 
 
 @torch.no_grad()
@@ -203,3 +262,129 @@ def test_ditblock_intermediate_dropout_scalar_and_per_sample(device):
     # Per-sample dropout requires p shaped [B]
     p = torch.tensor([0.1] * B, device=device)
     _ = block(x, c, p_dropout=p)  # should run
+
+
+# --- RoPE helper / mask-token tests (CPU-friendly: no NATTEN kernel needed) ---
+
+
+@torch.no_grad()
+def test_build_axial_rope_cos_sin_shape_and_validation():
+    h, w, head_dim = 5, 7, 16
+    cos, sin = build_axial_rope_cos_sin(h, w, head_dim, theta=10000.0)
+    assert cos.shape == (h, w, head_dim)
+    assert sin.shape == (h, w, head_dim)
+    assert cos.dtype == torch.float32 and sin.dtype == torch.float32
+    # Adjacent channels (2i, 2i+1) share a frequency, so their cos/sin match.
+    assert torch.allclose(cos[..., 0::2], cos[..., 1::2])
+    assert torch.allclose(sin[..., 0::2], sin[..., 1::2])
+    # head_dim must be divisible by 4.
+    with pytest.raises(ValueError):
+        build_axial_rope_cos_sin(h, w, head_dim=6)
+
+
+@torch.no_grad()
+def test_rope_rotation_matches_complex_rotation_and_preserves_norm():
+    """The rotate-half formulation must equal the canonical per-pair 2D rotation
+    (real-valued rotation matrix / complex multiply) and preserve pair norms."""
+    torch.manual_seed(0)
+    h, w, head_dim = 4, 6, 16
+    cos, sin = build_axial_rope_cos_sin(h, w, head_dim, theta=10000.0)
+    q = torch.randn(2, 3, h, w, head_dim)  # (B, heads, h, w, head_dim)
+
+    q_rot = q * cos + rotate_half_pairs(q) * sin
+
+    # Canonical rotation on each adjacent (even, odd) pair:
+    #   even' = even*cos - odd*sin ;  odd' = even*sin + odd*cos
+    cos_pair = cos[..., 0::2]
+    sin_pair = sin[..., 0::2]
+    q_even, q_odd = q[..., 0::2], q[..., 1::2]
+    expected_even = q_even * cos_pair - q_odd * sin_pair
+    expected_odd = q_even * sin_pair + q_odd * cos_pair
+
+    assert torch.allclose(q_rot[..., 0::2], expected_even, atol=1e-6)
+    assert torch.allclose(q_rot[..., 1::2], expected_odd, atol=1e-6)
+
+    # A rotation preserves the norm of each channel pair.
+    pair_norm_in = q_even.square() + q_odd.square()
+    pair_norm_out = q_rot[..., 0::2].square() + q_rot[..., 1::2].square()
+    assert torch.allclose(pair_norm_in, pair_norm_out, atol=1e-5)
+
+
+@torch.no_grad()
+def test_mask_token_arithmetic_matches_where():
+    """The mask-token splice (x*(1-alpha) + mask_token*alpha) must be identical
+    to torch.where for a boolean mask."""
+    torch.manual_seed(0)
+    hidden_size, num_heads = 32, 4
+    B, H, W = 2, 4, 4
+    N = H * W
+
+    attn = Natten2DSelfAttention(
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        attn_kernel=3,
+        use_mask_token=True,
+    )
+    # Give the mask token a non-trivial value so the splice is observable.
+    torch.nn.init.normal_(attn.mask_token)
+
+    x = torch.randn(B, N, hidden_size)
+    invalid = torch.zeros(N, dtype=torch.bool)
+    invalid[[1, 5, 12]] = True
+
+    spliced = attn._apply_mask_token(x, invalid)
+    expected = torch.where(invalid.view(1, -1, 1), attn.mask_token.to(x.dtype), x)
+    assert torch.equal(spliced, expected)
+
+    # When the module has no mask token, the input is returned unchanged.
+    attn_no_mask = Natten2DSelfAttention(hidden_size, num_heads, attn_kernel=3)
+    assert attn_no_mask.mask_token is None
+    assert torch.equal(attn_no_mask._apply_mask_token(x, invalid), x)
+
+
+# --- ConvDetokenizer tests ---
+
+
+@torch.no_grad()
+def test_conv_detokenizer_shape():
+    """Output shape matches ProjReshape2DDetokenizer."""
+    torch.manual_seed(0)
+    B, H, W, P = 2, 16, 16, 4
+    out_channels, hidden_size = 3, 64
+    input_size = (H, W)
+    patch_size = (P, P)
+    L = (H // P) * (W // P)
+
+    x_tokens = torch.randn(B, L, hidden_size)
+    c = torch.randn(B, hidden_size)
+
+    ref = ProjReshape2DDetokenizer(input_size, patch_size, out_channels, hidden_size)
+    ref.initialize_weights()
+    det = ConvDetokenizer(input_size, patch_size, out_channels, hidden_size)
+    det.initialize_weights()
+
+    assert det(x_tokens, c).shape == ref(x_tokens, c).shape == (B, out_channels, H, W)
+
+
+@torch.no_grad()
+def test_conv_detokenizer_zero_init_identity():
+    """At init the conv residual is zero, so ConvDetokenizer == ProjReshape2DDetokenizer."""
+    torch.manual_seed(0)
+    B, H, W, P = 2, 16, 16, 4
+    out_channels, hidden_size = 3, 64
+    input_size = (H, W)
+    patch_size = (P, P)
+    L = (H // P) * (W // P)
+
+    x_tokens = torch.randn(B, L, hidden_size)
+    c = torch.randn(B, hidden_size)
+
+    ref = ProjReshape2DDetokenizer(input_size, patch_size, out_channels, hidden_size)
+    ref.initialize_weights()
+
+    det = ConvDetokenizer(input_size, patch_size, out_channels, hidden_size)
+    det.initialize_weights()
+    # Copy inner proj weights so the two modules are identical pre-smoothing.
+    det.proj.load_state_dict(ref.state_dict())
+
+    assert torch.allclose(det(x_tokens, c), ref(x_tokens, c))

--- a/test/nn/module/test_rope.py
+++ b/test/nn/module/test_rope.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from physicsnemo.nn.module.rope import (
+    RotaryPositionEmbedding1D,
+    RotaryPositionEmbedding2D,
+    apply_rotary_pos_emb,
+    build_axial_rope_cos_sin,
+    build_rope_cos_sin_1d,
+    rotate_half_pairs,
+)
+
+
+@torch.no_grad()
+def test_rotary_module_shapes_and_validation():
+    head_dim, h, w = 16, 4, 5
+    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(h, w))
+    # Tables are flattened to (h*w, head_dim) so they broadcast over (..., N, D).
+    assert rope.cos.shape == (h * w, head_dim)
+    assert rope.sin.shape == (h * w, head_dim)
+    assert "cos" not in rope.state_dict()  # persistent=False
+
+    q = torch.randn(2, 8, h * w, head_dim)
+    k = torch.randn(2, 8, h * w, head_dim)
+    q_rot, k_rot = rope(q, k)
+    assert q_rot.shape == q.shape and k_rot.shape == k.shape
+
+    # head_dim must be divisible by 4.
+    with pytest.raises(ValueError):
+        RotaryPositionEmbedding2D(head_dim=6, latent_hw=(h, w))
+
+    # Wrong sequence length is rejected.
+    with pytest.raises(ValueError):
+        rope(torch.randn(2, 8, h * w + 1, head_dim), k)
+
+
+@torch.no_grad()
+def test_rotary_module_matches_flattened_tables():
+    """The module result must equal applying the flattened cos/sin directly."""
+    torch.manual_seed(0)
+    head_dim, h, w = 32, 6, 4
+    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(h, w))
+    q = torch.randn(3, 4, h * w, head_dim)
+
+    cos, sin = build_axial_rope_cos_sin(h, w, head_dim)
+    cos_flat = cos.reshape(-1, head_dim)
+    sin_flat = sin.reshape(-1, head_dim)
+    expected = apply_rotary_pos_emb(q, cos_flat, sin_flat)
+
+    q_rot, _ = rope(q, q)
+    assert torch.equal(q_rot, expected)
+
+
+@torch.no_grad()
+def test_rotary_module_layout_matches_spatial_rotation():
+    """Rotating a flattened (B, H, N, D) tensor with the module must match
+    rotating the spatial (B, H, h, w, D) tensor with the raw tables and then
+    flattening — i.e. the module's row-major (h, then w) assumption holds."""
+    torch.manual_seed(0)
+    head_dim, h, w = 16, 3, 5
+    B, heads = 2, 4
+
+    cos, sin = build_axial_rope_cos_sin(h, w, head_dim)  # (h, w, head_dim)
+    q_spatial = torch.randn(B, heads, h, w, head_dim)
+    spatial_rot = apply_rotary_pos_emb(
+        q_spatial, cos.unsqueeze(0).unsqueeze(0), sin.unsqueeze(0).unsqueeze(0)
+    )
+    spatial_rot_flat = spatial_rot.reshape(B, heads, h * w, head_dim)
+
+    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(h, w))
+    q_flat = q_spatial.reshape(B, heads, h * w, head_dim)
+    module_rot, _ = rope(q_flat, q_flat)
+
+    assert torch.allclose(module_rot, spatial_rot_flat, atol=1e-6)
+
+
+@torch.no_grad()
+def test_rotary_module_rebuild_for_new_shape():
+    head_dim = 16
+    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(4, 4))
+    q = torch.randn(1, 2, 5 * 6, head_dim)
+    # Passing a new latent_hw rebuilds the tables in place.
+    q_rot, _ = rope(q, q, latent_hw=(5, 6))
+    assert rope.cos.shape == (5 * 6, head_dim)
+    assert q_rot.shape == q.shape
+
+
+@torch.no_grad()
+def test_apply_rotary_pos_emb_preserves_dtype_and_norm():
+    torch.manual_seed(0)
+    head_dim, n = 16, 12
+    cos, sin = build_axial_rope_cos_sin(3, 4, head_dim)
+    cos_flat, sin_flat = cos.reshape(-1, head_dim), sin.reshape(-1, head_dim)
+
+    x = torch.randn(2, n, head_dim, dtype=torch.float32)
+    x_rot = apply_rotary_pos_emb(x, cos_flat, sin_flat)
+    assert x_rot.dtype == x.dtype
+
+    # Rotation preserves each channel pair's norm.
+    pair_in = x[..., 0::2].square() + x[..., 1::2].square()
+    pair_out = x_rot[..., 0::2].square() + x_rot[..., 1::2].square()
+    assert torch.allclose(pair_in, pair_out, atol=1e-5)
+
+    # Sanity: rotate_half_pairs applied twice negates (rotation by 90 deg twice).
+    assert torch.allclose(rotate_half_pairs(rotate_half_pairs(x)), -x, atol=1e-6)
+
+
+# --- 1D RoPE ---
+
+
+@torch.no_grad()
+def test_build_rope_cos_sin_1d_shape_and_validation():
+    seq_len, head_dim = 10, 16
+    cos, sin = build_rope_cos_sin_1d(seq_len, head_dim, theta=10000.0)
+    assert cos.shape == (seq_len, head_dim)
+    assert sin.shape == (seq_len, head_dim)
+    assert cos.dtype == torch.float32 and sin.dtype == torch.float32
+    # Adjacent channels (2k, 2k+1) share a frequency.
+    assert torch.allclose(cos[..., 0::2], cos[..., 1::2])
+    assert torch.allclose(sin[..., 0::2], sin[..., 1::2])
+    # Position 0 has zero angle: cos == 1, sin == 0.
+    assert torch.allclose(cos[0], torch.ones(head_dim))
+    assert torch.allclose(sin[0], torch.zeros(head_dim))
+    # head_dim must be even.
+    with pytest.raises(ValueError):
+        build_rope_cos_sin_1d(seq_len, head_dim=15)
+
+
+@torch.no_grad()
+def test_rotary_1d_module_shapes_and_validation():
+    head_dim, max_seq_len = 16, 32
+    rope = RotaryPositionEmbedding1D(head_dim=head_dim, max_seq_len=max_seq_len)
+    assert rope.cos.shape == (max_seq_len, head_dim)
+    assert "cos" not in rope.state_dict()  # persistent=False
+
+    q = torch.randn(2, 4, 20, head_dim)
+    k = torch.randn(2, 4, 20, head_dim)
+    q_rot, k_rot = rope(q, k)
+    assert q_rot.shape == q.shape and k_rot.shape == k.shape
+
+    with pytest.raises(ValueError):
+        RotaryPositionEmbedding1D(head_dim=15, max_seq_len=max_seq_len)
+    # Exceeding max_seq_len is rejected.
+    with pytest.raises(ValueError):
+        rope(torch.randn(2, 4, max_seq_len + 1, head_dim), k)
+    # Mismatched q/k lengths are rejected.
+    with pytest.raises(ValueError):
+        rope(torch.randn(2, 4, 20, head_dim), torch.randn(2, 4, 19, head_dim))
+
+
+@torch.no_grad()
+def test_rotary_1d_module_matches_sliced_tables():
+    """Shorter inputs use the leading positions of the precomputed tables."""
+    torch.manual_seed(0)
+    head_dim, max_seq_len = 32, 64
+    rope = RotaryPositionEmbedding1D(head_dim=head_dim, max_seq_len=max_seq_len)
+
+    seq_len = 40
+    q = torch.randn(3, 4, seq_len, head_dim)
+    cos, sin = build_rope_cos_sin_1d(max_seq_len, head_dim)
+    expected = apply_rotary_pos_emb(q, cos[:seq_len], sin[:seq_len])
+
+    q_rot, _ = rope(q, q)
+    assert torch.equal(q_rot, expected)
+
+
+@torch.no_grad()
+def test_rotary_1d_relative_phase_is_translation_invariant():
+    """RoPE encodes position as a relative rotation: the q.k inner product
+    between positions i and j depends only on (i - j)."""
+    torch.manual_seed(0)
+    head_dim, max_seq_len = 16, 64
+    rope = RotaryPositionEmbedding1D(head_dim=head_dim, max_seq_len=max_seq_len)
+
+    # Same content at every position; rotate, then compare inner products of
+    # pairs sharing the same offset.
+    base = torch.randn(1, 1, 1, head_dim)
+    seq = base.expand(1, 1, max_seq_len, head_dim).contiguous()
+    q_rot, k_rot = rope(seq, seq)
+
+    def dot(i, j):
+        return (q_rot[0, 0, i] * k_rot[0, 0, j]).sum()
+
+    # Offset of 3 gives the same score regardless of absolute position.
+    assert torch.allclose(dot(5, 2), dot(20, 17), atol=1e-4)
+    assert torch.allclose(dot(10, 4), dot(30, 24), atol=1e-4)

--- a/test/nn/module/test_rope.py
+++ b/test/nn/module/test_rope.py
@@ -14,16 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import pytest
 import torch
 
 from physicsnemo.nn.module.rope import (
     RotaryPositionEmbedding1D,
     RotaryPositionEmbedding2D,
+    StereographicRotaryPositionEmbedding2D,
     apply_rotary_pos_emb,
     build_axial_rope_cos_sin,
+    build_axial_rope_cos_sin_continuous,
     build_rope_cos_sin_1d,
+    build_rope_cos_sin_1d_continuous,
     rotate_half_pairs,
+    spherical_centroid,
+    stereographic_projection,
 )
 
 
@@ -200,3 +207,273 @@ def test_rotary_1d_relative_phase_is_translation_invariant():
     # Offset of 3 gives the same score regardless of absolute position.
     assert torch.allclose(dot(5, 2), dot(20, 17), atol=1e-4)
     assert torch.allclose(dot(10, 4), dot(30, 24), atol=1e-4)
+
+
+# --- Stereographic 2D RoPE ---
+
+
+@torch.no_grad()
+def test_build_rope_cos_sin_1d_continuous_matches_1d():
+    """Integer positions reproduce build_rope_cos_sin_1d (its continuous twin)."""
+    seq_len, head_dim = 10, 16
+    pos = torch.arange(seq_len).float()
+    cos_c, sin_c = build_rope_cos_sin_1d_continuous(pos, head_dim)
+    cos_i, sin_i = build_rope_cos_sin_1d(seq_len, head_dim)
+    assert cos_c.shape == (seq_len, head_dim)
+    assert torch.allclose(cos_c, cos_i, atol=1e-6)
+    assert torch.allclose(sin_c, sin_i, atol=1e-6)
+    # dim must be even.
+    with pytest.raises(ValueError):
+        build_rope_cos_sin_1d_continuous(pos, dim=15)
+
+
+@torch.no_grad()
+def test_build_axial_rope_cos_sin_continuous_matches_axial():
+    """Integer row/col coordinates reproduce build_axial_rope_cos_sin (flattened)."""
+    h, w, head_dim = 3, 5, 16
+    rows = torch.arange(h).reshape(h, 1).expand(h, w).reshape(-1).float()
+    cols = torch.arange(w).reshape(1, w).expand(h, w).reshape(-1).float()
+    cos2, sin2 = build_axial_rope_cos_sin_continuous(rows, cols, head_dim)
+    cos_ax, sin_ax = build_axial_rope_cos_sin(h, w, head_dim)
+    assert cos2.shape == (h * w, head_dim)
+    assert torch.allclose(cos2, cos_ax.reshape(h * w, head_dim), atol=1e-6)
+    assert torch.allclose(sin2, sin_ax.reshape(h * w, head_dim), atol=1e-6)
+    # head_dim must be divisible by 4.
+    with pytest.raises(ValueError):
+        build_axial_rope_cos_sin_continuous(rows, cols, head_dim=6)
+
+
+@torch.no_grad()
+def test_stereographic_projection_geometry():
+    """Center maps to the origin; East gives x > 0, North gives y > 0."""
+    zero = torch.zeros(1, 1, 1)
+    x, y = stereographic_projection(
+        torch.zeros(1, 3, 3), torch.zeros(1, 3, 3), zero, zero
+    )
+    assert torch.allclose(x, torch.zeros_like(x), atol=1e-6)
+    assert torch.allclose(y, torch.zeros_like(y), atol=1e-6)
+    x_east, _ = stereographic_projection(zero, torch.full((1, 1, 1), 0.2), zero, zero)
+    assert float(x_east) > 0.0
+    _, y_north = stereographic_projection(torch.full((1, 1, 1), 0.2), zero, zero, zero)
+    assert float(y_north) > 0.0
+
+
+@torch.no_grad()
+def test_stereographic_projection_matches_closed_form():
+    """Projection equals the analytic stereographic formula, pinning exact
+    numerics (the sign-only geometry test above would miss a wrong scale)."""
+    zero = torch.zeros(1, 1, 1)
+    d = 0.3
+    # The closed form along a single meridian / parallel from center (0, 0) is
+    # 2 * tan(delta / 2): East displacement -> x, North displacement -> y.
+    expected = 2.0 * math.tan(d / 2)
+    x, y = stereographic_projection(zero, torch.full((1, 1, 1), d), zero, zero)
+    assert torch.allclose(x, torch.full_like(x, expected), atol=1e-6)
+    assert torch.allclose(y, torch.zeros_like(y), atol=1e-6)
+    x2, y2 = stereographic_projection(torch.full((1, 1, 1), d), zero, zero, zero)
+    assert torch.allclose(x2, torch.zeros_like(x2), atol=1e-6)
+    assert torch.allclose(y2, torch.full_like(y2, expected), atol=1e-6)
+
+
+@torch.no_grad()
+def test_spherical_centroid_handles_pole_and_seam():
+    """The 3D vector centroid centers a ring around the North Pole at +pi/2 (where
+    a plain latitude mean undershoots), and a longitude ring straddling the
+    0 / 2*pi seam near 0 (not pi)."""
+    # Ring of points at 89 deg latitude spanning all longitudes -> center = pole.
+    lon_ring = torch.linspace(0.0, 2 * torch.pi, 8)[:-1]  # 7 evenly spaced, exclusive
+    lat_ring = torch.full_like(lon_ring, math.radians(89.0))
+    lat0, _ = spherical_centroid(lat_ring.reshape(1, 1, -1), lon_ring.reshape(1, 1, -1))
+    assert torch.allclose(lat0.reshape(()), torch.tensor(math.pi / 2), atol=1e-3)
+    # The plain mean of latitude would undershoot the pole.
+    assert float(lat_ring.mean()) < math.pi / 2 - 1e-3
+    # Longitude seam: points at +/-0.1 around 0 center near 0, not pi.
+    lat_eq = torch.zeros(1, 1, 2)
+    lon_seam = torch.tensor([[[0.1, 2 * torch.pi - 0.1]]])
+    _, lon0 = spherical_centroid(lat_eq, lon_seam)
+    wrapped = (lon0.reshape(()) + torch.pi) % (2 * torch.pi) - torch.pi  # to [-pi, pi)
+    assert abs(float(wrapped)) < 1e-5
+
+
+@torch.no_grad()
+def test_stereo_rope_module_shapes_and_validation():
+    rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    q = torch.randn(2, 4, 6, 16)
+    k = torch.randn(2, 4, 6, 16)
+    x_pos = torch.randn(6)
+    y_pos = torch.randn(6)
+    q_rot, k_rot = rope(q, k, x_pos, y_pos)
+    assert q_rot.shape == q.shape and k_rot.shape == k.shape
+    # Rotation preserves the per-token norm.
+    assert torch.allclose(q_rot.norm(dim=-1), q.norm(dim=-1), atol=1e-4)
+    # head_dim must be divisible by 4.
+    with pytest.raises(ValueError):
+        StereographicRotaryPositionEmbedding2D(head_dim=6)
+
+
+@torch.no_grad()
+def test_stereo_rope_relative_position_invariance():
+    """RoPE encodes relative position: shifting all coordinates by a constant
+    leaves the query-key score matrix unchanged."""
+    torch.manual_seed(0)
+    rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    q = torch.randn(1, 2, 6, 16)
+    k = torch.randn(1, 2, 6, 16)
+    x_pos = torch.randn(6)
+    y_pos = torch.randn(6)
+
+    q1, k1 = rope(q, k, x_pos, y_pos)
+    scores1 = q1 @ k1.transpose(-1, -2)
+    q2, k2 = rope(q, k, x_pos + 0.7, y_pos - 1.3)
+    scores2 = q2 @ k2.transpose(-1, -2)
+    assert torch.allclose(scores1, scores2, atol=1e-4)
+
+
+@torch.no_grad()
+def test_stereo_rope_forward_batched_coords():
+    """Per-sample (B, N) coordinates broadcast over heads automatically."""
+    torch.manual_seed(0)
+    rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    B, heads, n = 2, 4, 6
+    q = torch.randn(B, heads, n, 16)
+    k = torch.randn(B, heads, n, 16)
+    x_pos = torch.randn(B, n)  # distinct coords per batch sample
+    y_pos = torch.randn(B, n)
+    q_rot, k_rot = rope(q, k, x_pos, y_pos)
+    assert q_rot.shape == q.shape and k_rot.shape == k.shape
+    # Equivalent to manually inserting the heads axis into the tables.
+    cos, sin = rope.build_tables(x_pos, y_pos)
+    expected = apply_rotary_pos_emb(q, cos.unsqueeze(-3), sin.unsqueeze(-3))
+    assert torch.allclose(q_rot, expected, atol=1e-6)
+
+
+@torch.no_grad()
+def test_stereo_rope_end_to_end_latlon_pipeline():
+    """The intended usage path: project a lat/lon tile to coordinates, flatten to
+    the token axis, then rotate (B, heads, N, head_dim) q/k."""
+    torch.manual_seed(0)
+    rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    b, heads, h, w = 2, 4, 3, 3
+    n = h * w
+    lat = torch.linspace(-0.2, 0.2, h).reshape(1, h, 1).expand(b, h, w)
+    lon = torch.linspace(1.0, 1.4, w).reshape(1, 1, w).expand(b, h, w)
+    x_pos, y_pos = rope.project(lat, lon, length_scale=0.1)
+    x_pos = x_pos.reshape(b, n)  # flatten spatial dims to the token axis
+    y_pos = y_pos.reshape(b, n)
+    q = torch.randn(b, heads, n, 16)
+    k = torch.randn(b, heads, n, 16)
+    q_rot, k_rot = rope(q, k, x_pos, y_pos)
+    assert q_rot.shape == q.shape and k_rot.shape == k.shape
+    # Per-token norm is preserved through the full project -> forward pipeline.
+    assert torch.allclose(q_rot.norm(dim=-1), q.norm(dim=-1), atol=1e-4)
+
+
+@torch.no_grad()
+def test_stereographic_projection_finite_near_antipode():
+    """The antipodal singularity is guarded: outputs stay finite, not inf/nan."""
+    zero = torch.zeros(1, 1, 1)
+    # A point at the antipode of the center (dlon = pi, same latitude) has
+    # cos_c = -1, the projection's singular point.
+    lat = torch.zeros(1, 1, 1)
+    lon = torch.full((1, 1, 1), float(torch.pi))
+    x, y = stereographic_projection(lat, lon, zero, zero)
+    assert torch.isfinite(x).all() and torch.isfinite(y).all()
+
+
+@torch.no_grad()
+def test_stereo_rope_project_length_scale():
+    rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    lat = torch.linspace(-0.3, 0.3, 4).reshape(1, 4, 1).expand(1, 4, 4)
+    lon = torch.linspace(0.0, 0.5, 4).reshape(1, 1, 4).expand(1, 4, 4)
+    # Happy path: positive length_scale gives finite coords; doubling it halves them.
+    x1, y1 = rope.project(lat, lon, length_scale=1.0)
+    x2, y2 = rope.project(lat, lon, length_scale=2.0)
+    assert x1.shape == lat.shape and torch.isfinite(x1).all()
+    assert torch.allclose(x2, x1 / 2, atol=1e-6) and torch.allclose(
+        y2, y1 / 2, atol=1e-6
+    )
+    # length_scale is required and must be positive.
+    with pytest.raises(ValueError):
+        rope.project(lat, lon, length_scale=0.0)
+    with pytest.raises(ValueError):
+        rope.project(lat, lon, length_scale=-1.0)
+
+
+@torch.no_grad()
+def test_stereo_rope_project_centering_and_override():
+    """Default centering uses the spherical centroid (3D vector mean); an explicit
+    center overrides it and matches the bare projection."""
+    rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    lat = torch.linspace(0.3, 0.7, 4).reshape(1, 4, 1).expand(1, 4, 4)
+    lon = torch.linspace(1.0, 1.4, 4).reshape(1, 1, 4).expand(1, 4, 4)
+
+    # Default center == spherical_centroid(lat, lon), not per-axis means.
+    xd, yd = rope.project(lat, lon, length_scale=1.0)
+    lat0_ref, lon0_ref = spherical_centroid(lat, lon, reduce_dims=(-2, -1))
+    bx, by = stereographic_projection(lat, lon, lat0_ref, lon0_ref)
+    assert torch.allclose(xd, bx, atol=1e-6) and torch.allclose(yd, by, atol=1e-6)
+
+    # Longitude centering is circular: a field straddling the 0/2*pi seam stays
+    # near the origin. Plain-mean centering would place the center ~pi away and
+    # blow the coordinates up toward the antipode.
+    lon_seam = (
+        torch.tensor([0.05, 2 * torch.pi - 0.05]).reshape(1, 1, 2).expand(1, 2, 2)
+    )
+    lat_seam = torch.zeros(1, 2, 2)
+    xs, ys = rope.project(lat_seam, lon_seam, length_scale=1.0)
+    assert xs.abs().max() < 0.2 and ys.abs().max() < 0.2
+
+    # Explicit center overrides the default and equals the bare projection / scale.
+    lat0 = torch.full((1, 1, 1), 0.4)
+    lon0 = torch.full((1, 1, 1), 1.0)
+    xe, ye = rope.project(lat, lon, length_scale=2.0, lat0=lat0, lon0=lon0)
+    ox, oy = stereographic_projection(lat, lon, lat0, lon0)
+    assert torch.allclose(xe, ox / 2, atol=1e-6) and torch.allclose(
+        ye, oy / 2, atol=1e-6
+    )
+
+
+@torch.no_grad()
+def test_stereo_rope_forward_matches_manual_tables():
+    """Shared (N,) coords: forward exactly equals applying build_tables directly
+    (the non-batched broadcast branch, mirroring the axial module's table test)."""
+    torch.manual_seed(0)
+    rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    q = torch.randn(2, 4, 6, 16)
+    k = torch.randn(2, 4, 6, 16)
+    x_pos = torch.randn(6)
+    y_pos = torch.randn(6)
+    cos, sin = rope.build_tables(x_pos, y_pos)
+    expected_q = apply_rotary_pos_emb(q, cos, sin)
+    expected_k = apply_rotary_pos_emb(k, cos, sin)
+    q_rot, k_rot = rope(q, k, x_pos, y_pos)
+    assert torch.equal(q_rot, expected_q) and torch.equal(k_rot, expected_k)
+
+
+@torch.no_grad()
+def test_stereo_rope_forward_preserves_low_precision_dtype():
+    """bf16 q/k come back as bf16 (the rotation runs in fp32 internally)."""
+    torch.manual_seed(0)
+    rope = StereographicRotaryPositionEmbedding2D(head_dim=16)
+    q = torch.randn(2, 4, 6, 16, dtype=torch.bfloat16)
+    k = torch.randn(2, 4, 6, 16, dtype=torch.bfloat16)
+    x_pos = torch.randn(6)
+    y_pos = torch.randn(6)
+    q_rot, k_rot = rope(q, k, x_pos, y_pos)
+    assert q_rot.dtype == torch.bfloat16 and k_rot.dtype == torch.bfloat16
+    assert torch.isfinite(q_rot.float()).all() and torch.isfinite(k_rot.float()).all()
+
+
+@torch.no_grad()
+def test_stereo_rope_theta_changes_tables():
+    """The theta base is wired through: a different theta gives different tables."""
+    x_pos = torch.randn(6)
+    y_pos = torch.randn(6)
+    cos_a, sin_a = StereographicRotaryPositionEmbedding2D(
+        head_dim=16, theta=10000.0
+    ).build_tables(x_pos, y_pos)
+    cos_b, sin_b = StereographicRotaryPositionEmbedding2D(
+        head_dim=16, theta=100.0
+    ).build_tables(x_pos, y_pos)
+    assert not torch.allclose(cos_a, cos_b)
+    assert not torch.allclose(sin_a, sin_b)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Adds a **stereographic 2D rotary position embedding** to
`physicsnemo/nn/module/rope.py` — the continuous-coordinate sibling of the
`RotaryPositionEmbedding2D` introduced in #1731. Token latitude/longitude are
mapped to a local tangent plane via a stereographic projection, and the
resulting continuous `(x, y)` coordinates drive a 2D RoPE that **reuses #1731's
`apply_rotary_pos_emb` / `rotate_half_pairs` verbatim** (the per-pair rotation
math is identical — no new rotation code).

> **Stacked on #1731** (`pzharrington/physicsnemo:dit-enhancements`). Base is
> `NVIDIA/physicsnemo:main`; **please merge after #1731**. Until #1731 merges, the
> diff against `main` includes #1731's commits — review only the single
> StereographicRotaryPositionEmbedding2D commit on top (`5227b0ca`). I'll rebase
> onto `main` once #1731 lands.

### New public API

In `physicsnemo.nn.module.rope` (re-exported from `physicsnemo.nn`):

- `StereographicRotaryPositionEmbedding2D` — module: `project(lat, lon, length_scale, …)`
  maps lat/lon to continuous tangent-plane coordinates; `build_tables(...)` /
  `forward(q, k, x_pos, y_pos)` rotate the query/key tensors.
- `build_axial_rope_cos_sin_continuous(x_pos, y_pos, head_dim, theta)` — the
  continuous-coordinate generalization of `build_axial_rope_cos_sin` (the integer
  grid is its special case — asserted by a test). Built on a reusable
  `build_rope_cos_sin_1d_continuous` core (the continuous twin of
  `build_rope_cos_sin_1d`), applied once per axis.
- `stereographic_projection`, and `spherical_centroid` — a pole- and
  seam-robust tile center (3D unit-vector mean) used for `project`'s default centering.

### Why

Transformers over 3D / spherical fields (e.g. weather emulation) need a RoPE that
respects spherical geometry, not just integer row/column indices. This extends
the RoPE primitives #1731 introduces with a continuous-coordinate variant that
composes with the existing machinery (same rotation convention and channel layout).

### Reuse / consistency

- Reuses `apply_rotary_pos_emb` + `rotate_half_pairs` — no new rotation code.
- `build_axial_rope_cos_sin_continuous` uses the same frequency schedule and
  `(…, head_dim)` repeat-interleaved layout as `build_axial_rope_cos_sin`; a test
  asserts the two are identical on integer coordinates.

### Placement (MOD-002a)

`StereographicRotaryPositionEmbedding2D` lives in **production**
`physicsnemo/nn/module/rope.py` (re-exported from `physicsnemo.nn`) rather than
`experimental`, under the MOD-002a maturity exception:

- It is a small, **parameter-free** position-embedding primitive — the
  continuous-coordinate sibling of #1731's `RotaryPositionEmbedding2D`, which
  #1731 itself places in production `rope.py`.
- It reuses #1731's rotation convention and channel layout verbatim, so it shares
  that exact API surface (no divergent conventions to stabilize).
- It is geometry-agnostic and broadly applicable (any transformer over
  spherical / lat-lon tokens), not specific to a single model or example.

Per MOD-000a it is a reusable layer, so it belongs in `physicsnemo/nn/module`
(not `physicsnemo/models`). It is a plain `torch.nn.Module` primitive, not a
`physicsnemo.Module` model, so the model-specific standards (MOD-001,
MOD-005–010, the model test triad) do not apply.

### Tests (`test/nn/module/test_rope.py`)

- `build_rope_cos_sin_1d_continuous` ≡ `build_rope_cos_sin_1d`, and
  `build_axial_rope_cos_sin_continuous` ≡ `build_axial_rope_cos_sin`, on integer coords.
- Stereographic projection geometry (center → origin, East/North signs) and the
  closed-form value `2·tan(Δ/2)` (pins exact numerics, not just signs); finite
  outputs at the antipodal singularity.
- `spherical_centroid` robustness: a ring around the North Pole centers at `+π/2`
  (where a plain latitude mean undershoots), and a longitude ring across the 0/2π seam centers near 0.
- `project` default centering equals `spherical_centroid`, explicit-center override,
  stays near the origin across the seam, and required positive `length_scale`.
- `StereographicRotaryPositionEmbedding2D` shapes, `head_dim % 4` validation, norm preservation.
- Relative-position (shift-invariance) of the attention scores; per-sample `(B, N)`
  coordinate broadcasting; full lat/lon → `project` → `forward` pipeline.
- Mirrors #1731's module tests on the stereographic module: forward exactly equals
  applying `build_tables` directly (shared-coords branch), bf16 dtype is preserved,
  and the `theta` base is wired through (different `theta` → different tables).

All pass (24 tests in `test_rope.py`, including #1731's 9) plus the rope doctests;
`ruff`, `interrogate` (100%), the license-header check, and `import-linter` (10/0) are clean.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
