### PR TITLE
Mesh: correct remeshing, repair, sampling, and smoothing docs

### DIFF
--- a/docs/api/mesh/remeshing.rst
+++ b/docs/api/mesh/remeshing.rst
@@ -7,18 +7,18 @@ Uniform remeshing via the ACVD (Approximate Centroidal Voronoi Diagram)
 clustering algorithm. Given a target number of clusters, the algorithm
 redistributes mesh vertices to produce a more uniform cell distribution.
 
-The approach is dimension-agnostic and works for any simplicial manifold:
+The current implementation wraps ``pyacvd`` and therefore supports only
+triangle surfaces (2D manifolds) embedded in 3D:
 
 1. Weight vertices by incident cell areas
 2. Initialize clusters via area-based region growing
 3. Remove spatially isolated cluster regions
 4. Reconstruct a simplified mesh from cluster adjacency
 
-.. note::
-
-   The output mesh may contain a small percentage (~0.5-1%) of non-manifold
-   edges, which is inherent to the face-mapping approach. Higher cluster
-   counts relative to mesh resolution produce better manifold quality.
+``n_clusters`` controls the approximate number of output vertices (one per
+cluster), not the number of triangles. The output cell count follows from the
+surface topology and is commonly close to twice the vertex count for a closed
+triangular surface.
 
 .. code:: python
 
@@ -27,7 +27,7 @@ The approach is dimension-agnostic and works for any simplicial manifold:
 
     mesh = sphere_icosahedral.load(subdivisions=3)
     remeshed = remesh(mesh, n_clusters=100)
-    print(remeshed.n_cells)  # approximately 200 triangles
+    print(remeshed.n_points)  # approximately 100 cluster centroids
 
 API Reference
 -------------

--- a/docs/api/mesh/repair.rst
+++ b/docs/api/mesh/repair.rst
@@ -22,25 +22,28 @@ For full control, use :func:`repair_mesh` or call individual functions.
 
 .. code:: python
 
-    from physicsnemo.mesh.repair import repair_mesh, clean_mesh
+    from physicsnemo.mesh.repair import clean_mesh, repair_mesh
 
-    # Quick cleanup
+    # Quick cleanup through the Mesh convenience API returns only the mesh
     clean = mesh.clean()
 
-    # Full repair pipeline
-    repaired = repair_mesh(mesh)
+    # Standalone cleanup and the full repair pipeline also return statistics
+    clean, clean_stats = clean_mesh(mesh)
+    repaired, repair_stats = repair_mesh(mesh)
 
     # Individual operations
     from physicsnemo.mesh.repair import (
-        merge_duplicate_points,
         remove_degenerate_cells,
         fix_orientation,
         fill_holes,
     )
-    mesh = merge_duplicate_points(mesh)
-    mesh = remove_degenerate_cells(mesh)
-    mesh = fix_orientation(mesh)
-    mesh = fill_holes(mesh)
+    mesh, degenerate_stats = remove_degenerate_cells(mesh)
+    mesh, orientation_stats = fix_orientation(mesh)
+    mesh, hole_stats = fill_holes(mesh)
+
+``merge_duplicate_points`` is a lower-level tensor API accepting separate
+``points``, ``cells``, and ``point_data`` arguments. Use ``mesh.clean()`` or
+``clean_mesh()`` for mesh-level duplicate-point cleanup.
 
 API Reference
 -------------

--- a/docs/api/mesh/sampling.rst
+++ b/docs/api/mesh/sampling.rst
@@ -10,7 +10,9 @@ This module provides two categories of functionality:
     Points are sampled using the
     `Dirichlet distribution <https://en.wikipedia.org/wiki/Dirichlet_distribution>`_
     to produce uniform random barycentric coordinates within each cell. Sampling
-    can be uniform per cell or weighted by cell area/volume.
+    returns one point for every supplied cell index; repeated indices request
+    multiple samples from a cell. Callers can draw those indices using cell
+    areas/volumes when they need samples uniform over the full mesh measure.
 
 **Data interpolation at query points**
     Given a set of arbitrary query points, find which mesh cell contains each
@@ -28,12 +30,18 @@ Both capabilities are also accessible as methods on
 
     mesh = sphere_icosahedral.load(subdivisions=3)
 
-    # Sample 10000 random points on the surface
-    sampled_mesh = mesh.sample_random_points_on_cells(n_points=10000)
-    print(sampled_mesh.points.shape)  # (10000, 3)
+    # Sample 10000 points uniformly over surface area. The method returns a
+    # tensor of coordinates, not a new Mesh.
+    import torch
+    cell_indices = torch.multinomial(
+        mesh.cell_areas / mesh.cell_areas.sum(),
+        num_samples=10000,
+        replacement=True,
+    )
+    sampled_points = mesh.sample_random_points_on_cells(cell_indices)
+    print(sampled_points.shape)  # (10000, 3)
 
     # Interpolate data at arbitrary query points
-    import torch
     query_points = torch.randn(500, 3)
     mesh.point_data["height"] = mesh.points[:, 2]
     result = mesh.sample_data_at_points(query_points, data_source="points")

--- a/docs/api/mesh/smoothing.rst
+++ b/docs/api/mesh/smoothing.rst
@@ -8,8 +8,10 @@ geometric features.
 
 Provides
 `Laplacian smoothing <https://en.wikipedia.org/wiki/Laplacian_smoothing>`_,
-which iteratively moves each vertex toward the centroid of its neighbors.
-Boundary vertices are held fixed to preserve the mesh boundary.
+which iteratively moves each vertex toward a weighted average of its neighbors.
+Codimension-one manifolds of dimension at least 2 use cotangent weights; other
+supported mesh types use uniform weights. Boundary vertices are held fixed by
+default.
 
 .. code:: python
 
@@ -17,7 +19,7 @@ Boundary vertices are held fixed to preserve the mesh boundary.
     from physicsnemo.mesh.primitives.surfaces import sphere_icosahedral
 
     mesh = sphere_icosahedral.load(subdivisions=2)
-    smoothed = smooth_laplacian(mesh, iterations=10)
+    smoothed = smooth_laplacian(mesh, n_iter=10)
 
 API Reference
 -------------

--- a/physicsnemo/mesh/remeshing/__init__.py
+++ b/physicsnemo/mesh/remeshing/__init__.py
@@ -36,7 +36,7 @@ repeat).
 Example:
     >>> from physicsnemo.mesh.primitives.surfaces import sphere_icosahedral
     >>> mesh = sphere_icosahedral.load(subdivisions=3)
-    >>> # Remesh a triangle mesh to ~100 triangles
+    >>> # Remesh a triangle mesh to ~100 vertices (cluster centroids)
     >>> remeshed = remesh(mesh, n_clusters=100)
     >>> assert remeshed.n_cells > 0
 """

--- a/physicsnemo/mesh/remeshing/_remeshing.py
+++ b/physicsnemo/mesh/remeshing/_remeshing.py
@@ -43,9 +43,9 @@ def remesh(
 ) -> "Mesh":
     """Uniform remeshing of a 2D triangle surface (in 3D) via clustering.
 
-    Creates a simplified mesh with approximately n_clusters cells uniformly
-    distributed across the geometry. Uses the ACVD (Approximate Centroidal
-    Voronoi Diagram) clustering algorithm.
+    Creates a simplified mesh with approximately ``n_clusters`` vertices
+    uniformly distributed across the geometry. Uses the ACVD (Approximate
+    Centroidal Voronoi Diagram) clustering algorithm.
 
     The algorithm:
     1. Weights vertices by their dual volumes (Voronoi areas)
@@ -61,13 +61,13 @@ def remesh(
     mesh : Mesh
         Input mesh to remesh
     n_clusters : int
-        Target number of output cells. The actual number may vary
+        Target number of output vertices. The actual number may vary
         slightly depending on mesh topology.
 
     Returns
     -------
     Mesh
-        Remeshed mesh with approximately n_clusters cells. The vertices are
+        Remeshed mesh with approximately ``n_clusters`` vertices. The vertices are
         cluster centroids, and cells connect adjacent clusters.
 
     Raises
@@ -82,7 +82,7 @@ def remesh(
     >>> from physicsnemo.mesh.primitives.surfaces import sphere_icosahedral
     >>> from physicsnemo.mesh.remeshing import remesh
     >>> mesh = sphere_icosahedral.load(subdivisions=3)
-    >>> # Remesh a triangle mesh to ~100 triangles
+    >>> # Remesh a triangle mesh to approximately 100 cluster centroids
     >>> simplified = remesh(mesh, n_clusters=100)
     >>> assert simplified.n_cells > 0
 

--- a/physicsnemo/mesh/smoothing/laplacian.py
+++ b/physicsnemo/mesh/smoothing/laplacian.py
@@ -115,8 +115,8 @@ def smooth_laplacian(
 
     Notes
     -----
-    - Cotangent weights are used for codimension-1 manifolds (surfaces, curves)
-    - Uniform weights are used for higher codimension or volumetric meshes
+    - Cotangent weights are used for codimension-1 manifolds of dimension >= 2
+    - Uniform weights are used for curves, higher codimension, or volumetric meshes
     - Feature detection only works for codimension-1 manifolds where normals exist
     - Cell connectivity and all data fields are preserved (only points move)
     """


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Several mesh API examples and docstrings currently disagree with the implemented interfaces. Some examples fail outright, while others describe the wrong return type or parameter semantics.

This documentation-only PR:

- Clarifies that ACVD remeshing supports triangle surfaces embedded in 3D and that `n_clusters` targets output vertices, not triangles.
- Corrects repair examples to distinguish `Mesh.clean()` from standalone functions that return `(mesh, stats)`.
- Shows that `sample_random_points_on_cells()` accepts cell indices and returns a coordinate tensor, including area-weighted sampling.
- Uses the correct `n_iter` smoothing argument and documents when cotangent versus uniform weights are used.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
