### PR TITLE
Fix for Mesh SDF API

### DIFF
--- a/docs/api/mesh/spatial.rst
+++ b/docs/api/mesh/spatial.rst
@@ -55,15 +55,18 @@ The **sign** is determined by one of two methods, selected with
 .. code:: python
 
     import torch
+    from physicsnemo.mesh import Mesh
     from physicsnemo.mesh.spatial import signed_distance_field_mesh
 
-    # A triangle surface mesh: (n_vertices, 3) coords + flattened connectivity.
-    vertices = torch.randn(500, 3)
-    faces = torch.randint(0, 500, (3000,))  # (3 * n_faces,) or (n_faces, 3)
+    # A triangle surface mesh: (n_vertices, 3) coords + (n_faces, 3) connectivity.
+    mesh = Mesh(
+        points=torch.randn(500, 3),
+        cells=torch.randint(0, 500, (1000, 3)),
+    )
 
     query = torch.randn(10000, 3)
     sdf, hit_points = signed_distance_field_mesh(
-        vertices, faces, query, use_sign_winding_number=True
+        mesh, query, use_sign_winding_number=True
     )
     # sdf: (10000,) signed distances; hit_points: (10000, 3) closest surface points.
 

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
@@ -112,10 +112,8 @@ class ComputeSDFFromBoundary(MeshTransform):
             )
 
         surface = domain.boundaries[self.boundary_name]
-        vertices = surface.points.float()
-        faces = surface.cells
 
-        if faces is None or faces.numel() == 0:
+        if surface.n_cells == 0:
             raise ValueError(
                 f"Boundary {self.boundary_name!r} has no cell connectivity "
                 f"(required for SDF computation)"
@@ -124,8 +122,7 @@ class ComputeSDFFromBoundary(MeshTransform):
         query_points = domain.interior.points.float()
 
         sdf_values, closest_points = signed_distance_field_mesh(
-            vertices,
-            faces,
+            surface,
             query_points,
             use_sign_winding_number=self.use_winding_number,
         )
@@ -139,13 +136,16 @@ class ComputeSDFFromBoundary(MeshTransform):
             normals = query_points - closest_points
 
             # Fallback for points on the surface (zero distance): use direction
-            # from center of mass instead. Computed unconditionally and selected
-            # with a mask rather than branching on ``on_surface.any()`` -- that
-            # host readback would stall the prefetch stream.
+            # from the surface centroid instead. Computed unconditionally and
+            # selected with a mask rather than branching on ``on_surface.any()``
+            # -- that host readback would stall the prefetch stream.
             dist = torch.norm(normals, dim=-1)
             on_surface = dist < 1e-6
-            com = vertices.mean(dim=0, keepdim=True)
-            normals = torch.where(on_surface.unsqueeze(-1), query_points - com, normals)
+            # The mesh stays intact; read its points only here, at point of use.
+            centroid = surface.points.float().mean(dim=0, keepdim=True)
+            normals = torch.where(
+                on_surface.unsqueeze(-1), query_points - centroid, normals
+            )
 
             # Normalize to unit vectors
             norm = torch.norm(normals, dim=-1, keepdim=True).clamp(min=1e-8)

--- a/physicsnemo/datapipes/transforms/geometric.py
+++ b/physicsnemo/datapipes/transforms/geometric.py
@@ -30,6 +30,7 @@ from tensordict import TensorDict
 
 from physicsnemo.datapipes.registry import register
 from physicsnemo.datapipes.transforms.base import Transform
+from physicsnemo.mesh import Mesh
 from physicsnemo.mesh.spatial.sdf import signed_distance_field_mesh
 
 
@@ -142,6 +143,9 @@ class ComputeSDF(Transform):
         mesh_coords = data[self.mesh_coords_key]
         mesh_faces = data[self.mesh_faces_key].to(torch.int32)
 
+        # The SDF takes a Mesh; build one from the (flattened) triangle faces.
+        mesh = Mesh(points=mesh_coords, cells=mesh_faces.reshape(-1, 3))
+
         updates = {}
 
         # Compute SDF for each input key
@@ -153,8 +157,7 @@ class ComputeSDF(Transform):
 
             # Compute SDF and closest points
             sdf, closest_points = signed_distance_field_mesh(
-                mesh_coords,
-                mesh_faces,
+                mesh,
                 query_points,
                 use_sign_winding_number=self.use_winding_number,
             )

--- a/physicsnemo/mesh/spatial/sdf.py
+++ b/physicsnemo/mesh/spatial/sdf.py
@@ -945,12 +945,9 @@ def signed_distance_field_mesh(
     *,
     winding_backend: str = "clustertree",
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    r"""Signed distance field of a triangle surface mesh.
+    r"""Compute the signed distance to a triangle surface mesh.
 
-    Uses :class:`physicsnemo.mesh.spatial.BVH` for the nearest-triangle query
-    and a :class:`physicsnemo.mesh.spatial.ClusterTree` Barnes-Hut summation for
-    the winding-number sign, all in plain PyTorch. Returns the signed distance
-    and the closest surface point for each query.
+    Returns the signed distance and the closest surface point for each query.
 
     Parameters
     ----------
@@ -1114,19 +1111,16 @@ def _signed_distance_field_mesh_from_arrays(
     *,
     winding_backend: str = "clustertree",
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    r"""[INTERNAL - DO NOT USE] Array-based SDF mirroring the replaced Warp API.
+    r"""[INTERNAL - DO NOT USE] Private array-based SDF helper.
 
     .. warning::
 
-       **DON'T USE THIS ONE.** This is a private, debug-only entry point. Use
+       **DON'T USE THIS ONE.** This is a private, temporary entry point. Use
        the public :func:`signed_distance_field_mesh`, which takes a
        :class:`~physicsnemo.mesh.Mesh`, instead.
 
-       This variant takes raw ``(mesh_vertices, mesh_indices)`` arrays solely to
-       mirror the call signature of the (now replaced) Warp-based
-       ``signed_distance_field``, so the two can be swapped one-for-one while
-       debugging Warp parity for a release or two. It is unexported, carries no
-       backward-compatibility guarantee, and may be removed without notice.
+       This helper is unexported, carries no backward-compatibility guarantee,
+       and may be removed without notice.
 
     It wraps the arrays in a :class:`~physicsnemo.mesh.Mesh` and defers to
     :func:`signed_distance_field_mesh`, so the numerics are identical.

--- a/physicsnemo/mesh/spatial/sdf.py
+++ b/physicsnemo/mesh/spatial/sdf.py
@@ -106,7 +106,7 @@ def _build_surface_mesh(
         copy, ``face_vertices`` has shape ``(n_faces, 3, 3)`` and ``faces`` has
         shape ``(n_faces, 3)`` (int64).
     """
-    faces = mesh.cells.reshape(-1, 3).to(torch.long)
+    faces = mesh.cells.to(torch.long)
     work_mesh = Mesh(points=mesh.points.to(torch.float32), cells=faces)
     face_vertices = work_mesh.points[faces]  # (n_faces, 3, 3)
     return work_mesh, face_vertices, faces

--- a/physicsnemo/mesh/spatial/sdf.py
+++ b/physicsnemo/mesh/spatial/sdf.py
@@ -84,29 +84,32 @@ _WINDING_LEAF_SIZE = 8
 
 
 def _build_surface_mesh(
-    mesh_vertices: Float[torch.Tensor, "n_vertices 3"],
-    mesh_indices: Int[torch.Tensor, "..."],
+    mesh: Mesh,
 ) -> tuple[Mesh, Float[torch.Tensor, "n_faces 3 3"], Int[torch.Tensor, "n_faces 3"]]:
-    """Construct a triangle :class:`Mesh` and return per-face vertex positions.
+    """Normalize a triangle :class:`Mesh` into the float32 working representation.
+
+    The BVH build and the Triton nearest-triangle kernel assume a float32
+    coordinate dtype, so this returns a float32 copy of ``mesh`` alongside the
+    per-face vertex positions and the int64 triangle connectivity consumed by
+    the downstream tensor ops.
 
     Parameters
     ----------
-    mesh_vertices : torch.Tensor
-        Vertex coordinates, shape ``(n_vertices, 3)``.
-    mesh_indices : torch.Tensor
-        Triangle connectivity, either flattened ``(3 * n_faces,)`` or
-        ``(n_faces, 3)``.
+    mesh : Mesh
+        Triangle surface mesh: ``mesh.points`` has shape ``(n_vertices, 3)`` and
+        ``mesh.cells`` has shape ``(n_faces, 3)``.
 
     Returns
     -------
     tuple[Mesh, torch.Tensor, torch.Tensor]
-        ``(mesh, face_vertices, faces)`` where ``face_vertices`` has shape
-        ``(n_faces, 3, 3)`` and ``faces`` has shape ``(n_faces, 3)`` (int64).
+        ``(mesh, face_vertices, faces)`` where ``mesh`` is the float32 working
+        copy, ``face_vertices`` has shape ``(n_faces, 3, 3)`` and ``faces`` has
+        shape ``(n_faces, 3)`` (int64).
     """
-    faces = mesh_indices.reshape(-1, 3).to(torch.long)
-    mesh = Mesh(points=mesh_vertices, cells=faces)
-    face_vertices = mesh_vertices[faces]  # (n_faces, 3, 3)
-    return mesh, face_vertices, faces
+    faces = mesh.cells.reshape(-1, 3).to(torch.long)
+    work_mesh = Mesh(points=mesh.points.to(torch.float32), cells=faces)
+    face_vertices = work_mesh.points[faces]  # (n_faces, 3, 3)
+    return work_mesh, face_vertices, faces
 
 
 def _closest_point_on_triangles(
@@ -935,15 +938,14 @@ def _winding_number_sign_clustertree(
 
 
 def signed_distance_field_mesh(
-    mesh_vertices: Float[torch.Tensor, "n_vertices 3"],
-    mesh_indices: Int[torch.Tensor, "..."],
-    input_points: Float[torch.Tensor, "... 3"],
+    mesh: Mesh,
+    query_points: Float[torch.Tensor, "... 3"],
     max_dist: float | None = None,
     use_sign_winding_number: bool = False,
     *,
     winding_backend: str = "clustertree",
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Signed distance field of a triangle surface mesh.
+    r"""Signed distance field of a triangle surface mesh.
 
     Uses :class:`physicsnemo.mesh.spatial.BVH` for the nearest-triangle query
     and a :class:`physicsnemo.mesh.spatial.ClusterTree` Barnes-Hut summation for
@@ -952,11 +954,10 @@ def signed_distance_field_mesh(
 
     Parameters
     ----------
-    mesh_vertices : torch.Tensor
-        Mesh vertex coordinates, shape ``(n_vertices, 3)``.
-    mesh_indices : torch.Tensor
-        Triangle connectivity, flattened ``(3 * n_faces,)`` or ``(n_faces, 3)``.
-    input_points : torch.Tensor
+    mesh : Mesh
+        Triangle surface mesh embedded in 3D: ``mesh.points`` has shape
+        ``(n_vertices, 3)`` and ``mesh.cells`` has shape ``(n_faces, 3)``.
+    query_points : torch.Tensor
         Query points, shape ``(..., 3)``.
     max_dist : float or None, optional
         Maximum search radius for the nearest-triangle query. ``None``
@@ -976,15 +977,17 @@ def signed_distance_field_mesh(
     Returns
     -------
     tuple[torch.Tensor, torch.Tensor]
-        ``(sdf, hit_points)``: signed distance per query (shape ``input.shape[:-1]``)
-        and the closest point on the mesh per query (shape ``input.shape``).
+        ``(sdf, hit_points)``: signed distance per query
+        (shape ``query_points.shape[:-1]``) and the closest point on the mesh
+        per query (shape ``query_points.shape``).
 
     Raises
     ------
     ValueError
-        If ``input_points`` does not have a trailing dimension of size 3, if
-        ``mesh_indices`` is not 1D-flattened or ``(n_faces, 3)``, or if the mesh
-        has no faces (there is no surface to measure distance to).
+        If ``mesh`` is not a triangle surface in 3D (``n_spatial_dims == 3`` and
+        ``n_manifold_dims == 2``), if ``query_points`` does not have a trailing
+        dimension of size 3, or if the mesh has no faces (there is no surface to
+        measure distance to).
 
     Notes
     -----
@@ -993,49 +996,51 @@ def signed_distance_field_mesh(
     far query is never silently reported as on-surface (``sdf == 0``). The
     unbounded default never produces ``NaN`` for a non-empty mesh.
     """
-    if input_points.shape[-1] != 3:
-        raise ValueError("input_points must have last dimension of size 3")
+    if query_points.shape[-1] != 3:
+        raise ValueError("query_points must have last dimension of size 3")
 
-    if mesh_indices.ndim == 2:
-        if mesh_indices.shape[-1] != 3:
-            raise ValueError(
-                "mesh_indices with 2 dimensions must have shape (n_faces, 3)"
-            )
-    elif mesh_indices.ndim != 1:
+    # A triangle surface in 3D is required: the closest-point and solid-angle
+    # math both assume 3-vertex cells with 3D coordinates. Validate here so a
+    # mis-typed mesh fails loudly rather than deep inside the BVH/winding kernels.
+    if mesh.n_spatial_dims != 3:
         raise ValueError(
-            "mesh_indices must be either 1D flattened indices or 2D (n_faces, 3)"
+            "signed_distance_field_mesh requires a 3D mesh "
+            f"(n_spatial_dims == 3), but got {mesh.n_spatial_dims=}."
+        )
+    if mesh.n_manifold_dims != 2:
+        raise ValueError(
+            "signed_distance_field_mesh requires a triangle mesh "
+            f"(n_manifold_dims == 2), but got {mesh.n_manifold_dims=}."
+        )
+    if mesh.n_cells == 0:
+        raise ValueError(
+            "mesh has no faces; there is no surface to measure distance to"
         )
 
-    input_shape = input_points.shape
-    out_dtype = input_points.dtype
-    device = input_points.device
+    query_shape = query_points.shape
+    out_dtype = query_points.dtype
+    device = query_points.device
 
-    # Compute internally in float32; the BVH build path assumes a float
-    # coordinate dtype.
-    vertices = mesh_vertices.to(torch.float32)
-    queries = input_points.reshape(-1, 3).to(torch.float32)
+    queries = query_points.reshape(-1, 3).to(torch.float32)
     n_queries = queries.shape[0]
 
     # None -> unbounded exact search; a finite value is a narrow band.
     max_dist_eff = float("inf") if max_dist is None else float(max_dist)
 
-    mesh, face_vertices, faces = _build_surface_mesh(vertices, mesh_indices)
-
-    if faces.shape[0] == 0:
-        raise ValueError(
-            "mesh has no faces; there is no surface to measure distance to"
-        )
+    # Normalize the mesh to a float32 working copy; the BVH build and the Triton
+    # nearest-triangle kernel assume a float32 coordinate dtype.
+    work_mesh, face_vertices, _ = _build_surface_mesh(mesh)
 
     sdf = torch.zeros(n_queries, dtype=torch.float32, device=device)
     hit_points = queries.clone()
 
     if n_queries == 0:
-        sdf = sdf.reshape(input_shape[:-1]).to(out_dtype)
-        hit_points = hit_points.reshape(input_shape).to(out_dtype)
+        sdf = sdf.reshape(query_shape[:-1]).to(out_dtype)
+        hit_points = hit_points.reshape(query_shape).to(out_dtype)
         return sdf, hit_points
 
     with record_function("sdf/bvh_build"):
-        bvh = BVH.from_mesh(mesh, leaf_size=_BVH_LEAF_SIZE)
+        bvh = BVH.from_mesh(work_mesh, leaf_size=_BVH_LEAF_SIZE)
 
     # Nearest triangle + closest point. On CUDA with Triton available we run the
     # single-kernel per-thread DFS (:func:`_sdf_triton.nearest_triangle_triton`),
@@ -1082,7 +1087,7 @@ def signed_distance_field_mesh(
                     f"got {winding_backend!r}"
                 )
         else:
-            sign = _pseudo_normal_sign(mesh, queries, best_face, best_point)
+            sign = _pseudo_normal_sign(work_mesh, queries, best_face, best_point)
 
     sdf = sign * distance
     hit_points = best_point
@@ -1095,6 +1100,77 @@ def signed_distance_field_mesh(
             missed.unsqueeze(-1), hit_points.new_full((), float("nan")), hit_points
         )
 
-    sdf = sdf.reshape(input_shape[:-1]).to(out_dtype)
-    hit_points = hit_points.reshape(input_shape).to(out_dtype)
+    sdf = sdf.reshape(query_shape[:-1]).to(out_dtype)
+    hit_points = hit_points.reshape(query_shape).to(out_dtype)
     return sdf, hit_points
+
+
+def _signed_distance_field_mesh_from_arrays(
+    mesh_vertices: Float[torch.Tensor, "n_vertices 3"],
+    mesh_indices: Int[torch.Tensor, "..."],
+    query_points: Float[torch.Tensor, "... 3"],
+    max_dist: float | None = None,
+    use_sign_winding_number: bool = False,
+    *,
+    winding_backend: str = "clustertree",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""[INTERNAL - DO NOT USE] Array-based SDF mirroring the replaced Warp API.
+
+    .. warning::
+
+       **DON'T USE THIS ONE.** This is a private, debug-only entry point. Use
+       the public :func:`signed_distance_field_mesh`, which takes a
+       :class:`~physicsnemo.mesh.Mesh`, instead.
+
+       This variant takes raw ``(mesh_vertices, mesh_indices)`` arrays solely to
+       mirror the call signature of the (now replaced) Warp-based
+       ``signed_distance_field``, so the two can be swapped one-for-one while
+       debugging Warp parity for a release or two. It is unexported, carries no
+       backward-compatibility guarantee, and may be removed without notice.
+
+    It wraps the arrays in a :class:`~physicsnemo.mesh.Mesh` and defers to
+    :func:`signed_distance_field_mesh`, so the numerics are identical.
+
+    Parameters
+    ----------
+    mesh_vertices : torch.Tensor
+        Mesh vertex coordinates, shape ``(n_vertices, 3)``.
+    mesh_indices : torch.Tensor
+        Triangle connectivity, flattened ``(3 * n_faces,)`` or ``(n_faces, 3)``.
+    query_points : torch.Tensor
+        Query points, shape ``(..., 3)``.
+    max_dist : float or None, optional
+        Maximum search radius; see :func:`signed_distance_field_mesh`.
+    use_sign_winding_number : bool, optional
+        Sign method; see :func:`signed_distance_field_mesh`.
+    winding_backend : str, optional
+        Winding-number backend; see :func:`signed_distance_field_mesh`.
+
+    Returns
+    -------
+    tuple[torch.Tensor, torch.Tensor]
+        ``(sdf, hit_points)``; see :func:`signed_distance_field_mesh`.
+
+    Raises
+    ------
+    ValueError
+        If ``mesh_indices`` is not 1D-flattened or ``(n_faces, 3)``; the
+        remaining validation is performed by :func:`signed_distance_field_mesh`.
+    """
+    if mesh_indices.ndim == 2:
+        if mesh_indices.shape[-1] != 3:
+            raise ValueError(
+                "mesh_indices with 2 dimensions must have shape (n_faces, 3)"
+            )
+    elif mesh_indices.ndim != 1:
+        raise ValueError(
+            "mesh_indices must be either 1D flattened indices or 2D (n_faces, 3)"
+        )
+    mesh = Mesh(points=mesh_vertices, cells=mesh_indices.reshape(-1, 3))
+    return signed_distance_field_mesh(
+        mesh,
+        query_points,
+        max_dist,
+        use_sign_winding_number,
+        winding_backend=winding_backend,
+    )

--- a/test/mesh/spatial/test_mesh_sdf.py
+++ b/test/mesh/spatial/test_mesh_sdf.py
@@ -28,13 +28,18 @@ import math
 import pytest
 import torch
 
-from physicsnemo.mesh.spatial.sdf import signed_distance_field_mesh
+from physicsnemo.mesh import Mesh
+from physicsnemo.mesh.spatial.sdf import (
+    _signed_distance_field_mesh_from_arrays,
+    signed_distance_field_mesh,
+)
 
 
 # Build a simple tetrahedron surface mesh as four triangles (a deterministic
 # fixture with known SDF values).
-def _tetrahedron_vertices() -> torch.Tensor:
-    return torch.tensor(
+def _tetrahedron_mesh() -> Mesh:
+    """A tetrahedron surface mesh: 12 vertices, 4 triangles, known SDF values."""
+    vertices = torch.tensor(
         [
             [0.0, 0.0, 0.0],
             [0.0, 1.0, 0.0],
@@ -51,9 +56,11 @@ def _tetrahedron_vertices() -> torch.Tensor:
         ],
         dtype=torch.float64,
     )
+    cells = torch.arange(12, dtype=torch.int64).reshape(-1, 3)
+    return Mesh(points=vertices, cells=cells)
 
 
-def _uv_sphere(n_rings: int = 40, n_segments: int = 80):
+def _uv_sphere_mesh(n_rings: int = 40, n_segments: int = 80) -> Mesh:
     """Build a UV-sphere triangle mesh (unit radius) for analytic SDF checks."""
     phi = torch.linspace(0, math.pi, n_rings + 2)[1:-1]
     theta = torch.linspace(0, 2 * math.pi, n_segments + 1)[:-1]
@@ -79,8 +86,8 @@ def _uv_sphere(n_rings: int = 40, n_segments: int = 80):
     ).reshape(-1, 3)
     last = south - n_segments
     south_fan = torch.stack([last + j, torch.full_like(j, south), last + j_next], dim=1)
-    faces = torch.cat([north, body, south_fan]).to(torch.int32).reshape(-1)
-    return vertices, faces
+    faces = torch.cat([north, body, south_fan]).to(torch.int32)
+    return Mesh(points=vertices, cells=faces)
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +125,7 @@ def _l_prism_inside(points: torch.Tensor) -> torch.Tensor:
     return in_z & (bottom | top_left)
 
 
-def _l_prism() -> tuple[torch.Tensor, torch.Tensor]:
+def _l_prism_mesh() -> Mesh:
     r"""Build a watertight, outward-oriented L-prism surface mesh.
 
     A non-convex L-shaped polygon (one reflex corner) extruded in ``z`` into a
@@ -127,9 +134,9 @@ def _l_prism() -> tuple[torch.Tensor, torch.Tensor]:
 
     Returns
     -------
-    tuple[torch.Tensor, torch.Tensor]
-        ``(vertices, faces)`` with shapes :math:`(12, 3)` (``float32``) and
-        :math:`(20, 3)` (``int64``). Triangles are wound so normals point outward.
+    Mesh
+        Triangle surface mesh (12 vertices, 20 triangles); triangles are wound so
+        normals point outward.
     """
     # L-polygon corners in CCW order; index 3 is the reflex corner. The polygon
     # is star-shaped from corner 0, so each cap is a simple fan from that corner.
@@ -163,10 +170,10 @@ def _l_prism() -> tuple[torch.Tensor, torch.Tensor]:
     centroids = tri.mean(dim=1)
     points_inward = _l_prism_inside(centroids + 1e-4 * normals)
     faces[points_inward] = faces[points_inward][:, [0, 2, 1]]
-    return vertices, faces
+    return Mesh(points=vertices, cells=faces)
 
 
-def _open_uv_sphere(n_rings: int = 40, n_segments: int = 80):
+def _open_uv_sphere_mesh(n_rings: int = 40, n_segments: int = 80) -> Mesh:
     """A UV sphere with the south polar cap removed (non-watertight surface)."""
     phi = torch.linspace(0, math.pi, n_rings + 2)[1:-1]
     theta = torch.linspace(0, 2 * math.pi, n_segments + 1)[:-1]
@@ -190,11 +197,11 @@ def _open_uv_sphere(n_rings: int = 40, n_segments: int = 80):
     body = torch.stack(
         [torch.stack([p00, p10, p11], -1), torch.stack([p00, p11, p01], -1)], dim=2
     ).reshape(-1, 3)
-    faces = torch.cat([north, body]).to(torch.int32).reshape(-1)
-    return vertices, faces
+    faces = torch.cat([north, body]).to(torch.int32)
+    return Mesh(points=vertices, cells=faces)
 
 
-def _l_prism_thick(thickness: float = 1.0):
+def _l_prism_thick_mesh(thickness: float = 1.0) -> Mesh:
     """Watertight, outward-wound L-shaped triangular prism (non-convex solid).
 
     The cross-section (in the xy-plane) is the hexagon ``(0,0) -> (2,0) ->
@@ -225,7 +232,7 @@ def _l_prism_thick(thickness: float = 1.0):
     ]
     faces = bottom_cap + top_cap + walls
 
-    return vertices, torch.tensor(faces, dtype=torch.int32)
+    return Mesh(points=vertices, cells=torch.tensor(faces, dtype=torch.int32))
 
 
 def _inside_l(points: torch.Tensor, thickness: float = 1.0) -> torch.Tensor:
@@ -243,15 +250,13 @@ def _inside_l(points: torch.Tensor, thickness: float = 1.0) -> torch.Tensor:
 def test_sdf_tetrahedron_reference(dtype, use_winding, device):
     """Match the known deterministic tetrahedron SDF values."""
     device = torch.device(device)
-    mesh_vertices = _tetrahedron_vertices().to(device=device, dtype=dtype)
-    mesh_indices = torch.arange(12, device=device, dtype=torch.int32)
+    mesh = _tetrahedron_mesh().to(device=device, dtype=dtype)
     query_points = torch.tensor(
         [[1.0, 1.0, 1.0], [0.05, 0.1, 0.1]], device=device, dtype=dtype
     )
 
     sdf_out, hit_points = signed_distance_field_mesh(
-        mesh_vertices,
-        mesh_indices,
+        mesh,
         query_points,
         use_sign_winding_number=use_winding,
     )
@@ -275,18 +280,19 @@ def test_sdf_tetrahedron_reference(dtype, use_winding, device):
 
 
 def test_sdf_index_layout_compatibility(device):
-    """Flattened and (n_faces, 3) connectivity must give identical results."""
+    """Flat and (n_faces, 3) connectivity agree (private array helper)."""
     device = torch.device(device)
-    mesh_vertices = _tetrahedron_vertices().to(device=device, dtype=torch.float32)
-    mesh_indices_flat = torch.arange(12, device=device, dtype=torch.int32)
-    mesh_indices_faces = mesh_indices_flat.reshape(-1, 3)
+    tet = _tetrahedron_mesh().to(device)
+    # The array helper is tested directly here, so pull its inputs from the mesh.
+    mesh_indices_flat = tet.cells.reshape(-1)
+    mesh_indices_faces = tet.cells
     query_points = torch.tensor([[0.1, 0.2, 0.3]], device=device, dtype=torch.float32)
 
-    sdf_flat, hit_flat = signed_distance_field_mesh(
-        mesh_vertices, mesh_indices_flat, query_points
+    sdf_flat, hit_flat = _signed_distance_field_mesh_from_arrays(
+        tet.points, mesh_indices_flat, query_points
     )
-    sdf_faces, hit_faces = signed_distance_field_mesh(
-        mesh_vertices, mesh_indices_faces, query_points
+    sdf_faces, hit_faces = _signed_distance_field_mesh_from_arrays(
+        tet.points, mesh_indices_faces, query_points
     )
     torch.testing.assert_close(sdf_flat, sdf_faces)
     torch.testing.assert_close(hit_flat, hit_faces)
@@ -296,9 +302,7 @@ def test_sdf_index_layout_compatibility(device):
 def test_sdf_sphere_analytic(use_winding, device):
     """SDF of a tessellated unit sphere matches the analytic ``|r| - 1``."""
     device = torch.device(device)
-    vertices, faces = _uv_sphere()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _uv_sphere_mesh().to(device)
 
     torch.manual_seed(0)
     query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
@@ -306,7 +310,7 @@ def test_sdf_sphere_analytic(use_winding, device):
     gt = radius - 1.0
 
     sdf_out, hit = signed_distance_field_mesh(
-        vertices, faces, query, use_sign_winding_number=use_winding
+        mesh, query, use_sign_winding_number=use_winding
     )
 
     # The error is dominated by the polygonal approximation of the sphere, not
@@ -326,44 +330,77 @@ def test_sdf_sphere_analytic(use_winding, device):
 def test_sdf_preserves_input_shape(device):
     """Output SDF/hit-point shapes follow the (possibly batched) query shape."""
     device = torch.device(device)
-    vertices = _tetrahedron_vertices().to(device=device, dtype=torch.float32)
-    faces = torch.arange(12, device=device, dtype=torch.int32)
+    mesh = _tetrahedron_mesh().to(device)
     query = torch.rand(4, 5, 3, device=device)
 
-    sdf_out, hit = signed_distance_field_mesh(vertices, faces, query)
+    sdf_out, hit = signed_distance_field_mesh(mesh, query)
     assert sdf_out.shape == (4, 5)
     assert hit.shape == (4, 5, 3)
 
 
-def test_sdf_error_handling(device):
-    """Input validation for the SDF interface."""
+def test_sdf_public_matches_private_arrays(device):
+    """The public Mesh API and the private array helper agree exactly."""
     device = torch.device(device)
-    vertices = _tetrahedron_vertices().to(device=device, dtype=torch.float32)
-    faces = torch.arange(12, device=device, dtype=torch.int32)
+    mesh = _uv_sphere_mesh().to(device)
+
+    torch.manual_seed(0)
+    query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
+
+    sdf_pub, hit_pub = signed_distance_field_mesh(mesh, query)
+    sdf_priv, hit_priv = _signed_distance_field_mesh_from_arrays(
+        mesh.points, mesh.cells, query
+    )
+    torch.testing.assert_close(sdf_pub, sdf_priv)
+    torch.testing.assert_close(hit_pub, hit_priv)
+
+
+def test_sdf_error_handling(device):
+    """Input validation for the public (Mesh) SDF interface."""
+    device = torch.device(device)
+    mesh = _tetrahedron_mesh().to(device)
     query = torch.tensor([[0.1, 0.2, 0.3]], device=device, dtype=torch.float32)
 
     bad_queries = torch.randn(4, 2, device=device)
     with pytest.raises(ValueError, match="last dimension of size 3"):
-        signed_distance_field_mesh(vertices, faces, bad_queries)
+        signed_distance_field_mesh(mesh, bad_queries)
+
+    # Non-triangle connectivity (cells wider than 3) is rejected up front.
+    quad_cells = torch.zeros(2, 4, device=device, dtype=torch.int64)
+    with pytest.raises(ValueError, match="triangle mesh"):
+        signed_distance_field_mesh(Mesh(points=mesh.points, cells=quad_cells), query)
+
+    # A mesh embedded in 2D has no well-defined 3D signed distance.
+    flat_points = mesh.points[:, :2].contiguous()
+    with pytest.raises(ValueError, match="3D mesh"):
+        signed_distance_field_mesh(Mesh(points=flat_points, cells=mesh.cells), query)
+
+
+def test_sdf_array_connectivity_validation(device):
+    """The private array helper still validates raw connectivity layout."""
+    device = torch.device(device)
+    vertices = _tetrahedron_mesh().to(device).points
+    query = torch.tensor([[0.1, 0.2, 0.3]], device=device, dtype=torch.float32)
 
     bad_connectivity_shape = torch.zeros(4, 4, device=device, dtype=torch.int32)
     with pytest.raises(ValueError, match=r"shape \(n_faces, 3\)"):
-        signed_distance_field_mesh(vertices, bad_connectivity_shape, query)
+        _signed_distance_field_mesh_from_arrays(vertices, bad_connectivity_shape, query)
 
     bad_connectivity_rank = torch.zeros(1, 2, 3, device=device, dtype=torch.int32)
     with pytest.raises(ValueError, match="1D flattened indices or 2D"):
-        signed_distance_field_mesh(vertices, bad_connectivity_rank, query)
+        _signed_distance_field_mesh_from_arrays(vertices, bad_connectivity_rank, query)
 
 
 def test_sdf_empty_mesh_raises(device):
     """A mesh with no faces has no surface, so the query must raise."""
     device = torch.device(device)
-    vertices = _tetrahedron_vertices().to(device=device, dtype=torch.float32)
-    empty_faces = torch.zeros(0, device=device, dtype=torch.int32)
+    points = _tetrahedron_mesh().to(device).points
+    empty_mesh = Mesh(
+        points=points, cells=torch.zeros(0, 3, device=device, dtype=torch.int64)
+    )
     query = torch.tensor([[0.1, 0.2, 0.3]], device=device, dtype=torch.float32)
 
     with pytest.raises(ValueError, match="no faces"):
-        signed_distance_field_mesh(vertices, empty_faces, query)
+        signed_distance_field_mesh(empty_mesh, query)
 
 
 def test_sdf_max_dist_unbounded_and_narrow_band(device):
@@ -375,26 +412,25 @@ def test_sdf_max_dist_unbounded_and_narrow_band(device):
     ``NaN`` and leaves in-band queries identical to the unbounded result.
     """
     device = torch.device(device)
-    vertices = _tetrahedron_vertices().to(device=device, dtype=torch.float32)
-    faces = torch.arange(12, device=device, dtype=torch.int32)
+    mesh = _tetrahedron_mesh().to(device)
 
     far = torch.tensor([[100.0, 100.0, 100.0]], device=device, dtype=torch.float32)
     near = torch.tensor([[0.05, 0.1, 0.1]], device=device, dtype=torch.float32)
 
     # Unbounded default: the far query finds its true nearest triangle.
-    sdf_far, hit_far = signed_distance_field_mesh(vertices, faces, far)
+    sdf_far, hit_far = signed_distance_field_mesh(mesh, far)
     assert torch.isfinite(sdf_far).all()
     assert sdf_far.abs().item() > 1.0
     assert not torch.allclose(hit_far, far)
 
     # Finite band below the true distance: the far query is out of band -> NaN.
-    sdf_band, hit_band = signed_distance_field_mesh(vertices, faces, far, max_dist=1.0)
+    sdf_band, hit_band = signed_distance_field_mesh(mesh, far, max_dist=1.0)
     assert torch.isnan(sdf_band).all()
     assert torch.isnan(hit_band).all()
 
     # An in-band query with a finite max_dist matches the unbounded result.
-    sdf_unbounded, _ = signed_distance_field_mesh(vertices, faces, near)
-    sdf_in_band, _ = signed_distance_field_mesh(vertices, faces, near, max_dist=10.0)
+    sdf_unbounded, _ = signed_distance_field_mesh(mesh, near)
+    sdf_in_band, _ = signed_distance_field_mesh(mesh, near, max_dist=10.0)
     assert torch.isfinite(sdf_in_band).all()
     torch.testing.assert_close(sdf_in_band, sdf_unbounded, atol=1e-5, rtol=1e-5)
 
@@ -410,9 +446,7 @@ def test_sdf_pseudo_normal_sign_wrong_at_sharp_edges(device):
     generalized winding number.
     """
     device = torch.device(device)
-    vertices, faces = _l_prism()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _l_prism_mesh().to(device)
 
     # Build the query set on CPU (device-independent point set), then move it.
     # The expanded box reaches into the exterior wedges of the convex edges; the
@@ -428,7 +462,7 @@ def test_sdf_pseudo_normal_sign_wrong_at_sharp_edges(device):
     query = torch.cat([box, reflex], dim=0).to(device)
 
     sdf_out, _ = signed_distance_field_mesh(
-        vertices, faces, query, use_sign_winding_number=False
+        mesh, query, use_sign_winding_number=False
     )
 
     # The distance magnitude is correct; only the sign is in question. Compare to
@@ -456,9 +490,7 @@ def test_sdf_winding_sign_correct_at_sharp_edges(device):
     is valid and isolates the failure to the pseudo-normal method.
     """
     device = torch.device(device)
-    vertices, faces = _l_prism()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _l_prism_mesh().to(device)
 
     torch.manual_seed(1)
     lo = torch.tensor([-0.2, -0.2, -0.2])
@@ -466,7 +498,7 @@ def test_sdf_winding_sign_correct_at_sharp_edges(device):
     query = (lo + (hi - lo) * torch.rand(40_000, 3)).to(device)
 
     sdf_out, _ = signed_distance_field_mesh(
-        vertices, faces, query, use_sign_winding_number=True
+        mesh, query, use_sign_winding_number=True
     )
 
     # Exclude a near-surface band: the CUDA Barnes-Hut winding approximation is
@@ -493,16 +525,14 @@ def test_clustertree_winding_sign_matches_exact_oracle(device):
     )
 
     device = torch.device(device)
-    vertices, faces = _uv_sphere()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _uv_sphere_mesh().to(device)
 
     torch.manual_seed(0)
     query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
     radius = query.norm(dim=-1)
     away = (radius - 1.0).abs() > 0.05  # exclude the near-surface shell
 
-    _, face_vertices, _ = _build_surface_mesh(vertices.float(), faces)
+    _, face_vertices, _ = _build_surface_mesh(mesh)
 
     sign_fast = _winding_number_sign_clustertree(face_vertices, query)
     sign_exact = _winding_number_sign(face_vertices, query)
@@ -524,16 +554,14 @@ def test_clustertree_winding_sign_non_watertight(device):
     )
 
     device = torch.device(device)
-    vertices, faces = _open_uv_sphere()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _open_uv_sphere_mesh().to(device)
 
     torch.manual_seed(1)
     query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
     radius = query.norm(dim=-1)
     away = (radius - 1.0).abs() > 0.1  # exclude near-surface / near-hole shell
 
-    _, face_vertices, _ = _build_surface_mesh(vertices.float(), faces)
+    _, face_vertices, _ = _build_surface_mesh(mesh)
 
     sign_fast = _winding_number_sign_clustertree(face_vertices, query)
     sign_exact = _winding_number_sign(face_vertices, query)
@@ -563,14 +591,13 @@ def test_sdf_winding_sign_correct_at_sharp_edges_grid(device):
     """Winding-number sign matches the analytic L-prism field (companion check)."""
     device = torch.device(device)
     thickness = 1.0
-    vertices, faces = _l_prism_thick(thickness)
-    vertices, faces = vertices.to(device), faces.to(device)
+    mesh = _l_prism_thick_mesh(thickness).to(device)
 
     query = _l_prism_probe_grid(device, thickness)
     gt_inside = _inside_l(query, thickness)
 
     sdf_out, _ = signed_distance_field_mesh(
-        vertices, faces, query, use_sign_winding_number=True
+        mesh, query, use_sign_winding_number=True
     )
 
     # Compare signs away from the surface. The default ClusterTree backend is a
@@ -593,14 +620,13 @@ def test_sdf_pseudo_normal_sign_correct_at_sharp_edges(device):
     """
     device = torch.device(device)
     thickness = 1.0
-    vertices, faces = _l_prism_thick(thickness)
-    vertices, faces = vertices.to(device), faces.to(device)
+    mesh = _l_prism_thick_mesh(thickness).to(device)
 
     query = _l_prism_probe_grid(device, thickness)
     gt_inside = _inside_l(query, thickness)
 
     sdf_out, _ = signed_distance_field_mesh(
-        vertices, faces, query, use_sign_winding_number=False
+        mesh, query, use_sign_winding_number=False
     )
 
     away = sdf_out.abs() > 0.05
@@ -651,12 +677,10 @@ def test_edge_pseudonormals_matches_unique_reference(device):
     from physicsnemo.mesh.spatial.sdf import _build_surface_mesh, _edge_pseudonormals
 
     device = torch.device(device)
-    vertices, faces = _uv_sphere()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _uv_sphere_mesh().to(device)
 
-    mesh, _, tri_faces = _build_surface_mesh(vertices.float(), faces)
-    face_normals = mesh.cell_normals.float()
+    work_mesh, _, tri_faces = _build_surface_mesh(mesh)
+    face_normals = work_mesh.cell_normals.float()
 
     got = _edge_pseudonormals(tri_faces, face_normals)
     expected = _edge_pseudonormals_unique_reference(tri_faces, face_normals)
@@ -694,15 +718,13 @@ def test_sdf_triton_nearest_matches_torch_reference():
     from physicsnemo.mesh.spatial.sdf import _build_surface_mesh, _nearest_face_bvh
 
     device = torch.device("cuda")
-    vertices, faces = _uv_sphere()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _uv_sphere_mesh().to(device)
 
     torch.manual_seed(0)
     query = (torch.rand(8192, 3, device=device) * 3.0 - 1.5).float()
 
-    mesh, face_vertices, _ = _build_surface_mesh(vertices.float(), faces)
-    bvh = BVH.from_mesh(mesh)
+    work_mesh, face_vertices, _ = _build_surface_mesh(mesh)
+    bvh = BVH.from_mesh(work_mesh)
 
     ref_dist_sq, _, ref_pt = _nearest_face_bvh(bvh, face_vertices, query, 1e8)
     tri_dist_sq, _, tri_pt = _sdf_triton.nearest_triangle_triton(
@@ -727,16 +749,14 @@ def test_sdf_triton_end_to_end_matches_reference(use_winding, monkeypatch):
     from physicsnemo.mesh.spatial import _sdf_triton
 
     device = torch.device("cuda")
-    vertices, faces = _uv_sphere()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _uv_sphere_mesh().to(device)
 
     torch.manual_seed(0)
     query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
 
     # Triton fast path (default dispatch on CUDA).
     sdf_triton, _ = signed_distance_field_mesh(
-        vertices, faces, query, use_sign_winding_number=use_winding
+        mesh, query, use_sign_winding_number=use_winding
     )
 
     # Force the pure-PyTorch nearest-triangle reference by disabling the Triton
@@ -744,7 +764,7 @@ def test_sdf_triton_end_to_end_matches_reference(use_winding, monkeypatch):
     # path in both cases.
     monkeypatch.setattr(_sdf_triton, "available", lambda: False)
     sdf_ref, _ = signed_distance_field_mesh(
-        vertices, faces, query, use_sign_winding_number=use_winding
+        mesh, query, use_sign_winding_number=use_winding
     )
 
     torch.testing.assert_close(sdf_triton, sdf_ref, atol=1e-4, rtol=1e-4)
@@ -763,9 +783,7 @@ def test_sdf_no_winding_path_is_sync_free():
     intentionally excluded -- its ClusterTree traversal still syncs.
     """
     device = torch.device("cuda")
-    vertices, faces = _uv_sphere()
-    vertices = vertices.to(device)
-    faces = faces.to(device)
+    mesh = _uv_sphere_mesh().to(device)
 
     torch.manual_seed(0)
     query = (torch.rand(8192, 3, device=device) * 3.0 - 1.5).float()
@@ -774,7 +792,7 @@ def test_sdf_no_winding_path_is_sync_free():
     # lazy module loading, caching-allocator growth) legitimately synchronize.
     # The guarded run below reuses the same query shape so no new autotune key or
     # allocation is triggered.
-    signed_distance_field_mesh(vertices, faces, query, use_sign_winding_number=False)
+    signed_distance_field_mesh(mesh, query, use_sign_winding_number=False)
     torch.cuda.synchronize()
 
     # ``error`` mode raises on *implicit* synchronizing ops (``.item()``,
@@ -785,9 +803,7 @@ def test_sdf_no_winding_path_is_sync_free():
     prev = torch.cuda.get_sync_debug_mode()
     torch.cuda.set_sync_debug_mode("error")
     try:
-        signed_distance_field_mesh(
-            vertices, faces, query, use_sign_winding_number=False
-        )
+        signed_distance_field_mesh(mesh, query, use_sign_winding_number=False)
     finally:
         torch.cuda.set_sync_debug_mode(prev)
     torch.cuda.synchronize()

--- a/test/mesh/spatial/test_mesh_sdf.py
+++ b/test/mesh/spatial/test_mesh_sdf.py
@@ -461,9 +461,7 @@ def test_sdf_pseudo_normal_sign_wrong_at_sharp_edges(device):
     reflex[:, 2] = _L_PRISM_HEIGHT * reflex[:, 2]
     query = torch.cat([box, reflex], dim=0).to(device)
 
-    sdf_out, _ = signed_distance_field_mesh(
-        mesh, query, use_sign_winding_number=False
-    )
+    sdf_out, _ = signed_distance_field_mesh(mesh, query, use_sign_winding_number=False)
 
     # The distance magnitude is correct; only the sign is in question. Compare to
     # the analytic interior away from the surface, where the sign is unambiguous.
@@ -497,9 +495,7 @@ def test_sdf_winding_sign_correct_at_sharp_edges(device):
     hi = torch.tensor([1.2, 1.2, _L_PRISM_HEIGHT + 0.2])
     query = (lo + (hi - lo) * torch.rand(40_000, 3)).to(device)
 
-    sdf_out, _ = signed_distance_field_mesh(
-        mesh, query, use_sign_winding_number=True
-    )
+    sdf_out, _ = signed_distance_field_mesh(mesh, query, use_sign_winding_number=True)
 
     # Exclude a near-surface band: the CUDA Barnes-Hut winding approximation is
     # only loose right at the surface (cf. test_winding_sign_triton_matches_exact).
@@ -596,9 +592,7 @@ def test_sdf_winding_sign_correct_at_sharp_edges_grid(device):
     query = _l_prism_probe_grid(device, thickness)
     gt_inside = _inside_l(query, thickness)
 
-    sdf_out, _ = signed_distance_field_mesh(
-        mesh, query, use_sign_winding_number=True
-    )
+    sdf_out, _ = signed_distance_field_mesh(mesh, query, use_sign_winding_number=True)
 
     # Compare signs away from the surface. The default ClusterTree backend is a
     # Barnes-Hut approximation whose winding number is only unreliable in a thin
@@ -625,9 +619,7 @@ def test_sdf_pseudo_normal_sign_correct_at_sharp_edges(device):
     query = _l_prism_probe_grid(device, thickness)
     gt_inside = _inside_l(query, thickness)
 
-    sdf_out, _ = signed_distance_field_mesh(
-        mesh, query, use_sign_winding_number=False
-    )
+    sdf_out, _ = signed_distance_field_mesh(mesh, query, use_sign_winding_number=False)
 
     away = sdf_out.abs() > 0.05
     expected = torch.where(


### PR DESCRIPTION
## Summary

This updates the not-yet-released Mesh SDF API so `signed_distance_field_mesh()` accepts a `Mesh` directly:

```python
sdf, hit_points = signed_distance_field_mesh(mesh, query_points)
```

The public function now validates non-empty 3D triangle surfaces, uses the float32 working representation required by the BVH and Triton paths, and preserves the query shape and dtype in its outputs. The docs, data transform, and external-aerodynamics recipe now use the mesh-native interface. A private array wrapper remains for debugging and comparisons with the replaced Warp API.

## Testing

`test/mesh/spatial/test_mesh_sdf.py` covers public/private parity, invalid and empty meshes, batched queries, finite search bands, both sign methods, and CUDA/Triton behavior.