### PR TITLE
Mesh: fix Morton-code quantization edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   detached before `.numpy()`); and integer/bool data crashed (`safe_eps` on an
   integer dtype) or truncated via integer division during facet/scatter
   aggregation (now computed in a floating dtype).
+- `physicsnemo.mesh` Morton-code quantization now handles empty inputs, tiny
+  extents, half-precision coordinates, and one-dimensional endpoints correctly.
 - `physicsnemo.mesh`: fixed Loop subdivision pulling open boundaries inward (now
   applies the boundary/crease mask); subdivision zero-filling integer/bool
   `point_data` at new edge vertices (now inherits a parent label);

--- a/physicsnemo/mesh/spatial/bvh.py
+++ b/physicsnemo/mesh/spatial/bvh.py
@@ -79,16 +79,33 @@ def _compute_morton_codes(
 
     N, D = centroids.shape
     device = centroids.device
+    if D == 0:
+        raise ValueError("centroids must contain at least one spatial dimension")
+    if N == 0:
+        return torch.empty(0, dtype=torch.int64, device=device)
 
-    ### Bits per dimension: 63 // D keeps total code <= 63 bits (non-negative int64)
-    n_bits = 63 // D
+    ### Bits per dimension: keep the total code within non-negative int64. For
+    ### D=1, a 63-bit grid maximum rounds to 2^63 in floating point before the
+    ### int64 conversion. Limit that case to 62 bits to avoid overflow.
+    n_bits = min(62, 63 // D)
     max_val = (1 << n_bits) - 1
 
-    ### Quantize centroids to integer grid [0, 2^n_bits - 1]
-    cmin = centroids.min(dim=0).values  # (D,)
-    cmax = centroids.max(dim=0).values  # (D,)
-    extent = (cmax - cmin).clamp(min=1e-30)  # avoid division by zero
-    coords = ((centroids - cmin) / extent * max_val).long().clamp(0, max_val)  # (N, D)
+    ### Quantize centroids to integer grid [0, 2^n_bits - 1]. Half-precision
+    ### dtypes cannot represent this grid's scale, so normalize in at least
+    ### float32 while retaining float64 input precision.
+    quantization_dtype = (
+        torch.float64 if centroids.dtype == torch.float64 else torch.float32
+    )
+    quantization_points = centroids.to(quantization_dtype)
+    cmin = quantization_points.min(dim=0).values  # (D,)
+    cmax = quantization_points.max(dim=0).values  # (D,)
+    extent = cmax - cmin
+    # Preserve every representable nonzero extent. Constant axes have a zero
+    # numerator, so replacing only their zero denominator maps them to zero.
+    safe_extent = torch.where(extent != 0, extent, torch.ones_like(extent))
+    coords = (
+        ((quantization_points - cmin) / safe_extent * max_val).long().clamp(0, max_val)
+    )  # (N, D)
 
     ### Bit-interleave all dimensions: bit b of dim d -> position b*D + d.
     if device.type == "cuda":

--- a/test/mesh/spatial/test_bvh.py
+++ b/test/mesh/spatial/test_bvh.py
@@ -112,6 +112,35 @@ class TestMortonCodes:
         codes = _compute_morton_codes(points)
         assert (codes >= 0).all()
 
+    @pytest.mark.parametrize(
+        "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64]
+    )
+    def test_1d_maximum_endpoint_does_not_overflow(self, dtype):
+        """The maximum 1D coordinate must sort after interior coordinates."""
+        points = torch.tensor([[0.0], [0.5], [1.0]], dtype=dtype)
+
+        codes = _compute_morton_codes(points)
+
+        assert (codes >= 0).all()
+        assert codes[0] < codes[1] < codes[2]
+
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_low_precision_quantization_matches_float32_arithmetic(self, dtype):
+        points = torch.tensor(
+            [
+                [0.4961, 0.7695],
+                [0.0884, 0.1318],
+                [0.3066, 0.6328],
+                [0.4902, 0.8945],
+                [0.4551, 0.6328],
+            ],
+            dtype=dtype,
+        )
+
+        codes = _compute_morton_codes(points)
+
+        assert torch.equal(codes, _compute_morton_codes(points.float()))
+
     def test_spatial_locality_2d(self):
         """Nearby 2D points should have nearby morton codes."""
         # Two clusters: one near origin, one far away
@@ -157,15 +186,41 @@ class TestMortonCodes:
         """Morton codes work for a single point."""
         codes = _compute_morton_codes(torch.tensor([[1.0, 2.0, 3.0]]))
         assert codes.shape == (1,)
-        # Single point: all dimensions map to the same value, code = 0 or max
-        # Since min == max, extent is clamped, coordinates map to max_val
-        assert codes[0] >= 0
+        assert codes[0] == 0
 
     def test_identical_points(self):
         """All identical points produce the same code."""
         points = torch.ones(10, 3) * 5.0
         codes = _compute_morton_codes(points)
         assert (codes == codes[0]).all()
+
+    def test_tiny_nonzero_extents_preserve_distinct_float64_codes(self, device):
+        """Every representable nonzero extent must use the quantization grid."""
+        steps = torch.arange(5, dtype=torch.float64, device=device).unsqueeze(-1)
+        points = steps * torch.tensor(
+            [[1.0e-40, 2.0e-40, 3.0e-40]], dtype=torch.float64, device=device
+        )
+
+        codes = _compute_morton_codes(points)
+
+        assert len(torch.unique(codes)) == len(points)
+
+    def test_constant_axes_do_not_disturb_varying_axis(self, device):
+        points = torch.tensor(
+            [
+                [0.0, 7.0, -2.0],
+                [0.25, 7.0, -2.0],
+                [0.50, 7.0, -2.0],
+                [1.00, 7.0, -2.0],
+            ],
+            dtype=torch.float64,
+            device=device,
+        )
+
+        codes = _compute_morton_codes(points)
+
+        assert len(torch.unique(codes)) == len(points)
+        assert torch.equal(codes, codes.sort().values)
 
     def test_codes_are_deterministic_for_known_centroids(self):
         """Repeated CPU calls on known centroids produce identical codes."""
@@ -205,6 +260,18 @@ class TestMortonCodes:
         """1D input should be rejected."""
         with pytest.raises(ValueError, match="2D"):
             _compute_morton_codes(torch.rand(10))
+
+    def test_empty_input_returns_empty_codes(self, device):
+        points = torch.empty((0, 3), device=device)
+        codes = _compute_morton_codes(points)
+
+        assert codes.shape == (0,)
+        assert codes.dtype == torch.int64
+        assert codes.device == points.device
+
+    def test_rejects_zero_spatial_dimensions(self):
+        with pytest.raises(ValueError, match="at least one spatial dimension"):
+            _compute_morton_codes(torch.empty((2, 0)))
 
 
 ### Construction Tests ###


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Morton-code generation had a few edge cases that could collapse distinct points or produce invalid ordering: the one-dimensional upper endpoint could overflow `int64`, low-precision arithmetic could overflow during quantization, and the fixed extent clamp treated small but representable ranges as constant.

This PR:

- Quantizes in at least `float32`, while retaining `float64` input precision.
- Replaces only exactly zero extents, preserving tiny nonzero coordinate ranges.
- Limits one-dimensional quantization to 62 bits so all codes remain nonnegative `int64` values.
- Handles empty inputs and rejects inputs with no spatial dimension explicitly.
- Adds regression coverage for endpoints, low-precision inputs, tiny and constant extents, and empty inputs.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
