### PR TITLE
Mesh: Fixes bug in `extrude()` that could cause nonmanifold geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or any multi-column grid, which also broke `repair.fix_orientation`). Parent-cell
   vertices are now sorted into a global order before tessellation (the
   Freudenthal-Kuhn subdivision), a no-op for already-sorted inputs.
+- `physicsnemo.mesh.projections.extrude` now returns consistently oriented cells
+  for full-dimensional (codimension-0) output.
 - `physicsnemo.mesh.remesh` now preserves the input mesh's device and floating
   dtype (the pyacvd/pyvista round-trip previously dropped them to CPU/float32).
 - `physicsnemo.mesh`: `Mesh.to(<float dtype>)` and `DomainMesh.to(<float dtype>)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `physicsnemo.mesh.projections.extrude` now produces a *conforming* (crack-free)
+  simplicial complex for multi-cell inputs. Each prism was previously tessellated
+  using the per-cell local vertex order, so adjacent cells that listed a shared
+  edge's endpoints in different orders split the shared quad face along opposite
+  diagonals; the resulting non-manifold volume leaked interior crack faces into
+  `get_boundary_mesh` (boundary edges shared by 4 faces — e.g. an extruded L-shape
+  or any multi-column grid, which also broke `repair.fix_orientation`). Parent-cell
+  vertices are now sorted into a global order before tessellation (the
+  Freudenthal-Kuhn subdivision), a no-op for already-sorted inputs.
 - `physicsnemo.mesh.remesh` now preserves the input mesh's device and floating
   dtype (the pyacvd/pyvista round-trip previously dropped them to CPU/float32).
 - `physicsnemo.mesh`: `Mesh.to(<float dtype>)` and `DomainMesh.to(<float dtype>)`

--- a/physicsnemo/mesh/projections/_extrude.py
+++ b/physicsnemo/mesh/projections/_extrude.py
@@ -255,7 +255,9 @@ def extrude(
         # that list a shared edge's endpoints in different local orders split the
         # shared quad face along opposite diagonals, producing a non-manifold
         # boundary (interior crack faces then leak into get_boundary_mesh).
-        parent_cells = torch.sort(mesh.cells, dim=1).values  # (n_cells, n_verts_per_parent)
+        parent_cells = torch.sort(
+            mesh.cells, dim=1
+        ).values  # (n_cells, n_verts_per_parent)
 
         # NOTE: This loop iterates over child indices (bounded by simplex
         # dimension, not mesh size), so the iteration count is small (e.g. 3

--- a/physicsnemo/mesh/projections/_extrude.py
+++ b/physicsnemo/mesh/projections/_extrude.py
@@ -138,10 +138,20 @@ def extrude(
 
     Sorting the vertices is the Freudenthal-Kuhn subdivision: prisms that share a
     face split it along the same diagonal, so the output is a *conforming*
-    simplicial complex (no cracks / non-manifold facets). The child cells are not
-    guaranteed to share a single orientation (signed-volume sign); apply
-    :func:`physicsnemo.mesh.repair.fix_orientation` or inspect the signed volume
-    if a consistent orientation is required.
+    simplicial complex (no cracks / non-manifold facets).
+
+    Orientation depends on the codimension of the output:
+
+        - Codimension 0 (``target_manifold_dims == target_spatial_dims``): the
+          raw Kuhn children alternate in orientation, so the last two vertices of
+          any inverted cell are swapped to give every cell a positive signed
+          volume. The result is a consistently oriented complex.
+        - A 2D surface in 3D (e.g. extruding a curve): orientation is not
+          enforced here; pass the result through
+          :func:`physicsnemo.mesh.repair.fix_orientation`, which handles exactly
+          this case.
+        - Any other positive codimension: signed volume is undefined, so no
+          orientation is enforced.
     """
     ### Validate inputs
     if capping:
@@ -158,7 +168,7 @@ def extrude(
             raise ValueError(
                 f"Cannot extrude {n_manifold_dims=}-dimensional manifold in {n_spatial_dims=}-dimensional space "
                 f"to {target_manifold_dims=}-dimensional manifold without increasing spatial dimensions.\n"
-                f"Set allow_new_spatial_dims=True to add new spatial dimensions, or provide a custom vector."
+                f"Set allow_new_spatial_dims=True to add new spatial dimensions."
             )
         # Extend spatial dimensions to accommodate extruded manifold
         target_spatial_dims = target_manifold_dims
@@ -289,6 +299,22 @@ def extrude(
             start_idx = child_idx * n_original_cells
             end_idx = (child_idx + 1) * n_original_cells
             extruded_cells[start_idx:end_idx] = child_cells
+
+    ### Orient codim-0 cells consistently (positive signed volume)
+    # Signed volume (an n-simplex determinant) is only defined when the output is
+    # full-dimensional (target_manifold_dims == target_spatial_dims). The
+    # Freudenthal-Kuhn children alternate in orientation, so ~half are inverted;
+    # swap the last two vertices of those (one transposition negates the
+    # determinant) so every cell has positive signed volume. Conformity, |volume|,
+    # and propagated data are unaffected (only per-cell vertex order changes);
+    # degenerate (zero-volume) cells are left untouched.
+    if extruded_cells.shape[0] > 0 and target_manifold_dims == target_spatial_dims:
+        cell_points = all_points[extruded_cells]  # (n_cells, D+1, D)
+        edge_vectors = cell_points[:, 1:] - cell_points[:, :1]  # (n_cells, D, D)
+        inverted = torch.det(edge_vectors) < 0  # (n_cells,)
+        swapped = extruded_cells[inverted, -2].clone()
+        extruded_cells[inverted, -2] = extruded_cells[inverted, -1]
+        extruded_cells[inverted, -1] = swapped
 
     ### Propagate data (excluding cached properties, which depend on geometry)
     filtered_point_data = mesh.point_data

--- a/physicsnemo/mesh/projections/_extrude.py
+++ b/physicsnemo/mesh/projections/_extrude.py
@@ -126,14 +126,22 @@ def extrude(
 
     Notes
     -----
-    The tessellation pattern for an N-simplex with vertices [v0, v1, ..., vN]
-    creates (N+1) child (N+1)-simplices:
+    Before tessellating, the vertices of each parent simplex are sorted into a
+    consistent global (ascending-index) order. With that ordering, the
+    tessellation pattern for an N-simplex with (sorted) vertices
+    [v0, v1, ..., vN] creates (N+1) child (N+1)-simplices:
 
         - Child i has vertices: [v0', v1', ..., vi', vi, vi+1, ..., vN]
+
     where primed vertices (v') are the extruded copies (offset by the extrusion
     vector).
 
-    This tessellation preserves orientation and creates a valid simplicial complex.
+    Sorting the vertices is the Freudenthal-Kuhn subdivision: prisms that share a
+    face split it along the same diagonal, so the output is a *conforming*
+    simplicial complex (no cracks / non-manifold facets). The child cells are not
+    guaranteed to share a single orientation (signed-volume sign); apply
+    :func:`physicsnemo.mesh.repair.fix_orientation` or inspect the signed volume
+    if a consistent orientation is required.
     """
     ### Validate inputs
     if capping:
@@ -237,8 +245,17 @@ def extrude(
         )
 
         # Vectorized tessellation
-        # For each parent cell, generate all children simultaneously
-        parent_cells = mesh.cells  # Shape: (n_cells, n_vertices_per_parent)
+        # For each parent cell, generate all children simultaneously.
+        #
+        # Freudenthal-Kuhn: sort each parent simplex's vertices into a consistent
+        # global (ascending-index) order before tessellating. A shared face is
+        # then seen with the same vertex order by both incident prisms, so they
+        # split it along the SAME diagonal and the result is a *conforming*
+        # (crack-free) simplicial complex. Without the sort, neighbouring cells
+        # that list a shared edge's endpoints in different local orders split the
+        # shared quad face along opposite diagonals, producing a non-manifold
+        # boundary (interior crack faces then leak into get_boundary_mesh).
+        parent_cells = torch.sort(mesh.cells, dim=1).values  # (n_cells, n_verts_per_parent)
 
         # NOTE: This loop iterates over child indices (bounded by simplex
         # dimension, not mesh size), so the iteration count is small (e.g. 3

--- a/test/mesh/projections/test_projections.py
+++ b/test/mesh/projections/test_projections.py
@@ -21,7 +21,85 @@ import torch
 from tensordict import TensorDict
 
 from physicsnemo.mesh import Mesh
+from physicsnemo.mesh.primitives.planar import l_shape
 from physicsnemo.mesh.projections import embed, extrude, project
+
+
+def _undirected_edges(faces: torch.Tensor) -> torch.Tensor:
+    """Return the canonical (sorted-endpoint) undirected edges of a triangle mesh.
+
+    Args:
+        faces: Triangle connectivity of shape ``(n_faces, 3)``.
+
+    Returns:
+        Edge endpoints of shape ``(3 * n_faces, 2)`` with each row sorted
+        ascending, so an edge has the same representation regardless of the
+        triangle winding it came from.
+    """
+    edges = torch.cat([faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [0, 2]]], dim=0)
+    return torch.sort(edges, dim=1).values
+
+
+def _surface_edge_multiplicities(surface: Mesh) -> torch.Tensor:
+    """Count how many triangles share each undirected edge of a surface mesh.
+
+    For a closed 2-manifold every edge is shared by exactly two triangles, so any
+    count of 1 (a crack / open boundary) or >= 3 (a non-manifold edge) signals a
+    malformed surface.
+
+    Args:
+        surface: A triangle surface mesh (``n_manifold_dims == 2``).
+
+    Returns:
+        Per-unique-edge incidence counts, shape ``(n_unique_edges,)``.
+    """
+    _, counts = torch.unique(
+        _undirected_edges(surface.cells), dim=0, return_counts=True
+    )
+    return counts
+
+
+def _euler_characteristic(surface: Mesh) -> int:
+    """Euler characteristic ``V - E + F`` of a triangle surface mesh.
+
+    A closed, orientable, genus-0 surface (a topological sphere) has ``chi == 2``;
+    cracked / non-manifold output from a buggy tessellation does not.
+
+    Args:
+        surface: A triangle surface mesh (``n_manifold_dims == 2``).
+
+    Returns:
+        The integer Euler characteristic.
+    """
+    faces = surface.cells
+    n_vertices = int(torch.unique(faces).numel())
+    n_edges = int(torch.unique(_undirected_edges(faces), dim=0).shape[0])
+    n_faces = int(faces.shape[0])
+    return n_vertices - n_edges + n_faces
+
+
+def _two_column_grid() -> Mesh:
+    """Build a 2x1 grid of quads (4 triangles) - the minimal extrude-crack repro.
+
+    Two horizontally adjacent quads share a vertical edge whose endpoints are
+    listed in different local orders by the two columns. That is exactly the
+    configuration that makes the prism tessellation pick mismatched diagonals on
+    the shared quad face, so it is the smallest mesh that exposes the bug.
+
+    Returns:
+        A 2D-in-2D triangle mesh with 6 points and 4 triangles.
+    """
+    n_rows = 2  # points per column (a single row of quads)
+    points = torch.tensor(
+        [[float(i), float(j)] for i in range(3) for j in range(n_rows)],
+        dtype=torch.float32,
+    )
+    cells = []
+    for col in range(2):
+        idx = col * n_rows
+        cells.append([idx, idx + 1, idx + n_rows])
+        cells.append([idx + 1, idx + n_rows + 1, idx + n_rows])
+    return Mesh(points=points, cells=torch.tensor(cells, dtype=torch.int64))
 
 
 class TestExtrude:
@@ -334,6 +412,44 @@ class TestExtrude:
         # Cells are ordered [child0_parent0, child0_parent1, child1_parent0, child1_parent1]
         expected_cell_ids = torch.tensor([10, 20, 10, 20])
         assert torch.equal(extruded.cell_data["cell_id"], expected_cell_ids)
+
+    @pytest.mark.parametrize(
+        "make_base",
+        [
+            pytest.param(lambda: l_shape.load(subdivisions=1), id="l_shape_sub1"),
+            pytest.param(lambda: l_shape.load(subdivisions=3), id="l_shape_sub3"),
+            pytest.param(_two_column_grid, id="grid_2col"),
+        ],
+    )
+    def test_extrude_produces_conforming_boundary(self, make_base):
+        """Extruding a valid 2D complex must yield a conforming (crack-free) solid.
+
+        Regression test for inconsistent prism-diagonal tessellation: adjacent
+        cells that list a shared edge's endpoints in different local orders used
+        to split the shared quad face along opposite diagonals, producing a
+        non-manifold boundary (interior crack faces leaking into
+        ``get_boundary_mesh``). A conforming solid has a closed 2-manifold
+        boundary - every edge shared by exactly two triangles, with Euler
+        characteristic 2 (a topological sphere).
+        """
+        base = make_base()  # 2D triangulation in 2D space (valid complex)
+
+        # Embed into 3D and extrude into a solid tetrahedral volume, then take
+        # the boundary surface that a downstream consumer (e.g. text_2d_3d) uses.
+        volume = extrude(embed(base, target_n_spatial_dims=3), vector=[0.0, 0.0, 1.0])
+        boundary = volume.get_boundary_mesh(data_source="cells")
+
+        ### The boundary must be edge-manifold: every edge in exactly 2 triangles.
+        edge_counts = _surface_edge_multiplicities(boundary)
+        nonmanifold = torch.unique(edge_counts[edge_counts != 2]).tolist()
+        assert nonmanifold == [], (
+            f"extruded boundary is not edge-manifold: found edges with incidence "
+            f"counts {nonmanifold} (every edge of a watertight surface must be "
+            f"shared by exactly 2 triangles)"
+        )
+
+        ### ... and topologically a sphere (no cracks/handles introduced).
+        assert _euler_characteristic(boundary) == 2
 
     def test_extrude_empty_mesh(self):
         """Test extrusion of empty mesh (no cells)."""

--- a/test/mesh/projections/test_projections.py
+++ b/test/mesh/projections/test_projections.py
@@ -655,9 +655,9 @@ class TestExtrude:
         signed_volumes = torch.det(edge_vectors)  # (n_cells,)
 
         ### Every cell must be positively oriented (no inverted simplices)
-        assert (
-            signed_volumes > 0
-        ).all(), f"Inconsistent orientation, signed volumes: {signed_volumes.tolist()}"
+        assert (signed_volumes > 0).all(), (
+            f"Inconsistent orientation, signed volumes: {signed_volumes.tolist()}"
+        )
 
     def test_extrude_with_zero_vector_raises_or_degenerates(self):
         """Test extrusion with zero vector creates degenerate cells."""

--- a/test/mesh/projections/test_projections.py
+++ b/test/mesh/projections/test_projections.py
@@ -171,10 +171,12 @@ class TestExtrude:
         assert torch.allclose(extruded.points, expected_points)
 
         ### Verify cells
-        # Edge [0, 1] becomes 2 triangles:
-        #   Child 0: [v0', v0, v1] = [2, 0, 1]
-        #   Child 1: [v0', v1', v1] = [2, 3, 1]
-        expected_cells = torch.tensor([[2, 0, 1], [2, 3, 1]], dtype=torch.int64)
+        # Edge [0, 1] becomes 2 triangles. The raw Kuhn child 1 [2, 3, 1] is
+        # negatively oriented, so extrude swaps its last two vertices -> [2, 1, 3]
+        # (both cells then have positive signed area):
+        #   Child 0: [v0', v0, v1]       = [2, 0, 1]
+        #   Child 1: [v0', v1', v1] flip = [2, 1, 3]
+        expected_cells = torch.tensor([[2, 0, 1], [2, 1, 3]], dtype=torch.int64)
         assert torch.equal(extruded.cells, expected_cells)
 
         ### Verify total area (should equal width * height)
@@ -241,12 +243,14 @@ class TestExtrude:
         assert torch.allclose(extruded.points, expected_points)
 
         ### Verify cells
-        # Triangle [0, 1, 2] becomes 3 tetrahedra:
-        #   Child 0: [v0', v0, v1, v2] = [3, 0, 1, 2]
-        #   Child 1: [v0', v1', v1, v2] = [3, 4, 1, 2]
-        #   Child 2: [v0', v1', v2', v2] = [3, 4, 5, 2]
+        # Triangle [0, 1, 2] becomes 3 tetrahedra. The raw Kuhn children 0 and 2
+        # are negatively oriented, so extrude swaps their last two vertices
+        # (child 1 is already positive) so all three have positive signed volume:
+        #   Child 0: [v0', v0, v1, v2]   flip = [3, 0, 2, 1]
+        #   Child 1: [v0', v1', v1, v2]       = [3, 4, 1, 2]
+        #   Child 2: [v0', v1', v2', v2] flip = [3, 4, 2, 5]
         expected_cells = torch.tensor(
-            [[3, 0, 1, 2], [3, 4, 1, 2], [3, 4, 5, 2]], dtype=torch.int64
+            [[3, 0, 2, 1], [3, 4, 1, 2], [3, 4, 2, 5]], dtype=torch.int64
         )
         assert torch.equal(extruded.cells, expected_cells)
 
@@ -604,25 +608,56 @@ class TestExtrude:
         ### Verify all cells have positive hypervolume
         assert (extruded.cell_areas > 0).all()
 
-    def test_extrude_orientation_consistency(self):
-        """Test that extrusion maintains consistent orientation."""
-        ### Create a simple triangle with known orientation
-        points = torch.tensor(
-            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=torch.float32
-        )
-        cells = torch.tensor([[0, 1, 2]], dtype=torch.int64)
-        mesh = Mesh(points=points, cells=cells)
+    @pytest.mark.parametrize(
+        "make_mesh, extrude_kwargs",
+        [
+            # 1D edges -> 2D triangles in 2D space (codimension 0).
+            (
+                lambda: Mesh(
+                    points=torch.tensor(
+                        [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]], dtype=torch.float32
+                    ),
+                    cells=torch.tensor([[0, 1], [1, 2]], dtype=torch.int64),
+                ),
+                {"vector": [0.0, 1.0]},
+            ),
+            # 2D triangles -> 3D tetrahedra, auto-extending 2D space to 3D
+            # (codimension 0).
+            (
+                lambda: Mesh(
+                    points=torch.tensor(
+                        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+                        dtype=torch.float32,
+                    ),
+                    cells=torch.tensor([[0, 1, 2], [0, 2, 3]], dtype=torch.int64),
+                ),
+                {"allow_new_spatial_dims": True},
+            ),
+        ],
+        ids=["1d_to_2d", "2d_to_3d"],
+    )
+    def test_extrude_orientation_consistency(self, make_mesh, extrude_kwargs):
+        """Codim-0 extrusion must yield cells with consistent (positive) orientation.
 
-        ### Compute original normal (should point in +z direction)
-        original_normal = mesh.cell_normals[0]
-        assert original_normal[2] > 0  # Points upward
+        The raw Freudenthal-Kuhn children of a prism alternate in orientation, so
+        a multi-cell base produces a genuine mix of signs before correction.
+        ``extrude`` must flip the inverted ones so every full-dimensional cell has
+        a positive signed volume.  (A ``cell_areas > 0`` check is insufficient:
+        ``cell_areas`` is unsigned and cannot detect inversion.)
+        """
+        mesh = make_mesh()
+        extruded = extrude(mesh, **extrude_kwargs)
 
-        ### Extrude upward
-        extruded = extrude(mesh, vector=[0.0, 0.0, 1.0])
+        ### Full-dimensional output -> signed volume is the simplex determinant
+        assert extruded.codimension == 0
+        cell_points = extruded.points[extruded.cells]  # (n_cells, D+1, D)
+        edge_vectors = cell_points[:, 1:] - cell_points[:, :1]  # (n_cells, D, D)
+        signed_volumes = torch.det(edge_vectors)  # (n_cells,)
 
-        ### All extruded tetrahedra should have positive volume
-        # (negative volume would indicate inverted orientation)
-        assert (extruded.cell_areas > 0).all()
+        ### Every cell must be positively oriented (no inverted simplices)
+        assert (
+            signed_volumes > 0
+        ).all(), f"Inconsistent orientation, signed volumes: {signed_volumes.tolist()}"
 
     def test_extrude_with_zero_vector_raises_or_degenerates(self):
         """Test extrusion with zero vector creates degenerate cells."""


### PR DESCRIPTION


<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This fixes a bug in `physicsnemo.mesh.projection.extrude()`, where extruding a **manifold** geometry (e.g., `Mesh[2, 3]` -> `Mesh[3, 3]`) could result in a **nonmanifold** output.

That was due to the fact that the older implementation used the local per-cell vertex order, and adjacent cells do not necessarily list a shared edge in the same order. This would cause the higher-dimensional extruded mesh to split the new shared quad face across opposite diagonals, producing a "cracked" tet mesh.

This can lead to lots of downstream issues, most notably: `get_boundary_mesh()` will wrongly classify these cracked faces as a boundary, and hence the extruded geometry gets treated as nonmanifold.

(This generalizes to facets in higher dims.)

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
