### PR TITLE
Add CSR segment_softmax functional

### DIFF
--- a/benchmarks/physicsnemo/nn/functional/registry.py
+++ b/benchmarks/physicsnemo/nn/functional/registry.py
@@ -47,6 +47,7 @@ from physicsnemo.nn.functional.regularization_parameterization import (
     DropPath,
     WeightFact,
 )
+from physicsnemo.nn.functional.segments import SegmentSoftmax
 
 # FunctionSpec classes listed here must implement ``make_inputs_forward`` for ASV.
 # ``make_inputs_backward`` is optional and only used when backward benchmarks run.
@@ -54,6 +55,8 @@ FUNCTIONAL_SPECS: tuple[type[FunctionSpec], ...] = (
     # Regularization / parameterization.
     DropPath,
     WeightFact,
+    # Segments / ragged tensors.
+    SegmentSoftmax,
     # Neighbor queries.
     KNN,
     RadiusSearch,

--- a/docs/api/nn/functionals/segments.rst
+++ b/docs/api/nn/functionals/segments.rst
@@ -1,0 +1,8 @@
+Segment Functionals
+===================
+
+Segment Softmax
+---------------
+
+.. autofunction:: physicsnemo.nn.functional.segment_softmax
+

--- a/docs/api/physicsnemo.nn.functionals.rst
+++ b/docs/api/physicsnemo.nn.functionals.rst
@@ -23,5 +23,6 @@ in the documentation for performance comparisons.
    nn/functionals/geometry
    nn/functionals/fourier_spectral
    nn/functionals/regularization_parameterization
+   nn/functionals/segments
    nn/functionals/interpolation
    nn/functionals/rendering

--- a/physicsnemo/nn/functional/__init__.py
+++ b/physicsnemo/nn/functional/__init__.py
@@ -54,6 +54,7 @@ from .rendering import (
     volume_render,
     wireframe_render,
 )
+from .segments import segment_softmax
 
 __all__ = [
     "irfft",
@@ -85,6 +86,7 @@ __all__ = [
     "rfft2",
     "point_cloud_render",
     "scalar_field_to_rgba",
+    "segment_softmax",
     "signed_distance_field",
     "smooth_log",
     "spectral_grid_gradient",

--- a/physicsnemo/nn/functional/segments/__init__.py
+++ b/physicsnemo/nn/functional/segments/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .segment_softmax import SegmentSoftmax, segment_softmax
+
+__all__ = ["SegmentSoftmax", "segment_softmax"]

--- a/physicsnemo/nn/functional/segments/segment_softmax/__init__.py
+++ b/physicsnemo/nn/functional/segments/segment_softmax/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .segment_softmax import SegmentSoftmax, segment_softmax
+
+__all__ = ["SegmentSoftmax", "segment_softmax"]

--- a/physicsnemo/nn/functional/segments/segment_softmax/_torch_impl.py
+++ b/physicsnemo/nn/functional/segments/segment_softmax/_torch_impl.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from .utils import flatten_logits, validate_inputs
+
+
+def _segment_ids_from_offsets(offsets: torch.Tensor) -> torch.Tensor:
+    counts = offsets[1:] - offsets[:-1]
+    segment_ids = torch.arange(
+        int(offsets.shape[0]) - 1,
+        device=offsets.device,
+        dtype=torch.int64,
+    )
+    return torch.repeat_interleave(segment_ids, counts)
+
+
+def segment_softmax(logits: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+    """Pure-PyTorch segmented softmax using ``torch.segment_reduce``."""
+    validate_inputs(logits, offsets)
+    if int(logits.shape[0]) == 0 or int(logits.numel()) == 0:
+        return logits.clone()
+
+    offsets = offsets.to(dtype=torch.int64).contiguous()
+    flat, original_shape = flatten_logits(logits)
+    segment_ids = _segment_ids_from_offsets(offsets)
+
+    max_per_segment = torch.segment_reduce(
+        flat,
+        "max",
+        offsets=offsets,
+        axis=0,
+    )
+    shifted = flat - max_per_segment.index_select(0, segment_ids)
+    exp_shifted = shifted.exp()
+    sum_per_segment = torch.segment_reduce(
+        exp_shifted,
+        "sum",
+        offsets=offsets,
+        axis=0,
+    )
+    out = exp_shifted / sum_per_segment.index_select(0, segment_ids)
+    return out.reshape(original_shape)

--- a/physicsnemo/nn/functional/segments/segment_softmax/_warp_impl.py
+++ b/physicsnemo/nn/functional/segments/segment_softmax/_warp_impl.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Warp-accelerated CSR segmented softmax."""
+
+import torch
+import warp as wp
+
+from physicsnemo.core.function_spec import FunctionSpec
+
+from .kernels import segment_softmax_backward_kernel, segment_softmax_forward_kernel
+from .utils import flatten_logits, validate_inputs
+
+wp.config.log_level = wp.LOG_WARNING
+wp.init()
+
+
+def _require_cuda(tensor: torch.Tensor) -> None:
+    if tensor.device.type != "cuda":
+        raise ValueError(
+            "The Warp segment_softmax backend requires CUDA tensors; "
+            "use implementation='torch' on CPU."
+        )
+
+
+@torch.library.custom_op("physicsnemo::segment_softmax_warp", mutates_args=())
+def segment_softmax(logits: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+    """Warp segmented softmax custom op.
+
+    The Warp kernels compute in float32 and the public result is cast back to
+    the input dtype. The operation is grouped by CSR ``offsets`` along axis 0.
+    """
+    validate_inputs(logits, offsets)
+    _require_cuda(logits)
+    if int(logits.shape[0]) == 0 or int(logits.numel()) == 0:
+        return logits.clone()
+
+    input_dtype = logits.dtype
+    logits_f = logits.to(torch.float32).contiguous()
+    offsets_i64 = offsets.to(dtype=torch.int64).contiguous()
+    flat, original_shape = flatten_logits(logits_f)
+    out = torch.empty_like(flat)
+    num_segments = int(offsets_i64.shape[0]) - 1
+    num_channels = int(flat.shape[1])
+
+    wp_device, wp_stream = FunctionSpec.warp_launch_context(flat)
+    with wp.ScopedStream(wp_stream):
+        wp.launch(
+            segment_softmax_forward_kernel,
+            dim=(num_segments, num_channels),
+            inputs=[
+                wp.from_torch(flat, return_ctype=True),
+                wp.from_torch(offsets_i64, return_ctype=True),
+                wp.from_torch(out, return_ctype=True),
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+
+    return out.reshape(original_shape).to(input_dtype)
+
+
+@segment_softmax.register_fake
+def _(
+    logits: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(logits)
+
+
+@torch.library.custom_op(
+    "physicsnemo::segment_softmax_warp_backward", mutates_args=()
+)
+def segment_softmax_backward(
+    grad_out: torch.Tensor,
+    softmax_out: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    """Backward custom op for Warp segmented softmax."""
+    validate_inputs(softmax_out, offsets)
+    if grad_out.shape != softmax_out.shape:
+        raise ValueError(
+            "grad_out and softmax_out must have the same shape, got "
+            f"{tuple(grad_out.shape)} and {tuple(softmax_out.shape)}"
+        )
+    if grad_out.device != softmax_out.device:
+        raise ValueError(
+            "grad_out and softmax_out must be on the same device, got "
+            f"{grad_out.device} and {softmax_out.device}"
+        )
+    _require_cuda(softmax_out)
+    if int(softmax_out.shape[0]) == 0 or int(softmax_out.numel()) == 0:
+        return grad_out.clone()
+
+    grad_dtype = grad_out.dtype
+    grad_f = grad_out.to(torch.float32).contiguous()
+    out_f = softmax_out.to(torch.float32).contiguous()
+    offsets_i64 = offsets.to(dtype=torch.int64).contiguous()
+    grad_flat, original_shape = flatten_logits(grad_f)
+    out_flat, _ = flatten_logits(out_f)
+    grad_logits = torch.empty_like(grad_flat)
+    num_segments = int(offsets_i64.shape[0]) - 1
+    num_channels = int(grad_flat.shape[1])
+
+    wp_device, wp_stream = FunctionSpec.warp_launch_context(grad_flat)
+    with wp.ScopedStream(wp_stream):
+        wp.launch(
+            segment_softmax_backward_kernel,
+            dim=(num_segments, num_channels),
+            inputs=[
+                wp.from_torch(grad_flat, return_ctype=True),
+                wp.from_torch(out_flat, return_ctype=True),
+                wp.from_torch(offsets_i64, return_ctype=True),
+                wp.from_torch(grad_logits, return_ctype=True),
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+
+    return grad_logits.reshape(original_shape).to(grad_dtype)
+
+
+@segment_softmax_backward.register_fake
+def _(
+    grad_out: torch.Tensor,
+    softmax_out: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(grad_out)
+
+
+def setup_segment_softmax_context(
+    ctx: torch.autograd.function.FunctionCtx,
+    inputs: tuple,
+    output: torch.Tensor,
+) -> None:
+    _, offsets = inputs
+    ctx.save_for_backward(output, offsets)
+
+
+def backward_segment_softmax(
+    ctx: torch.autograd.function.FunctionCtx,
+    grad_out: torch.Tensor,
+) -> tuple[torch.Tensor, None]:
+    softmax_out, offsets = ctx.saved_tensors
+    grad_logits = segment_softmax_backward(grad_out, softmax_out, offsets)
+    return grad_logits, None
+
+
+segment_softmax.register_autograd(
+    backward_segment_softmax, setup_context=setup_segment_softmax_context
+)

--- a/physicsnemo/nn/functional/segments/segment_softmax/_warp_impl.py
+++ b/physicsnemo/nn/functional/segments/segment_softmax/_warp_impl.py
@@ -17,149 +17,153 @@
 """Warp-accelerated CSR segmented softmax."""
 
 import torch
-import warp as wp
 
-from physicsnemo.core.function_spec import FunctionSpec
+try:
+    import warp as wp
+except ImportError as exc:
+    _WARP_IMPORT_ERROR = exc
 
-from .kernels import segment_softmax_backward_kernel, segment_softmax_forward_kernel
-from .utils import flatten_logits, validate_inputs
+    def segment_softmax(logits: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+        """Stub for unavailable Warp segmented softmax backend."""
+        raise ImportError(
+            "The Warp segment_softmax backend requires the 'warp' package."
+        ) from _WARP_IMPORT_ERROR
 
-wp.config.log_level = wp.LOG_WARNING
-wp.init()
+else:
+    from physicsnemo.core.function_spec import FunctionSpec
 
+    from .kernels import segment_softmax_backward_kernel, segment_softmax_forward_kernel
+    from .utils import flatten_logits, validate_inputs
 
-def _require_cuda(tensor: torch.Tensor) -> None:
-    if tensor.device.type != "cuda":
-        raise ValueError(
-            "The Warp segment_softmax backend requires CUDA tensors; "
-            "use implementation='torch' on CPU."
-        )
+    wp.config.log_level = wp.LOG_WARNING
+    wp.init()
 
+    def _require_cuda(tensor: torch.Tensor) -> None:
+        if tensor.device.type != "cuda":
+            raise ValueError(
+                "The Warp segment_softmax backend requires CUDA tensors; "
+                "use implementation='torch' on CPU."
+            )
 
-@torch.library.custom_op("physicsnemo::segment_softmax_warp", mutates_args=())
-def segment_softmax(logits: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
-    """Warp segmented softmax custom op.
+    @torch.library.custom_op("physicsnemo::segment_softmax_warp", mutates_args=())
+    def segment_softmax(logits: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+        """Warp segmented softmax custom op.
 
-    The Warp kernels compute in float32 and the public result is cast back to
-    the input dtype. The operation is grouped by CSR ``offsets`` along axis 0.
-    """
-    validate_inputs(logits, offsets)
-    _require_cuda(logits)
-    if int(logits.shape[0]) == 0 or int(logits.numel()) == 0:
-        return logits.clone()
+        The Warp kernels compute in float32 and the public result is cast back
+        to the input dtype. The operation is grouped by CSR ``offsets`` along
+        axis 0.
+        """
+        validate_inputs(logits, offsets)
+        _require_cuda(logits)
+        if int(logits.shape[0]) == 0 or int(logits.numel()) == 0:
+            return logits.clone()
 
-    input_dtype = logits.dtype
-    logits_f = logits.to(torch.float32).contiguous()
-    offsets_i64 = offsets.to(dtype=torch.int64).contiguous()
-    flat, original_shape = flatten_logits(logits_f)
-    out = torch.empty_like(flat)
-    num_segments = int(offsets_i64.shape[0]) - 1
-    num_channels = int(flat.shape[1])
+        input_dtype = logits.dtype
+        logits_f = logits.to(torch.float32).contiguous()
+        offsets_i64 = offsets.to(dtype=torch.int64).contiguous()
+        flat, original_shape = flatten_logits(logits_f)
+        out = torch.empty_like(flat)
+        num_segments = int(offsets_i64.shape[0]) - 1
+        num_channels = int(flat.shape[1])
 
-    wp_device, wp_stream = FunctionSpec.warp_launch_context(flat)
-    with wp.ScopedStream(wp_stream):
-        wp.launch(
-            segment_softmax_forward_kernel,
-            dim=(num_segments, num_channels),
-            inputs=[
-                wp.from_torch(flat, return_ctype=True),
-                wp.from_torch(offsets_i64, return_ctype=True),
-                wp.from_torch(out, return_ctype=True),
-            ],
-            device=wp_device,
-            stream=wp_stream,
-        )
+        wp_device, wp_stream = FunctionSpec.warp_launch_context(flat)
+        with wp.ScopedStream(wp_stream):
+            wp.launch(
+                segment_softmax_forward_kernel,
+                dim=(num_segments, num_channels),
+                inputs=[
+                    wp.from_torch(flat, return_ctype=True),
+                    wp.from_torch(offsets_i64, return_ctype=True),
+                    wp.from_torch(out, return_ctype=True),
+                ],
+                device=wp_device,
+                stream=wp_stream,
+            )
 
-    return out.reshape(original_shape).to(input_dtype)
+        return out.reshape(original_shape).to(input_dtype)
 
+    @segment_softmax.register_fake
+    def _(
+        logits: torch.Tensor,
+        offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.empty_like(logits)
 
-@segment_softmax.register_fake
-def _(
-    logits: torch.Tensor,
-    offsets: torch.Tensor,
-) -> torch.Tensor:
-    return torch.empty_like(logits)
+    @torch.library.custom_op(
+        "physicsnemo::segment_softmax_warp_backward", mutates_args=()
+    )
+    def segment_softmax_backward(
+        grad_out: torch.Tensor,
+        softmax_out: torch.Tensor,
+        offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        """Backward custom op for Warp segmented softmax."""
+        validate_inputs(softmax_out, offsets)
+        if grad_out.shape != softmax_out.shape:
+            raise ValueError(
+                "grad_out and softmax_out must have the same shape, got "
+                f"{tuple(grad_out.shape)} and {tuple(softmax_out.shape)}"
+            )
+        if grad_out.device != softmax_out.device:
+            raise ValueError(
+                "grad_out and softmax_out must be on the same device, got "
+                f"{grad_out.device} and {softmax_out.device}"
+            )
+        _require_cuda(softmax_out)
+        if int(softmax_out.shape[0]) == 0 or int(softmax_out.numel()) == 0:
+            return grad_out.clone()
 
+        grad_dtype = grad_out.dtype
+        grad_f = grad_out.to(torch.float32).contiguous()
+        out_f = softmax_out.to(torch.float32).contiguous()
+        offsets_i64 = offsets.to(dtype=torch.int64).contiguous()
+        grad_flat, original_shape = flatten_logits(grad_f)
+        out_flat, _ = flatten_logits(out_f)
+        grad_logits = torch.empty_like(grad_flat)
+        num_segments = int(offsets_i64.shape[0]) - 1
+        num_channels = int(grad_flat.shape[1])
 
-@torch.library.custom_op(
-    "physicsnemo::segment_softmax_warp_backward", mutates_args=()
-)
-def segment_softmax_backward(
-    grad_out: torch.Tensor,
-    softmax_out: torch.Tensor,
-    offsets: torch.Tensor,
-) -> torch.Tensor:
-    """Backward custom op for Warp segmented softmax."""
-    validate_inputs(softmax_out, offsets)
-    if grad_out.shape != softmax_out.shape:
-        raise ValueError(
-            "grad_out and softmax_out must have the same shape, got "
-            f"{tuple(grad_out.shape)} and {tuple(softmax_out.shape)}"
-        )
-    if grad_out.device != softmax_out.device:
-        raise ValueError(
-            "grad_out and softmax_out must be on the same device, got "
-            f"{grad_out.device} and {softmax_out.device}"
-        )
-    _require_cuda(softmax_out)
-    if int(softmax_out.shape[0]) == 0 or int(softmax_out.numel()) == 0:
-        return grad_out.clone()
+        wp_device, wp_stream = FunctionSpec.warp_launch_context(grad_flat)
+        with wp.ScopedStream(wp_stream):
+            wp.launch(
+                segment_softmax_backward_kernel,
+                dim=(num_segments, num_channels),
+                inputs=[
+                    wp.from_torch(grad_flat, return_ctype=True),
+                    wp.from_torch(out_flat, return_ctype=True),
+                    wp.from_torch(offsets_i64, return_ctype=True),
+                    wp.from_torch(grad_logits, return_ctype=True),
+                ],
+                device=wp_device,
+                stream=wp_stream,
+            )
 
-    grad_dtype = grad_out.dtype
-    grad_f = grad_out.to(torch.float32).contiguous()
-    out_f = softmax_out.to(torch.float32).contiguous()
-    offsets_i64 = offsets.to(dtype=torch.int64).contiguous()
-    grad_flat, original_shape = flatten_logits(grad_f)
-    out_flat, _ = flatten_logits(out_f)
-    grad_logits = torch.empty_like(grad_flat)
-    num_segments = int(offsets_i64.shape[0]) - 1
-    num_channels = int(grad_flat.shape[1])
+        return grad_logits.reshape(original_shape).to(grad_dtype)
 
-    wp_device, wp_stream = FunctionSpec.warp_launch_context(grad_flat)
-    with wp.ScopedStream(wp_stream):
-        wp.launch(
-            segment_softmax_backward_kernel,
-            dim=(num_segments, num_channels),
-            inputs=[
-                wp.from_torch(grad_flat, return_ctype=True),
-                wp.from_torch(out_flat, return_ctype=True),
-                wp.from_torch(offsets_i64, return_ctype=True),
-                wp.from_torch(grad_logits, return_ctype=True),
-            ],
-            device=wp_device,
-            stream=wp_stream,
-        )
+    @segment_softmax_backward.register_fake
+    def _(
+        grad_out: torch.Tensor,
+        softmax_out: torch.Tensor,
+        offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.empty_like(grad_out)
 
-    return grad_logits.reshape(original_shape).to(grad_dtype)
+    def setup_segment_softmax_context(
+        ctx: torch.autograd.function.FunctionCtx,
+        inputs: tuple,
+        output: torch.Tensor,
+    ) -> None:
+        _, offsets = inputs
+        ctx.save_for_backward(output, offsets)
 
+    def backward_segment_softmax(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_out: torch.Tensor,
+    ) -> tuple[torch.Tensor, None]:
+        softmax_out, offsets = ctx.saved_tensors
+        grad_logits = segment_softmax_backward(grad_out, softmax_out, offsets)
+        return grad_logits, None
 
-@segment_softmax_backward.register_fake
-def _(
-    grad_out: torch.Tensor,
-    softmax_out: torch.Tensor,
-    offsets: torch.Tensor,
-) -> torch.Tensor:
-    return torch.empty_like(grad_out)
-
-
-def setup_segment_softmax_context(
-    ctx: torch.autograd.function.FunctionCtx,
-    inputs: tuple,
-    output: torch.Tensor,
-) -> None:
-    _, offsets = inputs
-    ctx.save_for_backward(output, offsets)
-
-
-def backward_segment_softmax(
-    ctx: torch.autograd.function.FunctionCtx,
-    grad_out: torch.Tensor,
-) -> tuple[torch.Tensor, None]:
-    softmax_out, offsets = ctx.saved_tensors
-    grad_logits = segment_softmax_backward(grad_out, softmax_out, offsets)
-    return grad_logits, None
-
-
-segment_softmax.register_autograd(
-    backward_segment_softmax, setup_context=setup_segment_softmax_context
-)
+    segment_softmax.register_autograd(
+        backward_segment_softmax, setup_context=setup_segment_softmax_context
+    )

--- a/physicsnemo/nn/functional/segments/segment_softmax/kernels.py
+++ b/physicsnemo/nn/functional/segments/segment_softmax/kernels.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Warp kernels for CSR segmented softmax."""
+
+import warp as wp
+
+
+@wp.kernel
+def segment_softmax_forward_kernel(
+    logits: wp.array2d(dtype=wp.float32),
+    offsets: wp.array(dtype=wp.int64),
+    out: wp.array2d(dtype=wp.float32),
+):
+    segment, channel = wp.tid()
+    start = int(offsets[segment])
+    end = int(offsets[segment + 1])
+    if end <= start:
+        return
+
+    max_value = float(-3.4028234663852886e38)
+    i = start
+    while i < end:
+        value = logits[i, channel]
+        if value > max_value:
+            max_value = value
+        i += 1
+
+    denom = float(0.0)
+    i = start
+    while i < end:
+        denom += wp.exp(logits[i, channel] - max_value)
+        i += 1
+
+    i = start
+    while i < end:
+        out[i, channel] = wp.exp(logits[i, channel] - max_value) / denom
+        i += 1
+
+
+@wp.kernel
+def segment_softmax_backward_kernel(
+    grad_out: wp.array2d(dtype=wp.float32),
+    softmax_out: wp.array2d(dtype=wp.float32),
+    offsets: wp.array(dtype=wp.int64),
+    grad_logits: wp.array2d(dtype=wp.float32),
+):
+    segment, channel = wp.tid()
+    start = int(offsets[segment])
+    end = int(offsets[segment + 1])
+    if end <= start:
+        return
+
+    dot = float(0.0)
+    i = start
+    while i < end:
+        dot += grad_out[i, channel] * softmax_out[i, channel]
+        i += 1
+
+    i = start
+    while i < end:
+        y = softmax_out[i, channel]
+        grad_logits[i, channel] = y * (grad_out[i, channel] - dot)
+        i += 1

--- a/physicsnemo/nn/functional/segments/segment_softmax/segment_softmax.py
+++ b/physicsnemo/nn/functional/segments/segment_softmax/segment_softmax.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+import torch
+from jaxtyping import Float, Int
+
+from physicsnemo.core.function_spec import FunctionSpec
+
+from ._torch_impl import segment_softmax as segment_softmax_torch
+from ._warp_impl import segment_softmax as segment_softmax_warp
+
+
+class SegmentSoftmax(FunctionSpec):
+    """Stable softmax over CSR/ragged segments.
+
+    ``segment_softmax`` normalizes entries along axis 0 independently for each
+    segment described by CSR-style ``offsets``. For a segment ``i``, entries
+    ``logits[offsets[i]:offsets[i + 1]]`` are treated as one softmax group.
+    The output has the same shape and dtype as ``logits`` and preserves the
+    flat ragged layout.
+
+    For an entry ``j`` in segment ``i``, the computation is:
+
+    .. math::
+
+       y_j =
+       \\frac{\\exp(x_j - m_i)}
+            {\\sum_{k=offsets_i}^{offsets_{i+1}-1} \\exp(x_k - m_i)}
+
+    where ``m_i = max(logits[offsets[i]:offsets[i + 1]])`` is subtracted for
+    numerical stability. The reduction is performed independently for every
+    trailing channel of ``logits``.
+
+    This is the ragged-neighborhood analogue of attention softmax: each
+    query, node, anchor, or supernode can have a different number of edges
+    without padding to a fixed neighborhood size. Trailing dimensions are
+    normalized independently, so ``logits`` may be ``(E,)``, ``(E, H)``, or
+    ``(E, ...)`` for multi-head or channel-wise attention scores.
+
+    Examples
+    --------
+    A flat vector with two segments:
+
+    >>> logits = torch.tensor([2.0, 1.0, 0.0, 4.0, 2.0])
+    >>> offsets = torch.tensor([0, 3, 5])
+    >>> segment_softmax(logits, offsets)
+    tensor([0.6652, 0.2447, 0.0900, 0.8808, 0.1192])
+
+    The first three entries are normalized together and the last two entries
+    are normalized together. Each non-empty segment sums to one.
+
+    In sparse/local attention, ``offsets`` typically groups flattened edges by
+    query or anchor. For anchor-to-point cross-attention:
+
+    >>> weights = segment_softmax(edge_scores, anchor_offsets)
+    >>> messages = weights.unsqueeze(-1) * point_values[point_indices]
+    >>> anchor_updates = torch.segment_reduce(
+    ...     messages,
+    ...     "sum",
+    ...     offsets=anchor_offsets,
+    ...     axis=0,
+    ... )
+
+    This pattern computes one attention distribution per anchor without
+    padding every anchor neighborhood to the same length and without requiring
+    PyG or ``torch_scatter``.
+
+    Parameters
+    ----------
+    logits : torch.Tensor
+        Floating point scores with shape ``(num_entries, ...)``. Softmax is
+        applied over ``num_entries`` within each segment for every trailing
+        channel independently.
+    offsets : torch.Tensor
+        CSR segment pointer of shape ``(num_segments + 1,)`` with dtype
+        ``int32`` or ``int64``. ``offsets[0]`` must be 0, offsets must be
+        monotonically nondecreasing, and ``offsets[-1]`` must equal
+        ``logits.shape[0]``. Empty segments are allowed and produce no output
+        entries.
+    implementation : {"warp", "torch"} or None
+        Explicit backend name. ``None`` auto-selects Warp for CUDA tensors
+        when available and falls back to the torch baseline otherwise.
+
+    Returns
+    -------
+    torch.Tensor
+        Segment-normalized weights with the same shape and dtype as
+        ``logits``. Values in each non-empty segment sum to one along axis 0.
+
+    Notes
+    -----
+    - The segment axis is fixed to axis 0 in this initial API. Move or reshape
+      other axes before calling this functional.
+    - This version accepts CSR ``offsets`` only. It does not accept
+      per-entry ``segment_ids``.
+    - The operation is differentiable with respect to ``logits``. ``offsets``
+      are integer topology metadata and do not receive gradients.
+    - Empty segments are valid. Since they own no entries, they produce no
+      output values and do not affect neighboring segments.
+    - The Warp backend computes in float32 internally and casts the result
+      back to the input dtype.
+    """
+
+    _BENCHMARK_CASES = (
+        ("small-s2048-l16-scalar", 2048, 16, ()),
+        ("attention-s8192-l32-h8", 8192, 32, (8,)),
+        ("wide-s4096-l48-h4-d16", 4096, 48, (4, 16)),
+        ("tiny-neighborhoods-s32768-l8-h4", 32768, 8, (4,)),
+    )
+
+    @FunctionSpec.register(name="warp", required_imports=("warp>=0.6.0",), rank=0)
+    def warp_forward(
+        logits: Float[torch.Tensor, "num_entries ..."],
+        offsets: Int[torch.Tensor, "num_segments_plus_one"],
+    ) -> Float[torch.Tensor, "num_entries ..."]:
+        """Warp-accelerated CSR segmented softmax."""
+        return segment_softmax_warp(logits, offsets)
+
+    @FunctionSpec.register(name="torch", rank=1, baseline=True)
+    def torch_forward(
+        logits: Float[torch.Tensor, "num_entries ..."],
+        offsets: Int[torch.Tensor, "num_segments_plus_one"],
+    ) -> Float[torch.Tensor, "num_entries ..."]:
+        """Pure-PyTorch segmented softmax baseline."""
+        return segment_softmax_torch(logits, offsets)
+
+    @classmethod
+    def dispatch(
+        cls,
+        logits: torch.Tensor,
+        offsets: torch.Tensor,
+        implementation: Literal["warp", "torch"] | None = None,
+    ) -> torch.Tensor:
+        impls = cls._get_impls()
+        cls._check_impl(implementation, impls)
+
+        if implementation is not None:
+            impl = impls[implementation]
+            if not impl.available:
+                raise ImportError(
+                    f"Implementation '{implementation}' is not available "
+                    f"for {cls.__name__}"
+                )
+            return impl.func(logits, offsets)
+
+        warp_impl = impls.get("warp")
+        if logits.is_cuda and warp_impl is not None and warp_impl.available:
+            return warp_impl.func(logits, offsets)
+        return impls["torch"].func(logits, offsets)
+
+    @classmethod
+    def make_inputs_forward(cls, device: torch.device | str = "cpu"):
+        device = torch.device(device)
+        for label, num_segments, average_length, tail_shape in cls._BENCHMARK_CASES:
+            offsets = _make_offsets(num_segments, average_length, device)
+            num_entries = int(offsets[-1].item())
+            logits = torch.randn(
+                (num_entries, *tail_shape),
+                device=device,
+                dtype=torch.float32,
+            )
+            yield label, (logits, offsets), {}
+
+    @classmethod
+    def make_inputs_backward(cls, device: torch.device | str = "cpu"):
+        device = torch.device(device)
+        for label, num_segments, average_length, tail_shape in cls._BENCHMARK_CASES:
+            offsets = _make_offsets(num_segments, average_length, device)
+            num_entries = int(offsets[-1].item())
+            logits = torch.randn(
+                (num_entries, *tail_shape),
+                device=device,
+                dtype=torch.float32,
+                requires_grad=True,
+            )
+            yield label, (logits, offsets), {}
+
+    @classmethod
+    def compare_forward(cls, output: torch.Tensor, reference: torch.Tensor) -> None:
+        torch.testing.assert_close(output, reference, atol=1e-5, rtol=1e-5)
+
+    @classmethod
+    def compare_backward(cls, output: torch.Tensor, reference: torch.Tensor) -> None:
+        torch.testing.assert_close(output, reference, atol=1e-5, rtol=1e-5)
+
+
+def _make_offsets(
+    num_segments: int,
+    average_length: int,
+    device: torch.device,
+) -> torch.Tensor:
+    # Deterministic ragged lengths with average close to ``average_length``.
+    segment_ids = torch.arange(num_segments, device=device, dtype=torch.int64)
+    jitter = (segment_ids % 7) - 3
+    lengths = torch.clamp(average_length + jitter, min=1)
+    offsets = torch.empty(num_segments + 1, device=device, dtype=torch.int64)
+    offsets[0] = 0
+    torch.cumsum(lengths, dim=0, out=offsets[1:])
+    return offsets
+
+
+segment_softmax = SegmentSoftmax.make_function("segment_softmax")
+
+
+__all__ = ["SegmentSoftmax", "segment_softmax"]

--- a/physicsnemo/nn/functional/segments/segment_softmax/utils.py
+++ b/physicsnemo/nn/functional/segments/segment_softmax/utils.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def validate_inputs(logits: torch.Tensor, offsets: torch.Tensor) -> None:
+    """Validate common ``segment_softmax`` inputs."""
+    if logits.ndim < 1:
+        raise ValueError(f"logits must have rank >= 1, got rank {logits.ndim}")
+    if not torch.is_floating_point(logits):
+        raise ValueError(f"logits must be floating point, got dtype {logits.dtype}")
+    if offsets.ndim != 1:
+        raise ValueError(f"offsets must be a rank-1 tensor, got rank {offsets.ndim}")
+    if offsets.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"offsets must have dtype int32 or int64, got {offsets.dtype}")
+    if offsets.device != logits.device:
+        raise ValueError(
+            "logits and offsets must be on the same device, got "
+            f"{logits.device} and {offsets.device}"
+        )
+    if int(offsets.shape[0]) < 1:
+        raise ValueError("offsets must contain at least one element")
+
+    if torch.compiler.is_compiling():
+        return
+
+    if int(offsets[0].item()) != 0:
+        raise ValueError(f"offsets must start at 0, got {int(offsets[0].item())}")
+    last_offset = int(offsets[-1].item())
+    if last_offset != int(logits.shape[0]):
+        raise ValueError(
+            "offsets[-1] must equal logits.shape[0], got "
+            f"{last_offset} and {int(logits.shape[0])}"
+        )
+    if bool(torch.any(offsets[1:] < offsets[:-1]).item()):
+        raise ValueError("offsets must be monotonically nondecreasing")
+
+
+def flatten_logits(logits: torch.Tensor) -> tuple[torch.Tensor, tuple[int, ...]]:
+    """Flatten trailing logit dimensions to ``(num_entries, channels)``."""
+    original_shape = tuple(int(dim) for dim in logits.shape)
+    num_entries = original_shape[0]
+    channels = 1
+    for dim in original_shape[1:]:
+        channels *= dim
+    flat = logits.reshape(num_entries, channels)
+    return flat, original_shape

--- a/test/nn/functional/segments/test_segment_softmax.py
+++ b/test/nn/functional/segments/test_segment_softmax.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from physicsnemo.nn.functional import segment_softmax
+from physicsnemo.nn.functional.segments import SegmentSoftmax
+
+
+def _reference_segment_softmax(logits: torch.Tensor, offsets: torch.Tensor):
+    chunks = []
+    offsets_cpu = offsets.detach().cpu()
+    for i in range(int(offsets_cpu.numel()) - 1):
+        start = int(offsets_cpu[i].item())
+        end = int(offsets_cpu[i + 1].item())
+        if end > start:
+            chunks.append(torch.softmax(logits[start:end], dim=0))
+    if not chunks:
+        return logits.clone()
+    return torch.cat(chunks, dim=0)
+
+
+def _assert_segment_sums_are_one(weights: torch.Tensor, offsets: torch.Tensor):
+    offsets_cpu = offsets.detach().cpu()
+    for i in range(int(offsets_cpu.numel()) - 1):
+        start = int(offsets_cpu[i].item())
+        end = int(offsets_cpu[i + 1].item())
+        if end > start:
+            sums = weights[start:end].sum(dim=0)
+            torch.testing.assert_close(sums, torch.ones_like(sums))
+
+
+@pytest.mark.parametrize("implementation", ["torch", "warp"])
+def test_segment_softmax_known_answer(device: str, implementation: str):
+    if implementation == "warp" and "cpu" in device:
+        pytest.skip("warp segment_softmax backend is CUDA-only")
+    logits = torch.tensor([2.0, 1.0, 0.0, 4.0, 2.0], device=device)
+    offsets = torch.tensor([0, 3, 5], device=device, dtype=torch.int64)
+
+    out = segment_softmax(logits, offsets, implementation=implementation)
+    expected = torch.cat(
+        [
+            torch.softmax(logits[:3], dim=0),
+            torch.softmax(logits[3:], dim=0),
+        ]
+    )
+    torch.testing.assert_close(out, expected, atol=1e-6, rtol=1e-6)
+    _assert_segment_sums_are_one(out, offsets)
+
+
+@pytest.mark.parametrize("implementation", ["torch", "warp"])
+def test_segment_softmax_empty_segments(device: str, implementation: str):
+    if implementation == "warp" and "cpu" in device:
+        pytest.skip("warp segment_softmax backend is CUDA-only")
+    logits = torch.tensor([[1.0, 0.0], [2.0, 4.0], [-1.0, 3.0]], device=device)
+    offsets = torch.tensor([0, 0, 2, 2, 3], device=device, dtype=torch.int64)
+
+    out = segment_softmax(logits, offsets, implementation=implementation)
+    expected = _reference_segment_softmax(logits, offsets)
+    torch.testing.assert_close(out, expected, atol=1e-6, rtol=1e-6)
+    _assert_segment_sums_are_one(out, offsets)
+
+
+@pytest.mark.parametrize("implementation", ["torch", "warp"])
+@pytest.mark.parametrize("tail_shape", [(), (4,), (2, 3)])
+def test_segment_softmax_trailing_dims(device, implementation, tail_shape):
+    if implementation == "warp" and "cpu" in device:
+        pytest.skip("warp segment_softmax backend is CUDA-only")
+    torch.manual_seed(12)
+    offsets = torch.tensor([0, 1, 4, 4, 9, 10], device=device, dtype=torch.int64)
+    logits = torch.randn((10, *tail_shape), device=device)
+
+    out = segment_softmax(logits, offsets, implementation=implementation)
+    expected = _reference_segment_softmax(logits, offsets)
+    assert out.shape == logits.shape
+    assert out.dtype == logits.dtype
+    torch.testing.assert_close(out, expected, atol=1e-6, rtol=1e-6)
+    _assert_segment_sums_are_one(out, offsets)
+
+
+@pytest.mark.parametrize("implementation", ["torch", "warp"])
+def test_segment_softmax_stable_large_logits(device, implementation):
+    if implementation == "warp" and "cpu" in device:
+        pytest.skip("warp segment_softmax backend is CUDA-only")
+    logits = torch.tensor(
+        [[10000.0, -10000.0], [9999.0, -9999.0], [0.0, 0.0]],
+        device=device,
+    )
+    offsets = torch.tensor([0, 2, 3], device=device, dtype=torch.int64)
+
+    out = segment_softmax(logits, offsets, implementation=implementation)
+    expected = _reference_segment_softmax(logits, offsets)
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, expected, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.parametrize("offset_dtype", [torch.int32, torch.int64])
+def test_segment_softmax_offset_dtypes(device: str, offset_dtype: torch.dtype):
+    logits = torch.randn(6, 3, device=device)
+    offsets = torch.tensor([0, 2, 6], device=device, dtype=offset_dtype)
+    out = segment_softmax(logits, offsets, implementation="torch")
+    expected = _reference_segment_softmax(logits, offsets)
+    torch.testing.assert_close(out, expected)
+
+
+def test_segment_softmax_backward_torch_matches_reference(device: str):
+    torch.manual_seed(4)
+    offsets = torch.tensor([0, 2, 5, 9], device=device, dtype=torch.int64)
+    logits = torch.randn(9, 3, device=device, dtype=torch.float64, requires_grad=True)
+    ref_logits = logits.detach().clone().requires_grad_(True)
+    weight = torch.randn_like(logits)
+
+    out = segment_softmax(logits, offsets, implementation="torch")
+    ref = _reference_segment_softmax(ref_logits, offsets)
+    (out * weight).sum().backward()
+    (ref * weight).sum().backward()
+
+    torch.testing.assert_close(logits.grad, ref_logits.grad, atol=1e-8, rtol=1e-8)
+
+
+def test_segment_softmax_warp_backend_parity(device: str):
+    if "cpu" in device:
+        pytest.skip("warp segment_softmax backend is CUDA-only")
+    torch.manual_seed(9)
+    offsets = torch.tensor([0, 3, 8, 8, 11, 17], device=device, dtype=torch.int64)
+    logits = torch.randn(17, 5, device=device, dtype=torch.float32)
+
+    out_torch = segment_softmax(logits, offsets, implementation="torch")
+    out_warp = segment_softmax(logits, offsets, implementation="warp")
+    SegmentSoftmax.compare_forward(out_warp, out_torch)
+
+
+def test_segment_softmax_warp_backward_parity(device: str):
+    if "cpu" in device:
+        pytest.skip("warp segment_softmax backend is CUDA-only")
+    torch.manual_seed(10)
+    offsets = torch.tensor([0, 2, 6, 7, 13], device=device, dtype=torch.int64)
+    logits_torch = torch.randn(13, 4, device=device, dtype=torch.float32)
+    logits_warp = logits_torch.detach().clone()
+    logits_torch.requires_grad_(True)
+    logits_warp.requires_grad_(True)
+    weight = torch.randn_like(logits_torch)
+
+    out_torch = segment_softmax(logits_torch, offsets, implementation="torch")
+    out_warp = segment_softmax(logits_warp, offsets, implementation="warp")
+    (out_torch * weight).sum().backward()
+    (out_warp * weight).sum().backward()
+
+    torch.testing.assert_close(logits_warp.grad, logits_torch.grad, atol=1e-5, rtol=1e-5)
+
+
+def test_segment_softmax_empty_input(device: str):
+    logits = torch.empty(0, 3, device=device)
+    offsets = torch.tensor([0, 0, 0], device=device, dtype=torch.int64)
+    out = segment_softmax(logits, offsets, implementation="torch")
+    assert out.shape == logits.shape
+    assert out.numel() == 0
+
+
+def test_segment_softmax_empty_trailing_dimension(device: str):
+    logits = torch.empty(4, 0, device=device)
+    offsets = torch.tensor([0, 2, 4], device=device, dtype=torch.int64)
+    out = segment_softmax(logits, offsets, implementation="torch")
+    assert out.shape == logits.shape
+    assert out.numel() == 0
+
+
+def test_segment_softmax_error_handling(device: str):
+    logits = torch.randn(4, device=device)
+    with pytest.raises(ValueError, match="rank-1"):
+        segment_softmax(logits, torch.tensor([[0, 4]], device=device))
+    with pytest.raises(ValueError, match="int32 or int64"):
+        segment_softmax(logits, torch.tensor([0.0, 4.0], device=device))
+    with pytest.raises(ValueError, match="start at 0"):
+        segment_softmax(logits, torch.tensor([1, 4], device=device))
+    with pytest.raises(ValueError, match="offsets\\[-1\\]"):
+        segment_softmax(logits, torch.tensor([0, 3], device=device))
+    with pytest.raises(ValueError, match="monotonically"):
+        segment_softmax(logits, torch.tensor([0, 3, 2, 4], device=device))
+    with pytest.raises(ValueError, match="floating point"):
+        segment_softmax(torch.arange(4, device=device), torch.tensor([0, 4], device=device))
+
+
+def test_segment_softmax_make_inputs_forward(device: str):
+    label, args, kwargs = next(iter(SegmentSoftmax.make_inputs_forward(device)))
+    assert isinstance(label, str)
+    assert isinstance(args, tuple)
+    assert isinstance(kwargs, dict)
+    out = SegmentSoftmax.dispatch(*args, implementation="torch", **kwargs)
+    assert out.shape == args[0].shape
+
+
+def test_segment_softmax_compare_forward_contract(device: str):
+    _, args, kwargs = next(iter(SegmentSoftmax.make_inputs_forward(device)))
+    out = SegmentSoftmax.dispatch(*args, implementation="torch", **kwargs)
+    SegmentSoftmax.compare_forward(out, out.detach().clone())
+
+
+def test_segment_softmax_opcheck(device: str):
+    if "cpu" in device:
+        pytest.skip("warp segment_softmax backend is CUDA-only")
+    from physicsnemo.nn.functional.segments.segment_softmax._warp_impl import (
+        segment_softmax as segment_softmax_warp,
+    )
+
+    logits = torch.randn(7, 2, device=device, dtype=torch.float32, requires_grad=True)
+    offsets = torch.tensor([0, 2, 7], device=device, dtype=torch.int64)
+    torch.library.opcheck(segment_softmax_warp, (logits, offsets))

--- a/test/nn/functional/segments/test_segment_softmax.py
+++ b/test/nn/functional/segments/test_segment_softmax.py
@@ -132,7 +132,17 @@ def test_segment_softmax_backward_torch_matches_reference(device: str):
     torch.testing.assert_close(logits.grad, ref_logits.grad, atol=1e-8, rtol=1e-8)
 
 
-def test_segment_softmax_warp_backend_parity(device: str):
+def test_segment_softmax_dispatch_cpu_matches_torch():
+    torch.manual_seed(8)
+    offsets = torch.tensor([0, 2, 6], dtype=torch.int64)
+    logits = torch.randn(6, 3)
+
+    out_default = segment_softmax(logits, offsets)
+    out_torch = segment_softmax(logits, offsets, implementation="torch")
+    torch.testing.assert_close(out_default, out_torch)
+
+
+def test_segment_softmax_backend_forward_parity(device: str):
     if "cpu" in device:
         pytest.skip("warp segment_softmax backend is CUDA-only")
     torch.manual_seed(9)
@@ -144,7 +154,7 @@ def test_segment_softmax_warp_backend_parity(device: str):
     SegmentSoftmax.compare_forward(out_warp, out_torch)
 
 
-def test_segment_softmax_warp_backward_parity(device: str):
+def test_segment_softmax_backend_backward_parity(device: str):
     if "cpu" in device:
         pytest.skip("warp segment_softmax backend is CUDA-only")
     torch.manual_seed(10)
@@ -204,10 +214,29 @@ def test_segment_softmax_make_inputs_forward(device: str):
     assert out.shape == args[0].shape
 
 
+def test_segment_softmax_make_inputs_backward(device: str):
+    label, args, kwargs = next(iter(SegmentSoftmax.make_inputs_backward(device)))
+    assert isinstance(label, str)
+    assert isinstance(args, tuple)
+    assert isinstance(kwargs, dict)
+    logits, _ = args
+    assert logits.requires_grad
+    out = SegmentSoftmax.dispatch(*args, implementation="torch", **kwargs)
+    assert out.shape == logits.shape
+
+
 def test_segment_softmax_compare_forward_contract(device: str):
     _, args, kwargs = next(iter(SegmentSoftmax.make_inputs_forward(device)))
     out = SegmentSoftmax.dispatch(*args, implementation="torch", **kwargs)
     SegmentSoftmax.compare_forward(out, out.detach().clone())
+
+
+def test_segment_softmax_compare_backward_contract(device: str):
+    _, args, kwargs = next(iter(SegmentSoftmax.make_inputs_backward(device)))
+    logits, _ = args
+    out = SegmentSoftmax.dispatch(*args, implementation="torch", **kwargs)
+    out.square().mean().backward()
+    SegmentSoftmax.compare_backward(logits.grad, logits.grad.detach().clone())
 
 
 def test_segment_softmax_opcheck(device: str):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adds `segment_softmax`, a backend-dispatched functional for numerically stable softmax over CSR/ragged segments.

This is intended as a low-level primitive for sparse/local attention over variable-size neighborhoods, such as anchor-to-point aggregation, graph attention, and ragged neighborhood attention without padding or PyG/`torch_scatter`.


```python
weights = segment_softmax(logits, offsets)
```

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
