### PR TITLE
Mesh: support bfloat16 fields in marching_cubes()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or any multi-column grid, which also broke `repair.fix_orientation`). Parent-cell
   vertices are now sorted into a global order before tessellation (the
   Freudenthal-Kuhn subdivision), a no-op for already-sorted inputs.
+- `physicsnemo.mesh.generate.marching_cubes` now accepts `bfloat16` fields by
+  converting them to `float32` before crossing the NumPy boundary.
 - `physicsnemo.mesh.projections.extrude` now returns consistently oriented cells
   for full-dimensional (codimension-0) output.
 - `physicsnemo.mesh.remesh` now preserves the input mesh's device and floating

--- a/physicsnemo/mesh/generate/marching_cubes.py
+++ b/physicsnemo/mesh/generate/marching_cubes.py
@@ -18,7 +18,6 @@
 
 from typing import TYPE_CHECKING
 
-import numpy as np
 import torch
 import warp as wp
 from jaxtyping import Float
@@ -120,7 +119,9 @@ def marching_cubes(
                     f"size {field.shape[dim]} along dimension {dim}"
                 )
 
-    field_np = field.detach().cpu().numpy().astype(np.float32)
+    # Convert before crossing the NumPy boundary: NumPy has no bfloat16 dtype,
+    # so ``field.cpu().numpy().astype(...)`` raises before the cast can run.
+    field_np = field.detach().to(device="cpu", dtype=torch.float32).numpy()
     field_wp = wp.array(field_np)
 
     mc = wp.MarchingCubes(

--- a/test/mesh/generate/test_marching_cubes.py
+++ b/test/mesh/generate/test_marching_cubes.py
@@ -179,3 +179,11 @@ class TestMarchingCubesValidation:
     def test_rejects_4d_input(self):
         with pytest.raises(NotImplementedError, match="3D scalar fields"):
             marching_cubes(torch.randn(10, 10, 10, 10))
+
+    def test_accepts_bfloat16_field(self):
+        sdf, _ = _sphere_sdf(resolution=16)
+
+        mesh = marching_cubes(sdf.to(torch.bfloat16))
+
+        assert mesh.n_points > 0
+        assert mesh.points.dtype == torch.float32


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

`marching_cubes()` previously converted its input to NumPy before casting it to `float32`. NumPy cannot represent `bfloat16`, so those inputs failed before the cast was reached.

This PR converts the detached field to CPU `float32` before calling `.numpy()`, preserving the existing marching-cubes behavior for other inputs. It also adds regression coverage for a `bfloat16` signed-distance field.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
