### PR TITLE
Improve StormScope recipe masking ergonomics

### DIFF
--- a/examples/weather/stormcast/README.md
+++ b/examples/weather/stormcast/README.md
@@ -302,6 +302,8 @@ The following methods are optional for training:
 * `get_invariants`: Returns the invariants (conditions that are the same for each sample) for the dataset. To use them, `"invariant"` needs to be included in `model.diffusion_conditions`and `model.regression_conditions`.
 * `scalar_condition_channels`: Returns a list with the names of the scalar condition channels. The corresponding 1D array of scalar conditions should be returned in the `scalar_conditions` key of the dict returned by `__getitem__`.
 
+**Spatial mask**: `__getitem__` may optionally return a `"mask"` key containing a float32 array of shape `(1, H, W)` with values in `{0, 1}` (or boolean), where `1`/`True` marks *valid* pixels and `0`/`False` marks invalid or excluded pixels (e.g. outside sensor coverage, LAM sponge zones, land-sea boundaries). When present, the training loop uses the mask as a per-pixel loss weight. For the DiT architecture with `use_nan_mask_tokens: true` in `model.hyperparameters`, the mask is additionally pooled to token granularity and used to replace invalid-region tokens with learned mask tokens inside every NATTEN attention block. The dataset is responsible for producing this mask (e.g. loading a pre-computed coverage map or computing it from quality flags); for static masks, caching the array internally and returning it for every sample is recommended.
+
 The following methods are optional and are **only used by the `inference.py` script**:
 
 * `normalize_background`: Performs the transformation from physical values to normalized values for the background array.

--- a/examples/weather/stormcast/config/dataset/mock.yaml
+++ b/examples/weather/stormcast/config/dataset/mock.yaml
@@ -23,3 +23,4 @@ num_scalar_cond_channels: 2
 image_size: [256, 128]
 num_samples: 100
 model_type: "hybrid"
+use_mask: false

--- a/examples/weather/stormcast/config/model/stormscope.yaml
+++ b/examples/weather/stormcast/config/model/stormscope.yaml
@@ -31,3 +31,4 @@ hyperparameters:
   attn_kernel_size: 31
   num_heads: 16
   patch_size: 4
+  use_nan_mask_tokens: false  # replace invalid-region tokens with a learned mask token (requires a per-sample dataloader "mask")

--- a/examples/weather/stormcast/config/training/default.yaml
+++ b/examples/weather/stormcast/config/training/default.yaml
@@ -88,6 +88,11 @@ validation_steps: 1 # Number of batches to evaluate during validation
 validation_plot_variables: ["u10m", "v10m", "t2m", "refc", "q1", "q5", "q10"]
 validation_plot_background_channels: [] # Background channels to show in validation plots (list of names or indices)
 
+# Per-channel loss weights: a mapping from state channel name to scalar weight.
+# Channels not listed default to 1.0.  Use 0.0 to exclude a channel from the loss.
+# Example: channel_loss_weights: {u10m: 0.0, t2m: 2.0}
+channel_loss_weights: null
+
 # Loss options
 loss:
   type: 'regression' # Loss type; use 'regression' or 'edm' for the regression and diffusion, respectively

--- a/examples/weather/stormcast/datasets/dataset.py
+++ b/examples/weather/stormcast/datasets/dataset.py
@@ -39,12 +39,16 @@ class StormCastDataset(torch.utils.data.Dataset, ABC):
             and index 1 containing the target state data
         - `lead_time_label` (optional): this must be returned if lead_time_steps > 0. A single
             integer indicating which lead time embedding should be used
-        - `mask` (optional): a numpy.ndarray or torch.Tensor of shape `(1, height, width)`
-            with values in {0, 1} (or boolean), where 1/True marks valid pixels and
-            0/False marks invalid/excluded pixels (e.g. outside sensor coverage, LAM
-            padding zones, land-sea boundaries).  When provided, the training loop uses
-            the mask as a per-pixel loss weight and, for the DiT architecture with
-            `use_nan_mask_tokens=True`, pools it to token granularity to replace
+        - `mask` (optional): a numpy.ndarray or torch.Tensor with values in {0, 1}
+            (or boolean), where 1/True marks valid pixels and 0/False marks
+            invalid/excluded pixels (e.g. outside sensor coverage, LAM padding zones,
+            land-sea boundaries).  The shape must broadcast with `(num_channels_state,
+            height, width)`: use `(1, height, width)` for a spatial mask shared across
+            all channels, `(num_channels_state, height, width)` for per-channel spatial
+            masks, or `(num_channels_state, 1, 1)` to mark entire channels as invalid.
+            When provided, the training loop uses the mask as a per-pixel loss weight.
+            For the DiT architecture with `use_nan_mask_tokens=True`, a spatial invalid
+            mask is derived (any channel invalid → token invalid) and used to replace
             invalid-region tokens with learned mask tokens.  The dataset is responsible
             for producing this mask; caching internally is encouraged when the pattern
             is static across samples.

--- a/examples/weather/stormcast/datasets/dataset.py
+++ b/examples/weather/stormcast/datasets/dataset.py
@@ -39,6 +39,15 @@ class StormCastDataset(torch.utils.data.Dataset, ABC):
             and index 1 containing the target state data
         - `lead_time_label` (optional): this must be returned if lead_time_steps > 0. A single
             integer indicating which lead time embedding should be used
+        - `mask` (optional): a numpy.ndarray or torch.Tensor of shape `(1, height, width)`
+            with values in {0, 1} (or boolean), where 1/True marks valid pixels and
+            0/False marks invalid/excluded pixels (e.g. outside sensor coverage, LAM
+            padding zones, land-sea boundaries).  When provided, the training loop uses
+            the mask as a per-pixel loss weight and, for the DiT architecture with
+            `use_nan_mask_tokens=True`, pools it to token granularity to replace
+            invalid-region tokens with learned mask tokens.  The dataset is responsible
+            for producing this mask; caching internally is encouraged when the pattern
+            is static across samples.
         The outputs of __getitem__ should be already normalized (this is not done in the training
         loop for performance reasons).
 

--- a/examples/weather/stormcast/datasets/dataset.py
+++ b/examples/weather/stormcast/datasets/dataset.py
@@ -48,6 +48,7 @@ class StormCastDataset(torch.utils.data.Dataset, ABC):
             invalid-region tokens with learned mask tokens.  The dataset is responsible
             for producing this mask; caching internally is encouraged when the pattern
             is static across samples.
+
         The outputs of __getitem__ should be already normalized (this is not done in the training
         loop for performance reasons).
 

--- a/examples/weather/stormcast/datasets/mock.py
+++ b/examples/weather/stormcast/datasets/mock.py
@@ -43,6 +43,7 @@ class _MockDataset(StormCastDataset):
         model_type: Literal[
             "hybrid", "nowcasting", "downscaling", "unconditional"
         ] = "hybrid",
+        use_mask: bool = False,
     ):
         self._num_state_channels = num_state_channels
         self._num_background_channels = num_background_channels
@@ -51,6 +52,7 @@ class _MockDataset(StormCastDataset):
         self._image_size = image_size
         self._num_samples = num_samples
         self._model_type = model_type
+        self._use_mask = use_mask
 
     def __len__(self) -> int:
         return self._num_samples
@@ -94,6 +96,12 @@ class _MockDataset(StormCastDataset):
             item["scalar_conditions"] = rng.normal(
                 size=(self._num_scalar_cond_channels,)
             ).astype(np.float32)
+
+        # Optional per-sample mask: right half of the domain is valid
+        if self._use_mask:
+            mask = np.zeros((1, height, width), dtype=np.float32)
+            mask[:, :, width // 2 :] = 1.0
+            item["mask"] = mask
 
         return item
 

--- a/examples/weather/stormcast/test_training.py
+++ b/examples/weather/stormcast/test_training.py
@@ -519,6 +519,78 @@ def test_seeding(
     torch.distributed.barrier()
 
 
+@pytest.mark.parametrize(
+    "world_size, domain_parallel_size, batch_size",
+    [(1, 1, 1), (2, 2, 1), (4, 2, 2)],
+    ids=["single", "domain_parallel", "data_domain_parallel"],
+)
+def test_masking(
+    tmp_path: Path,
+    cfg_diffusion: DictConfig,
+    *,
+    world_size: int,
+    domain_parallel_size: int,
+    batch_size: int,
+):
+    """Exercise the DiT masking pathway end-to-end across parallelism schemes.
+
+    Verifies that training and validation run correctly when:
+    - The dataset serves a per-sample ``"mask"`` key (right-half valid).
+    - The DiT is built with ``use_nan_mask_tokens=True``, enabling token-level
+      mask-token substitution inside every NATTEN block.
+    - The loss weight is computed at token granularity (patch-level pooling +
+      nearest-neighbour expansion) rather than at pixel level.
+
+    Three launch configurations are covered (each run targets one and skips the
+    others, matching the world size pytest was launched with):
+
+    - ``single`` (1 GPU): no sharding; pixel tensors are plain ``torch.Tensor``
+      and the mask pooling runs on ordinary tensors.
+    - ``domain_parallel`` (2 GPUs): ``domain_parallel_size=2``, which shards the
+      height dimension and exercises the ShardTensor ``max_pool2d`` /
+      ``interpolate`` path used to pool the mask to token granularity.
+    - ``data_domain_parallel`` (4 GPUs): a (2, 2) mesh combining data
+      parallelism (``batch_size=2``) with domain parallelism
+      (``domain_parallel_size=2``).
+    """
+    dist = DistributedManager()
+    if dist.world_size != world_size:
+        pytest.skip(
+            f"Skipping: this configuration requires {world_size} process(es), "
+            f"current: {dist.world_size}."
+        )
+
+    rundir = _setup_rundir(tmp_path, dist.world_size)
+
+    cfg = cfg_diffusion.copy()
+    cfg.training.rundir = rundir
+    cfg.training.validation_freq = 5
+    cfg.training.domain_parallel_size = domain_parallel_size
+    cfg.training.batch_size = batch_size
+
+    # Enable dataloader mask in the mock dataset
+    cfg.dataset.use_mask = True
+
+    # Enable DiT token-level masking
+    cfg.model.architecture = "dit"
+    cfg.model.hyperparameters.use_nan_mask_tokens = True
+
+    if "regression" in cfg.model.diffusion_conditions:
+        cfg.model.diffusion_conditions.remove("regression")
+
+    train.main(cfg)
+
+    if dist.world_size > 1:
+        torch.distributed.barrier()
+
+    ckpt_path = os.path.join(
+        rundir, "checkpoints_diffusion", "EDMPreconditioner.0.10.mdlus"
+    )
+    assert os.path.isfile(ckpt_path), (
+        "Diffusion checkpoint not found after masked training"
+    )
+
+
 @pytest.mark.parametrize("net_architecture", ["unet", "dit"])
 @pytest.mark.parametrize(
     "model_type", ["hybrid", "nowcasting", "downscaling", "unconditional"]

--- a/examples/weather/stormcast/test_training.py
+++ b/examples/weather/stormcast/test_training.py
@@ -591,6 +591,101 @@ def test_masking(
     )
 
 
+@pytest.mark.parametrize(
+    "world_size, domain_parallel_size, batch_size",
+    [(1, 1, 1), (2, 2, 1), (4, 2, 2)],
+    ids=["single", "domain_parallel", "data_domain_parallel"],
+)
+def test_channel_loss_weights(
+    tmp_path: Path,
+    cfg_diffusion_unet: DictConfig,
+    *,
+    world_size: int,
+    domain_parallel_size: int,
+    batch_size: int,
+):
+    """Verify that channel_loss_weights composes correctly with the dataset mask.
+
+    Mirrors the parallelism parametrisation of ``test_masking`` but exercises
+    the channel-weight path instead of token masking.  Uses the UNet model
+    (no channels_last memory format) to keep weight-value assertions simple.
+
+    - A dataset spatial mask: right half of the domain is valid (1), left half
+      is invalid (0).  Image is (H=32, W=16) so the boundary is at column 8.
+    - ``channel_loss_weights``: ``state_0`` zeroed out (0.0), ``state_2``
+      doubled (2.0), ``state_1`` left at the default (1.0).
+
+    Expected per-pixel weight after composition (broadcast to B, C, H, W):
+
+    - ``state_0``: all zeros (channel weight 0 overrides spatial validity).
+    - ``state_1``: 0 on the left half, 1 on the right half (spatial mask only).
+    - ``state_2``: 0 on the left half, 2 on the right half (spatial × channel).
+
+    Under domain parallelism the weight tensor is a height-sharded
+    ``ShardTensor``; the width-based spatial pattern is still fully visible on
+    every rank's local shard, so the same value assertions apply.
+    """
+    dist = DistributedManager()
+    if dist.world_size != world_size:
+        pytest.skip(
+            f"Skipping: this configuration requires {world_size} process(es), "
+            f"current: {dist.world_size}."
+        )
+
+    rundir = _setup_rundir(tmp_path, dist.world_size)
+
+    cfg = cfg_diffusion_unet.copy()
+    cfg.training.rundir = rundir
+    cfg.training.domain_parallel_size = domain_parallel_size
+    cfg.training.batch_size = batch_size
+    cfg.dataset.image_size = [32, 16]  # small image: W=16, mask boundary at col 8
+    cfg.dataset.use_mask = True
+    cfg.training.channel_loss_weights = {"state_0": 0.0, "state_2": 2.0}
+
+    t = trainer.Trainer(cfg)
+
+    # --- Check the channel weight tensor (replicated across all ranks) ---
+    ch_w = t._channel_loss_weight
+    # Under domain parallelism ch_w is a DTensor; extract local copy.
+    ch_w_local = ch_w.to_local() if isinstance(ch_w, DTensor) else ch_w
+    assert ch_w_local.shape == (1, 3, 1, 1)
+    assert ch_w_local[0, 0, 0, 0].item() == pytest.approx(0.0)
+    assert ch_w_local[0, 1, 0, 0].item() == pytest.approx(1.0)
+    assert ch_w_local[0, 2, 0, 0].item() == pytest.approx(2.0)
+
+    # --- Intercept loss_fn to capture the composed weight during train_step ---
+    captured_weights: list[torch.Tensor] = []
+    _orig_loss = t.loss_fn
+
+    def _capturing_loss(target, weight, **kwargs):
+        # Under domain parallelism weight is a ShardTensor; .to_local() gives
+        # the local height shard (B, C, H_local, W).  The width-based spatial
+        # pattern (columns 0-7 invalid, 8-15 valid) is fully visible locally.
+        w_local = weight.to_local() if isinstance(weight, DTensor) else weight
+        captured_weights.append(w_local.detach().cpu())
+        return _orig_loss(target, weight, **kwargs)
+
+    t.loss_fn = _capturing_loss
+    t.train_step()
+
+    assert captured_weights, "loss_fn was never called during train_step"
+    w = captured_weights[0]  # (B, C, H_local, W)
+
+    # Image width = 16; left half = columns 0-7 (invalid), right = 8-15 (valid).
+    assert w[:, 0].eq(0.0).all(), "state_0 should be zero everywhere"
+    assert w[:, 1, :, :8].eq(0.0).all(), "state_1 left half should be 0"
+    assert w[:, 1, :, 8:].eq(1.0).all(), "state_1 right half should be 1"
+    assert w[:, 2, :, :8].eq(0.0).all(), "state_2 left half should be 0"
+    assert w[:, 2, :, 8:].eq(2.0).all(), "state_2 right half should be 2"
+
+    # Validation path should also run without error.
+    t.total_steps += 1
+    t.validate()
+
+    if dist.world_size > 1:
+        torch.distributed.barrier()
+
+
 @pytest.mark.parametrize("net_architecture", ["unet", "dit"])
 @pytest.mark.parametrize(
     "model_type", ["hybrid", "nowcasting", "downscaling", "unconditional"]

--- a/examples/weather/stormcast/utils/config.py
+++ b/examples/weather/stormcast/utils/config.py
@@ -218,6 +218,10 @@ class TrainingConfig:
 
     loss: LossConfig = Field(default=LossConfig())
 
+    channel_loss_weights: dict[str, float] | None = (
+        None  # per-channel loss weights by state channel name; unlisted channels default to 1.0
+    )
+
 
 @dataclass(config={"extra": "allow"})
 class DatasetConfig:

--- a/examples/weather/stormcast/utils/trainer.py
+++ b/examples/weather/stormcast/utils/trainer.py
@@ -341,6 +341,8 @@ class Trainer:
         self.scalar_cond_channels = self.dataset_train.scalar_condition_channels()
         self.lead_time_steps = self.dataset_train.lead_time_steps
 
+        self._channel_loss_weight = self._build_channel_loss_weight()
+
         # Dataloaders
         num_workers = self.cfg.training.num_data_workers
         self.train_dataloader = self.parallel_helper.sharded_dataloader(
@@ -377,6 +379,25 @@ class Trainer:
             raise ValueError(
                 "Scalar conditions are only supported for the 'dit' architecture."
             )
+
+    def _build_channel_loss_weight(self) -> torch.Tensor:
+        r"""Build a ``(1, C, 1, 1)`` per-channel loss weight tensor from config.
+
+        Reads ``cfg.training.channel_loss_weights`` (a dict mapping state
+        channel names to float weights) and returns a broadcastable tensor.
+        Channels not listed default to ``1.0``.  Unknown names emit a warning.
+        """
+        cfg_weights = self.cfg.training.channel_loss_weights or {}
+        unknown = set(cfg_weights) - set(self.state_channels)
+        if unknown:
+            self.logger.info(
+                f"channel_loss_weights references unknown state channels (will be ignored): {sorted(unknown)}"
+            )
+        weights = [cfg_weights.get(ch, 1.0) for ch in self.state_channels]
+        t = torch.tensor(weights, dtype=torch.float32, device=self.device).view(
+            1, -1, 1, 1
+        )
+        return self.parallel_helper.replicate_tensor(t)
 
     # =========================================================================
     # Model Setup
@@ -459,9 +480,12 @@ class Trainer:
         The ``weight`` is derived at the appropriate granularity:
 
         * **DiT + ``use_nan_mask_tokens``**: token-granularity weight — any
-          pixel in a patch where *any* pixel is invalid gets weight 0, matching
-          the token-level substitution done inside the model.  Uses the
-          ``patch_size`` extracted directly from the DiT at construction.
+          pixel in a patch where *any* channel or pixel is invalid gets weight
+          0, matching the token-level substitution done inside the model.
+          Per-channel invalidity from the dataset mask is also applied, so a
+          pixel gets weight 0 if either its token is spatially invalid *or* its
+          specific channel is marked invalid.  Uses the ``patch_size`` extracted
+          directly from the DiT at construction.
         * **Otherwise**: pixel-level weight — ``1 - invalid_mask.float()``.
         * **No mask at all**: scalar ``1.0`` replicated onto the correct device
           mesh (same as the unconditional behaviour).
@@ -470,6 +494,10 @@ class Trainer:
         *also* injected into the DiT as the ``invalid_mask`` forward kwarg (so
         the model can replace invalid tokens with the learned mask token); the
         loss weight is applied regardless.
+
+        The returned ``invalid_mask`` (used for the DiT forward) is always
+        ``(B, 1, H, W)``: it is the spatial union (any-channel) of the
+        dataset mask, since token replacement operates across all channels.
 
         Under domain parallelism the inputs are height-sharded
         ``ShardTensor``s.  :func:`torch.nn.functional.max_pool2d` and
@@ -482,9 +510,9 @@ class Trainer:
             Diffusion target of shape :math:`(B, C, H, W)`; used only for its
             spatial shape and device/dtype.
         batch_mask : torch.Tensor or None
-            Per-sample mask from the dataloader, shape :math:`(B, 1, H, W)`.
-            ``1`` = valid pixel, ``0`` = invalid pixel.  ``None`` when the
-            dataset does not provide a mask.
+            Per-sample mask from the dataloader, broadcastable to
+            :math:`(B, C, H, W)`.  ``1`` = valid pixel, ``0`` = invalid pixel.
+            ``None`` when the dataset does not provide a mask.
 
         Returns
         -------
@@ -501,7 +529,12 @@ class Trainer:
             return None, weight
 
         # batch_mask convention: 1=valid, 0=invalid → invert to invalid-first.
-        invalid_mask = batch_mask < 0.5  # (B, 1, H, W) bool
+        invalid_mask = batch_mask < 0.5  # (B, C_or_1, H_or_1, W_or_1) bool
+
+        # The DiT token-replacement path needs a purely spatial (B, 1, H, W)
+        # mask.  Collapse the channel dimension: a spatial location is invalid
+        # if it is invalid in *any* channel.
+        spatial_invalid = invalid_mask.any(dim=1, keepdim=True)  # (B, 1, H, W)
 
         if self._dit_patch_size is not None and self.use_nan_mask_tokens:
             # Token-granularity: pool mask down to patch level, then expand
@@ -513,7 +546,7 @@ class Trainer:
                     f"patch_size={self._dit_patch_size}."
                 )
             patch_invalid = F.max_pool2d(
-                invalid_mask.float(),
+                spatial_invalid.float(),
                 kernel_size=(patch_h, patch_w),
                 stride=(patch_h, patch_w),
             )  # (B, 1, H/p, W/p)
@@ -523,13 +556,15 @@ class Trainer:
             # scalar scale_factor (it computes halo sizes as
             # scale_factor * halo). A scalar is exact here because patches are
             # square and H/p * p == H (patching requires H, W divisible by p).
-            weight = 1.0 - F.interpolate(
+            token_valid = 1.0 - F.interpolate(
                 patch_invalid, scale_factor=patch_h, mode="nearest"
             )  # (B, 1, H, W), 0 at any pixel whose patch is invalid
+            # Also zero-out pixels invalid per the per-channel dataset mask.
+            weight = token_valid * (1.0 - invalid_mask.float())
         else:
-            weight = 1.0 - invalid_mask.float()  # (B, 1, H, W)
+            weight = 1.0 - invalid_mask.float()  # (B, C_or_1, H_or_1, W_or_1)
 
-        return invalid_mask, weight
+        return spatial_invalid, weight
 
     def _load_regression_net(self) -> Module | None:
         r"""
@@ -764,6 +799,7 @@ class Trainer:
                 # (token-granularity for DiT, pixel-level otherwise) and an
                 # invalid_mask for the DiT forward.
                 invalid_mask, weight = self._build_masks(target, mask)
+                weight = weight * self._channel_loss_weight
 
                 loss_kwargs = {}
                 if lead_time_label is not None:
@@ -902,6 +938,7 @@ class Trainer:
                     )
 
                     invalid_mask, weight = self._build_masks(target, mask)
+                    weight = weight * self._channel_loss_weight
 
                     loss_kwargs = {}
                     if lead_time_label is not None:
@@ -985,7 +1022,7 @@ class Trainer:
                 device=state[1].device,
                 sampler_args=self.cfg.sampler.args.__dict__,
                 lead_time_label=lead_time_label,
-                invalid_mask=invalid_mask,
+                invalid_mask=invalid_mask if self.use_nan_mask_tokens else None,
             )
             if "regression" in self.condition_list:
                 outputs += reg_out

--- a/examples/weather/stormcast/utils/trainer.py
+++ b/examples/weather/stormcast/utils/trainer.py
@@ -507,6 +507,11 @@ class Trainer:
             # Token-granularity: pool mask down to patch level, then expand
             # back so every pixel in a masked patch gets weight 0.
             patch_h, patch_w = self._dit_patch_size
+            if patch_h != patch_w:
+                raise NotImplementedError(
+                    "Token-level loss masking requires square DiT patches; got "
+                    f"patch_size={self._dit_patch_size}."
+                )
             patch_invalid = F.max_pool2d(
                 invalid_mask.float(),
                 kernel_size=(patch_h, patch_w),
@@ -518,11 +523,6 @@ class Trainer:
             # scalar scale_factor (it computes halo sizes as
             # scale_factor * halo). A scalar is exact here because patches are
             # square and H/p * p == H (patching requires H, W divisible by p).
-            if patch_h != patch_w:
-                raise NotImplementedError(
-                    "Token-level loss masking requires square DiT patches; got "
-                    f"patch_size={self._dit_patch_size}."
-                )
             weight = 1.0 - F.interpolate(
                 patch_invalid, scale_factor=patch_h, mode="nearest"
             )  # (B, 1, H, W), 0 at any pixel whose patch is invalid

--- a/examples/weather/stormcast/utils/trainer.py
+++ b/examples/weather/stormcast/utils/trainer.py
@@ -22,6 +22,7 @@ import time
 import numpy as np
 from omegaconf import DictConfig, OmegaConf
 import torch
+import torch.nn.functional as F
 from torch.nn.utils import clip_grad_norm_
 import psutil
 from physicsnemo.core import Module
@@ -228,13 +229,16 @@ class Trainer:
         self.loss_type = cfg.training.loss.type
         self.net_name = "regression" if self.loss_type == "regression" else "diffusion"
 
-        # Dynamic invalid-region (NaN) masking for the DiT NATTEN backend. When
-        # enabled, a per-sample invalid-pixel mask is derived from NaNs in the
-        # model's spatial inputs and passed to the model's forward; the inputs
-        # are sanitized (NaN -> 0) so the masked-token splice is well-defined.
+        # Invalid-region masking for the DiT NATTEN backend. When enabled, the
+        # per-sample mask from the dataloader is passed to the model's forward
+        # as the ``invalid_mask`` kwarg so invalid tokens are replaced by the
+        # learned mask token.  Only meaningful for the DiT architecture; always
+        # False for UNet.
         self.use_nan_mask_tokens = bool(
             cfg.model.hyperparameters.get("use_nan_mask_tokens", False)
         )
+        # Patch size extracted from the DiT in _setup_model; None for UNet.
+        self._dit_patch_size = None
         self.condition_list = (
             cfg.model.regression_conditions
             if self.net_name == "regression"
@@ -431,74 +435,101 @@ class Trainer:
                 lead_time_steps=self.lead_time_steps,
                 **model_cfg.hyperparameters,
             )
+            # Capture patch_size directly from the DiT before FSDP wrapping
+            # changes the module hierarchy. EDMPreconditioner.model is the
+            # ConcatConditionWrapper; .model of that is the DiT.
+            self._dit_patch_size = net.model.model.patch_size
         else:
             raise ValueError("model.architecture must be 'unet' or 'dit'")
 
         return net
 
-    def _derive_invalid_mask(self, condition, target) -> tuple:
-        r"""Derive a per-sample invalid-region mask from NaNs in the inputs.
+    def _build_masks(self, target, batch_mask) -> tuple:
+        r"""Build the invalid-region mask and the loss weight tensor.
 
-        No-op (returns ``invalid_mask=None``) unless the model was built with
-        ``use_nan_mask_tokens=True``. When enabled, an invalid pixel is any
-        spatial location that is NaN in *either* the diffusion target or the
-        image-like conditioning (both occupy the model's spatial input once
-        concatenated). The corresponding mask is returned at shape
-        :math:`(B, 1, H, W)` for the DiT's ``invalid_mask`` argument, and the
-        offending inputs are sanitized in place (NaN -> 0) so the masked-token
-        splice is well-defined (it multiplies by zero, which does not remove a
-        NaN). The mask differs per sample and per step, enabling dynamic masking.
+        The per-sample mask is supplied entirely by the dataloader under the
+        ``"mask"`` key (convention: ``1`` = valid, ``0`` = invalid).  The
+        dataset owns the definition of the mask and is free to cache and reuse
+        it internally when the pattern is static.  This method translates that
+        mask into the two artefacts the training step needs:
 
-        Under domain parallelism the inputs are already height-sharded
-        ``ShardTensor``s; ``torch.isnan``/``torch.nan_to_num`` and the channel
-        reduction (``sum`` over the unsharded channel axis) keep the derived mask
-        sharded along height like ``x``.
+        * an ``invalid_mask`` (``True`` = invalid) for the DiT forward, and
+        * a ``weight`` tensor for the loss.
+
+        The ``weight`` is derived at the appropriate granularity:
+
+        * **DiT + ``use_nan_mask_tokens``**: token-granularity weight — any
+          pixel in a patch where *any* pixel is invalid gets weight 0, matching
+          the token-level substitution done inside the model.  Uses the
+          ``patch_size`` extracted directly from the DiT at construction.
+        * **Otherwise**: pixel-level weight — ``1 - invalid_mask.float()``.
+        * **No mask at all**: scalar ``1.0`` replicated onto the correct device
+          mesh (same as the unconditional behaviour).
+
+        ``use_nan_mask_tokens`` only controls whether the dataloader mask is
+        *also* injected into the DiT as the ``invalid_mask`` forward kwarg (so
+        the model can replace invalid tokens with the learned mask token); the
+        loss weight is applied regardless.
+
+        Under domain parallelism the inputs are height-sharded
+        ``ShardTensor``s.  :func:`torch.nn.functional.max_pool2d` and
+        :func:`torch.nn.functional.interpolate` are registered for
+        ``ShardTensor`` and preserve the height sharding.
 
         Parameters
         ----------
-        condition : torch.Tensor, TensorDict, or None
-            Model conditioning. A ``TensorDict`` carries the image-like part
-            under ``"cond_concat"``; a plain tensor is itself the image part.
         target : torch.Tensor
-            Diffusion target of shape :math:`(B, C, H, W)`.
+            Diffusion target of shape :math:`(B, C, H, W)`; used only for its
+            spatial shape and device/dtype.
+        batch_mask : torch.Tensor or None
+            Per-sample mask from the dataloader, shape :math:`(B, 1, H, W)`.
+            ``1`` = valid pixel, ``0`` = invalid pixel.  ``None`` when the
+            dataset does not provide a mask.
 
         Returns
         -------
         tuple
-            ``(condition, target, invalid_mask)`` with sanitized inputs and a
-            :math:`(B, 1, H, W)` boolean mask (or ``None`` when disabled).
+            ``(invalid_mask, weight)`` where ``invalid_mask`` is a
+            :math:`(B, 1, H, W)` bool tensor (``True`` = invalid) or ``None``
+            when the dataset provides no mask, and ``weight`` is a
+            broadcastable loss-weight tensor.
         """
-        if not self.use_nan_mask_tokens:
-            return condition, target, None
+        if batch_mask is None:
+            weight = self.parallel_helper.replicate_tensor(
+                torch.ones((), device=target.device, dtype=target.dtype)
+            )
+            return None, weight
 
-        # Locate the image-like conditioning that is concatenated to the target.
-        if isinstance(condition, torch.Tensor):
-            image_cond = condition
-        elif condition is not None:
-            image_cond = condition.get("cond_concat", None)
+        # batch_mask convention: 1=valid, 0=invalid → invert to invalid-first.
+        invalid_mask = batch_mask < 0.5  # (B, 1, H, W) bool
+
+        if self._dit_patch_size is not None and self.use_nan_mask_tokens:
+            # Token-granularity: pool mask down to patch level, then expand
+            # back so every pixel in a masked patch gets weight 0.
+            patch_h, patch_w = self._dit_patch_size
+            patch_invalid = F.max_pool2d(
+                invalid_mask.float(),
+                kernel_size=(patch_h, patch_w),
+                stride=(patch_h, patch_w),
+            )  # (B, 1, H/p, W/p)
+            # Expand back to pixel resolution with a *scalar* scale_factor.
+            # Neither size= nor a tuple scale_factor works under domain
+            # parallelism: the ShardTensor interpolate wrapper requires a
+            # scalar scale_factor (it computes halo sizes as
+            # scale_factor * halo). A scalar is exact here because patches are
+            # square and H/p * p == H (patching requires H, W divisible by p).
+            if patch_h != patch_w:
+                raise NotImplementedError(
+                    "Token-level loss masking requires square DiT patches; got "
+                    f"patch_size={self._dit_patch_size}."
+                )
+            weight = 1.0 - F.interpolate(
+                patch_invalid, scale_factor=patch_h, mode="nearest"
+            )  # (B, 1, H, W), 0 at any pixel whose patch is invalid
         else:
-            image_cond = None
+            weight = 1.0 - invalid_mask.float()  # (B, 1, H, W)
 
-        invalid = None
-        for part in (target, image_cond):
-            if part is None:
-                continue
-            # (B, 1, H, W): count NaN channels at each pixel (sum over the
-            # channel axis is ShardTensor-safe; ``any`` is not registered).
-            nan_count = torch.isnan(part).to(part.dtype).sum(dim=1, keepdim=True)
-            invalid = nan_count if invalid is None else invalid + nan_count
-        invalid_mask = invalid > 0  # (B, 1, H, W) bool
-
-        # Sanitize so the masked-token splice (x * 0 + mask_token) is finite.
-        target = torch.nan_to_num(target, nan=0.0)
-        if image_cond is not None:
-            image_cond = torch.nan_to_num(image_cond, nan=0.0)
-            if isinstance(condition, torch.Tensor):
-                condition = image_cond
-            else:
-                condition["cond_concat"] = image_cond
-
-        return condition, target, invalid_mask
+        return invalid_mask, weight
 
     def _load_regression_net(self) -> Module | None:
         r"""
@@ -729,23 +760,15 @@ class Trainer:
                 )
                 del background, state, scalar_conditions
 
-                # Derive a per-sample invalid-region mask from NaNs in the model
-                # inputs and sanitize those inputs (no-op unless enabled).
-                condition, target, invalid_mask = self._derive_invalid_mask(
-                    condition, target
-                )
+                # Translate the dataloader mask into a loss weight
+                # (token-granularity for DiT, pixel-level otherwise) and an
+                # invalid_mask for the DiT forward.
+                invalid_mask, weight = self._build_masks(target, mask)
 
-                weight = (
-                    mask
-                    if mask is not None
-                    else self.parallel_helper.replicate_tensor(
-                        torch.ones((), device=target.device, dtype=target.dtype)
-                    )
-                )
                 loss_kwargs = {}
                 if lead_time_label is not None:
                     loss_kwargs["lead_time_label"] = lead_time_label
-                if invalid_mask is not None:
+                if invalid_mask is not None and self.use_nan_mask_tokens:
                     loss_kwargs["invalid_mask"] = invalid_mask
 
                 sigma = None
@@ -878,21 +901,12 @@ class Trainer:
                         regression_condition_list=self.cfg.model.regression_conditions,
                     )
 
-                    condition, target, invalid_mask = self._derive_invalid_mask(
-                        condition, target
-                    )
+                    invalid_mask, weight = self._build_masks(target, mask)
 
-                    weight = (
-                        mask
-                        if mask is not None
-                        else self.parallel_helper.replicate_tensor(
-                            torch.ones((), device=target.device, dtype=target.dtype)
-                        )
-                    )
                     loss_kwargs = {}
                     if lead_time_label is not None:
                         loss_kwargs["lead_time_label"] = lead_time_label
-                    if invalid_mask is not None:
+                    if invalid_mask is not None and self.use_nan_mask_tokens:
                         loss_kwargs["invalid_mask"] = invalid_mask
 
                     valid_loss = self.loss_fn(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

### Summary
Reworks spatial masking in the StormCast/StormScope recipe into a single, dataloader-owned interface, and fixes a domain-parallelism bug in the loss-mask construction. Previously masking came from two reconciled-at-train-time sources (a dataloader `mask` key and a NaN-inspection pathway), which was confusing and produced a shape bug under domain parallelism. Changes:

- Single mask source (dataloader-owned). The per-sample `"mask"` served by the dataset (convention `1`=valid, `0`=invalid) is now the only mask source. The NaN-inspection pathway is removed entirely. `Trainer._build_masks(target, batch_mask)` translates that mask into a loss weight and an `invalid_mask`; `use_nan_mask_tokens` now solely controls whether `invalid_mask` is also injected into the DiT forward so it can swap invalid tokens for its learned mask token.
- Token-granularity loss weight for DiT. When the DiT runs with `use_nan_mask_tokens`, the loss weight is pooled to patch granularity (`max_pool2d`) and expanded back (`interpolate`), matching the model's token-level substitution. The patch size is read directly from the constructed DiT (patch_size), and the expansion uses a scalar `scale_factor`. Pixel-level weight is retained otherwise.
- Domain-parallelism fix. Eliminates a mask shape bug that arose from detecting NaNs under sharding; the mask now stays correctly `(B, 1, H, W)` as a height-sharded ShardTensor through pooling and expansion.
- Config / docs. Adds `use_mask: false` (mock dataset) and `use_nan_mask_tokens: false` (stormscope hyperparameters) defaults so the keys exist in the OmegaConf struct, documents the `"mask"` key in the dataset docstring and README, and adds an optional `use_mask` pattern to the mock dataset.

### Tests

`test_masking` now exercises the full masked DiT path across three launch configs — single (1 GPU), domain_parallel (2 GPU, height-sharded), and data_domain_parallel (4 GPU, 2×2 data+domain mesh) — skipping configs that don't match the launched world size.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
