### PR TITLE
Mesh: preserve attached-data dtypes in to_pyvista()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for full-dimensional (codimension-0) output.
 - `physicsnemo.mesh.remesh` now preserves the input mesh's device and floating
   dtype (the pyacvd/pyvista round-trip previously dropped them to CPU/float32).
+- `physicsnemo.mesh.io.to_pyvista` now preserves supported dtypes for attached
+  point, cell, and global data instead of narrowing every array to `float32`.
+  Reduced-precision floating-point values are promoted only as needed for VTK.
 - `physicsnemo.mesh`: `Mesh.to(<float dtype>)` and `DomainMesh.to(<float dtype>)`
   raised `TypeError: cells must have an int-like dtype` because the cast was applied
   to the integer `cells` tensor. A floating/complex dtype is now applied only to

--- a/physicsnemo/mesh/io/io_pyvista.py
+++ b/physicsnemo/mesh/io/io_pyvista.py
@@ -49,6 +49,19 @@ def _vtk_data_to_tensor_dict(data) -> dict[str, torch.Tensor]:  # noqa: ANN001
     return tensor_data
 
 
+def _tensor_to_vtk_numpy(tensor: torch.Tensor) -> np.ndarray:
+    """Convert tensor data without narrowing dtypes supported by PyVista."""
+    tensor = tensor.detach().cpu()
+    # VTK has no native real type below float32. PyVista represents complex
+    # values with two real components, but likewise only supports complex64
+    # and complex128 inputs.
+    if tensor.is_floating_point() and tensor.element_size() < 4:
+        tensor = tensor.to(dtype=torch.float32)
+    elif tensor.is_complex() and tensor.element_size() < 8:
+        tensor = tensor.to(dtype=torch.complex64)
+    return tensor.resolve_conj().resolve_neg().numpy()
+
+
 @require_version_spec("pyvista")
 def from_pyvista(
     pyvista_mesh: "pv.PolyData | pv.UnstructuredGrid | pv.PointSet",
@@ -400,7 +413,7 @@ def to_pyvista(
         (mesh.global_data, pv_mesh.field_data),
     ]:
         for k, v in source.items(include_nested=True, leaves_only=True):
-            arr = v.detach().float().cpu().numpy()
+            arr = _tensor_to_vtk_numpy(v)
             target[str(k)] = arr.reshape(arr.shape[0], -1) if arr.ndim > 2 else arr
 
     return pv_mesh

--- a/test/mesh/io/io_pyvista/test_to_pyvista_dtypes.py
+++ b/test/mesh/io/io_pyvista/test_to_pyvista_dtypes.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for dtype preservation when exporting mesh data to PyVista."""
+
+import numpy as np
+import pytest
+import torch
+
+from physicsnemo.mesh import Mesh
+
+pv = pytest.importorskip("pyvista")
+
+from physicsnemo.mesh.io import to_pyvista  # noqa: E402
+
+
+def _line_mesh(**kwargs) -> Mesh:
+    return Mesh(
+        points=torch.tensor([[0.0, 0.0], [1.0, 0.0]]),
+        cells=torch.tensor([[0, 1]]),
+        **kwargs,
+    )
+
+
+def test_preserves_supported_point_cell_and_global_data_dtypes():
+    large_ids = torch.tensor([2**40, 2**40 + 1], dtype=torch.int64)
+    mesh = _line_mesh(
+        point_data={
+            "large_ids": large_ids,
+            "flags": torch.tensor([True, False]),
+        },
+        cell_data={"weight": torch.tensor([1.25], dtype=torch.float64)},
+        global_data={
+            "phase": torch.tensor([1.0 + 2.0j], dtype=torch.complex64),
+        },
+    )
+
+    result = to_pyvista(mesh)
+
+    assert np.asarray(result.point_data["large_ids"]).dtype == np.int64
+    assert np.array_equal(result.point_data["large_ids"], large_ids.numpy())
+    assert np.asarray(result.point_data["flags"]).dtype == np.bool_
+    assert np.asarray(result.cell_data["weight"]).dtype == np.float64
+    assert np.asarray(result.field_data["phase"]).dtype == np.complex64
+    assert np.array_equal(
+        np.asarray(result.field_data["phase"]).reshape(-1),
+        mesh.global_data["phase"].numpy(),
+    )
+
+
+def test_resolves_lazy_conjugate_before_export():
+    values = torch.tensor([1.0 + 2.0j], dtype=torch.complex64).conj()
+
+    result = to_pyvista(_line_mesh(global_data={"phase": values}))
+
+    exported = np.asarray(result.field_data["phase"]).reshape(-1)
+    assert np.array_equal(exported, values.resolve_conj().numpy())
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_promotes_reduced_precision_real_data_to_float32(dtype):
+    values = torch.tensor([1.0, 2.0], dtype=dtype)
+
+    result = to_pyvista(_line_mesh(point_data={"value": values}))
+
+    exported = np.asarray(result.point_data["value"])
+    assert exported.dtype == np.float32
+    assert np.array_equal(exported, values.float().numpy())
+
+
+@pytest.mark.filterwarnings("ignore:ComplexHalf support is experimental")
+def test_promotes_reduced_precision_complex_data_to_complex64():
+    complex32 = getattr(torch, "complex32", None)
+    if complex32 is None:
+        pytest.skip("torch.complex32 is unavailable")
+    values = torch.tensor([1.0 + 2.0j, 3.0 - 4.0j], dtype=complex32)
+
+    result = to_pyvista(_line_mesh(point_data={"value": values}))
+
+    exported = np.asarray(result.point_data["value"])
+    assert exported.dtype == np.complex64
+    assert np.array_equal(exported, values.to(dtype=torch.complex64).numpy())


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Previously, `to_pyvista()` converted every attached point, cell, and global array to `float32`. This could lose precision for integers and `float64` data, and could discard the imaginary component of complex data.

This PR preserves dtypes that PyVista/VTK supports:

- Preserve boolean, integer, `float32`, `float64`, `complex64`, and `complex128` data.
- Promote `float16` and `bfloat16` to `float32`, and reduced-precision complex data to `complex64`.
- Resolve lazy conjugate and negative tensor views before NumPy conversion.
- Add coverage for point, cell, and global data, including large integers, complex values, reduced-precision inputs, and lazy conjugate views.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
