### PR TITLE
fix nan_to_num crash on DTensor gradients in  domain-parallel training

### DIFF
--- a/examples/weather/stormcast/utils/trainer.py
+++ b/examples/weather/stormcast/utils/trainer.py
@@ -792,9 +792,9 @@ class Trainer:
         # Clean NaN gradients
         for param in self.net.parameters():
             if param.grad is not None:
-                torch.nan_to_num(
-                    param.grad, nan=0, posinf=1e5, neginf=-1e5, out=param.grad
-                )
+                grad = param.grad
+                local = grad.to_local() if hasattr(grad, "to_local") else grad
+                local.nan_to_num_(nan=0, posinf=1e5, neginf=-1e5)
 
         self.optimizer.step()
         step_scheduler(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
 After domain-parallel backward, `param.grad` is a DTensor with `Partial(sum)` placement -- meaning each rank holds an unreduced partial sum. PyTorch's DTensor dispatch has no registered sharding strategy for `nan_to_num` on `Partial` tensors, so it fails. 

  ## Fix
 This PR adds a fix that extracts the local shard with `.to_local()` and apply `nan_to_num_` in-place on it directly.
 
  
## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
