### PR TITLE
Rope opt

### DIFF
--- a/docs/api/nn/layers/rope.rst
+++ b/docs/api/nn/layers/rope.rst
@@ -1,0 +1,6 @@
+Rotary Position Embeddings (RoPE)
+==================================
+
+.. automodule:: physicsnemo.nn.module.rope
+   :members:
+   :show-inheritance:

--- a/docs/api/physicsnemo.nn.layers.rst
+++ b/docs/api/physicsnemo.nn.layers.rst
@@ -14,6 +14,7 @@ PhysicsNeMo Layers
    nn/layers/fully_connected_mlp
    nn/layers/normalization
    nn/layers/resampling_interpolation
+   nn/layers/rope
    nn/layers/regularization
    nn/layers/specialized
    nn/layers/graph_geometry

--- a/physicsnemo/models/dit/dit.py
+++ b/physicsnemo/models/dit/dit.py
@@ -286,7 +286,7 @@ class DiT(Module):
 
         # Constructor-time attention kwargs (copied so the caller's dict is not
         # mutated). The mask-token backends need to allocate their learned mask
-        # parameter. RoPE tables are NOT built per block: the model owns a single
+        # parameter. RoPE tables are not built per block: the model owns a single
         # RotaryEmbedding2DTables provider (below) and passes its tables into
         # every block's forward, so the tables are built, stored, and — under
         # domain parallelism — sharded exactly once for the whole model.

--- a/physicsnemo/models/dit/dit.py
+++ b/physicsnemo/models/dit/dit.py
@@ -30,6 +30,7 @@ from physicsnemo.nn import (
     ConditioningEmbedderType,
     DetokenizerModuleBase,
     DiTBlock,
+    RotaryEmbedding2DTables,
     TokenizerModuleBase,
     get_conditioning_embedder,
     get_detokenizer,
@@ -284,12 +285,21 @@ class DiT(Module):
             )
 
         # Constructor-time attention kwargs (copied so the caller's dict is not
-        # mutated). RoPE attention needs the latent grid at construction so its
-        # cos/sin tables can be precomputed; the mask-token backends need to
-        # allocate their learned mask parameter.
+        # mutated). The mask-token backends need to allocate their learned mask
+        # parameter. RoPE tables are NOT built per block: the model owns a single
+        # RotaryEmbedding2DTables provider (below) and passes its tables into
+        # every block's forward, so the tables are built, stored, and — under
+        # domain parallelism — sharded exactly once for the whole model.
         attn_kwargs = dict(attn_kwargs)
-        if attention_backend == "natten2d_rope":
-            attn_kwargs["latent_hw"] = latent_hw
+        self._is_rope = attention_backend == "natten2d_rope"
+        self.rope = None
+        if self._is_rope:
+            rope_theta = attn_kwargs.pop("rope_theta", 10000.0)
+            self.rope = RotaryEmbedding2DTables(
+                head_dim=hidden_size // num_heads,
+                latent_hw=latent_hw,
+                theta=rope_theta,
+            )
         if use_nan_mask_tokens:
             attn_kwargs["use_mask_token"] = True
 
@@ -581,6 +591,14 @@ class DiT(Module):
         c = self.conditioning_embedder(t, condition=condition)  # (B, D)
 
         block_attn_kwargs = {**self.attn_kwargs_forward, **attn_kwargs}
+        if self._is_rope:
+            # Fetch the shared RoPE tables once and pass them into every block's
+            # forward. latent_hw comes from block_attn_kwargs (fixed at the
+            # model's latent grid, or overridden by the caller for variable-res
+            # inference), so the provider rebuilds only when the shape changes.
+            rope_cos, rope_sin = self.rope(block_attn_kwargs.get("latent_hw"))
+            block_attn_kwargs["rope_cos"] = rope_cos
+            block_attn_kwargs["rope_sin"] = rope_sin
         if invalid_mask is not None:
             # Reduce the (B, *spatial) pixel mask to a (B, L) token mask aligned
             # with the token sequence. Under domain parallelism invalid_mask is a

--- a/physicsnemo/models/dit/dit.py
+++ b/physicsnemo/models/dit/dit.py
@@ -593,10 +593,11 @@ class DiT(Module):
         block_attn_kwargs = {**self.attn_kwargs_forward, **attn_kwargs}
         if self._is_rope:
             # Fetch the shared RoPE tables once and pass them into every block's
-            # forward. latent_hw comes from block_attn_kwargs (fixed at the
-            # model's latent grid, or overridden by the caller for variable-res
-            # inference), so the provider rebuilds only when the shape changes.
-            rope_cos, rope_sin = self.rope(block_attn_kwargs.get("latent_hw"))
+            # forward. Only forward a latent_hw *override* explicitly supplied by
+            # the caller (variable-resolution inference); the fixed
+            # construction-time grid stays None so the provider returns its
+            # prebuilt tables with no per-call shape comparison on the hot path.
+            rope_cos, rope_sin = self.rope(attn_kwargs.get("latent_hw"))
             block_attn_kwargs["rope_cos"] = rope_cos
             block_attn_kwargs["rope_sin"] = rope_sin
         if invalid_mask is not None:

--- a/physicsnemo/nn/__init__.py
+++ b/physicsnemo/nn/__init__.py
@@ -137,8 +137,8 @@ from .module.resample_layers import (
     UpSample3D,
 )
 from .module.rope import (
-    RotaryPositionEmbedding1D,
-    RotaryPositionEmbedding2D,
+    RotaryEmbedding1DTables,
+    RotaryEmbedding2DTables,
     apply_rotary_pos_emb,
     build_axial_rope_cos_sin_2d,
     build_rope_cos_sin_1d,

--- a/physicsnemo/nn/module/__init__.py
+++ b/physicsnemo/nn/module/__init__.py
@@ -107,8 +107,8 @@ from .resample_layers import (
     UpSample3D,
 )
 from .rope import (
-    RotaryPositionEmbedding1D,
-    RotaryPositionEmbedding2D,
+    RotaryEmbedding1DTables,
+    RotaryEmbedding2DTables,
     apply_rotary_pos_emb,
     build_axial_rope_cos_sin_2d,
     build_rope_cos_sin_1d,

--- a/physicsnemo/nn/module/dit_layers.py
+++ b/physicsnemo/nn/module/dit_layers.py
@@ -580,12 +580,12 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
         Input tensor of shape :math:`(B, L, D)`.
     latent_hw : Tuple[int, int]
         The height and width of the 2D latent space for reshaping.
-    invalid_token_mask : torch.Tensor, optional
-        See :class:`Natten2DSelfAttention`.
     rope_cos, rope_sin : torch.Tensor
         Axial 2D RoPE tables of shape :math:`(h, w, head\_dim)` from a
         :class:`~physicsnemo.nn.module.rope.RotaryEmbedding2DTables` provider.
-        Required; a :class:`ValueError` is raised if not supplied.
+        Required.
+    invalid_token_mask : torch.Tensor, optional
+        See :class:`Natten2DSelfAttention`.
 
     Outputs
     -------
@@ -608,23 +608,15 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
         self,
         x: Float[torch.Tensor, "batch sequence hidden_size"],
         latent_hw: Tuple[int, int],
+        rope_cos: Float[torch.Tensor, "h w head_dim"],
+        rope_sin: Float[torch.Tensor, "h w head_dim"],
         invalid_token_mask: Optional[
             Union[
                 Float[torch.Tensor, " sequence"],
                 Float[torch.Tensor, "batch sequence"],
             ]
         ] = None,
-        rope_cos: Optional[Float[torch.Tensor, "h w head_dim"]] = None,
-        rope_sin: Optional[Float[torch.Tensor, "h w head_dim"]] = None,
     ) -> Float[torch.Tensor, "batch sequence hidden_size"]:
-        if rope_cos is None or rope_sin is None:
-            raise ValueError(
-                "RopeNatten2DSelfAttention requires the rope_cos/rope_sin tables "
-                "to be passed to forward; they are owned by the top-level model's "
-                "RotaryEmbedding2DTables provider (the DiT 'natten2d_rope' backend "
-                "supplies them automatically). None were supplied."
-            )
-
         B, N, C = x.shape
         h, w = int(latent_hw[0]), int(latent_hw[1])
         if not torch.compiler.is_compiling():

--- a/physicsnemo/nn/module/dit_layers.py
+++ b/physicsnemo/nn/module/dit_layers.py
@@ -587,7 +587,7 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
         :class:`~physicsnemo.nn.module.rope.RotaryEmbedding2DTables` provider.
         Required; a :class:`ValueError` is raised if not supplied.
 
-    Returns
+    Outputs
     -------
     torch.Tensor
         Output tensor of shape :math:`(B, L, D)`.
@@ -627,10 +627,17 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
 
         B, N, C = x.shape
         h, w = int(latent_hw[0]), int(latent_hw[1])
-        if not torch.compiler.is_compiling() and N != h * w:
-            raise ValueError(
-                f"Sequence length must be {h * w} based on latent_hw={latent_hw}, but got {N}"
-            )
+        if not torch.compiler.is_compiling():
+            if N != h * w:
+                raise ValueError(
+                    f"Sequence length must be {h * w} based on latent_hw={latent_hw}, but got {N}"
+                )
+            expected = (h, w, self.head_dim)
+            if tuple(rope_cos.shape) != expected or tuple(rope_sin.shape) != expected:
+                raise ValueError(
+                    f"Expected rope_cos/rope_sin of shape {expected}, but got "
+                    f"rope_cos={tuple(rope_cos.shape)}, rope_sin={tuple(rope_sin.shape)}"
+                )
 
         # Overwrite invalid spatial tokens with the learned mask token before QKV.
         x = self._apply_mask_token(x, invalid_token_mask)

--- a/physicsnemo/nn/module/dit_layers.py
+++ b/physicsnemo/nn/module/dit_layers.py
@@ -35,10 +35,7 @@ from physicsnemo.nn.module.hpx.tokenizer import (
     HEALPixPatchTokenizer,
 )
 from physicsnemo.nn.module.mlp_layers import Mlp
-from physicsnemo.nn.module.rope import (
-    apply_rotary_pos_emb,
-    build_axial_rope_cos_sin_2d,
-)
+from physicsnemo.nn.module.rope import apply_rotary_pos_emb
 from physicsnemo.nn.module.utils import PatchEmbed2D
 
 te = OptionalImport("transformer_engine.pytorch")
@@ -105,7 +102,7 @@ def get_attention(
     num_heads : int
         Number of attention heads.
     attention_backend : Literal["transformer_engine", "timm", "natten2d", "natten2d_rope"]
-        One of ``"timm"``, ``"transformer_engine"``, ``"natten2d"``, or ``"natten2d_rope"`` to select between pre-defined attention modules. ``"natten2d_rope"`` is :class:`Natten2DSelfAttention` with axial 2D rotary position embeddings (see :class:`RopeNatten2DSelfAttention`) and requires ``latent_hw`` in ``attn_kwargs``.
+        One of ``"timm"``, ``"transformer_engine"``, ``"natten2d"``, or ``"natten2d_rope"`` to select between pre-defined attention modules. ``"natten2d_rope"`` is :class:`Natten2DSelfAttention` with axial 2D rotary position embeddings (see :class:`RopeNatten2DSelfAttention`); its cos/sin tables are supplied at ``forward`` time (as ``rope_cos`` / ``rope_sin``) by the owning model, which holds a single :class:`~physicsnemo.nn.module.rope.RotaryEmbedding2DTables` provider, so it is not usable standalone.
     attn_drop_rate : float, optional, default=0.0
         The dropout rate for the attention operation.
     proj_drop_rate : float, optional, default=0.0
@@ -556,22 +553,23 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
     used, the model should disable any additive positional embedding to avoid
     double-counting the position signal.
 
-    The cos/sin tables are precomputed at construction so that
-    :func:`torch.compile` sees a stable forward graph. They are stored as
-    ``persistent=False`` buffers because they are deterministically rebuilt from
-    ``(latent_hw, head_dim, rope_theta)``; for domain-parallel training they are
-    built at the global spatial size and sharded along height by
-    ``distribute_module``, so each rank holds the rows with globally-correct
-    frequencies and no explicit rank offset is needed in model code.
+    This block does **not** own the cos/sin tables. The tables are owned by a
+    single :class:`~physicsnemo.nn.module.rope.RotaryEmbedding2DTables` provider
+    held by the top-level model (e.g. :class:`~physicsnemo.models.dit.DiT`), and
+    are passed into :meth:`forward` as the ``rope_cos`` / ``rope_sin`` keyword
+    arguments. Sharing one provider across all blocks means the tables are
+    built, stored, and — under domain parallelism — sharded exactly once for the
+    whole model instead of once per block.
+
+    Because the tables are a required forward input, this block cannot be used in
+    isolation: it must be driven by a model that supplies the tables (the DiT
+    ``natten2d_rope`` backend does this automatically). For domain-parallel
+    training the provider builds the tables at the global spatial size and shards
+    them, so each rank receives rows with globally-correct
+    frequencies and no explicit rank offset is needed here.
 
     Parameters
     ----------
-    latent_hw : Tuple[int, int]
-        Spatial size :math:`(h, w)` of the token grid used to precompute the
-        cos/sin tables. For inference at a different shape, :meth:`forward`
-        rebuilds the tables in place (off the ``torch.compile`` path).
-    rope_theta : float, optional, default=10000.0
-        Base used for the RoPE frequency schedule.
     *args, **kwargs
         Forwarded to :class:`Natten2DSelfAttention` (e.g. ``attn_kernel``,
         ``qk_norm``, ``use_mask_token``).
@@ -584,6 +582,10 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
         The height and width of the 2D latent space for reshaping.
     invalid_token_mask : torch.Tensor, optional
         See :class:`Natten2DSelfAttention`.
+    rope_cos, rope_sin : torch.Tensor
+        Axial 2D RoPE tables of shape :math:`(h, w, head\_dim)` from a
+        :class:`~physicsnemo.nn.module.rope.RotaryEmbedding2DTables` provider.
+        Required; a :class:`ValueError` is raised if not supplied.
 
     Returns
     -------
@@ -594,8 +596,6 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
     def __init__(
         self,
         *args: Any,
-        latent_hw: Tuple[int, int],
-        rope_theta: float = 10000.0,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
@@ -603,32 +603,6 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
             raise ValueError(
                 f"head_dim={self.head_dim} must be divisible by 4 for axial 2D RoPE."
             )
-        self.rope_theta = float(rope_theta)
-        self._latent_hw: Tuple[int, int] = (int(latent_hw[0]), int(latent_hw[1]))
-
-        cos, sin = build_axial_rope_cos_sin_2d(
-            *self._latent_hw, self.head_dim, theta=self.rope_theta
-        )
-        # persistent=False: not in state_dict (rebuilt deterministically at
-        # __init__ from latent_hw + head_dim + theta), so checkpoints stay lean.
-        self.register_buffer("rope_cos", cos, persistent=False)  # (h, w, head_dim)
-        self.register_buffer("rope_sin", sin, persistent=False)  # (h, w, head_dim)
-
-    def _rebuild_for_shape(self, h: int, w: int) -> None:
-        r"""Rebuild the RoPE buffers for a new latent shape.
-
-        Reached only when :meth:`forward` is called with a ``latent_hw`` that
-        differs from construction (e.g. variable-resolution inference); not part
-        of the training-time hot path.
-        """
-        target_dtype = self.rope_cos.dtype
-        target_device = self.rope_cos.device
-        cos, sin = build_axial_rope_cos_sin_2d(
-            h, w, self.head_dim, theta=self.rope_theta, device=target_device
-        )
-        self.register_buffer("rope_cos", cos.to(dtype=target_dtype), persistent=False)
-        self.register_buffer("rope_sin", sin.to(dtype=target_dtype), persistent=False)
-        self._latent_hw = (int(h), int(w))
 
     def forward(
         self,
@@ -640,15 +614,23 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
                 Float[torch.Tensor, "batch sequence"],
             ]
         ] = None,
+        rope_cos: Optional[Float[torch.Tensor, "h w head_dim"]] = None,
+        rope_sin: Optional[Float[torch.Tensor, "h w head_dim"]] = None,
     ) -> Float[torch.Tensor, "batch sequence hidden_size"]:
+        if rope_cos is None or rope_sin is None:
+            raise ValueError(
+                "RopeNatten2DSelfAttention requires the rope_cos/rope_sin tables "
+                "to be passed to forward; they are owned by the top-level model's "
+                "RotaryEmbedding2DTables provider (the DiT 'natten2d_rope' backend "
+                "supplies them automatically). None were supplied."
+            )
+
         B, N, C = x.shape
         h, w = int(latent_hw[0]), int(latent_hw[1])
         if not torch.compiler.is_compiling() and N != h * w:
             raise ValueError(
                 f"Sequence length must be {h * w} based on latent_hw={latent_hw}, but got {N}"
             )
-        if (h, w) != self._latent_hw:
-            self._rebuild_for_shape(h, w)
 
         # Overwrite invalid spatial tokens with the learned mask token before QKV.
         x = self._apply_mask_token(x, invalid_token_mask)
@@ -666,8 +648,8 @@ class RopeNatten2DSelfAttention(Natten2DSelfAttention):
 
         # cos/sin: (h, w, head_dim) -> (1, 1, h, w, head_dim) broadcasts over
         # batch and head axes. apply_rotary_pos_emb rotates in fp32 internally.
-        cos = self.rope_cos.unsqueeze(0).unsqueeze(0)
-        sin = self.rope_sin.unsqueeze(0).unsqueeze(0)
+        cos = rope_cos.unsqueeze(0).unsqueeze(0)
+        sin = rope_sin.unsqueeze(0).unsqueeze(0)
         q_rot = apply_rotary_pos_emb(q_2d, cos, sin)
         k_rot = apply_rotary_pos_emb(k_2d, cos, sin)
 

--- a/physicsnemo/nn/module/rope.py
+++ b/physicsnemo/nn/module/rope.py
@@ -302,7 +302,7 @@ class RotaryEmbedding2DTables(Module):
         the in-place rebuild replaces the sharded buffers with plain tensors, so
         it is only appropriate for single-device variable-resolution inference.
 
-    Returns
+    Outputs
     -------
     Tuple[torch.Tensor, torch.Tensor]
         ``(rope_cos, rope_sin)``, each of shape :math:`(h, w, head\_dim)`.
@@ -349,7 +349,7 @@ class RotaryEmbedding2DTables(Module):
         self.register_buffer("rope_cos", cos, persistent=False)  # (h, w, head_dim)
         self.register_buffer("rope_sin", sin, persistent=False)  # (h, w, head_dim)
 
-    def maybe_rebuild(self, h: int, w: int) -> None:
+    def _maybe_rebuild(self, h: int, w: int) -> None:
         r"""Rebuild the cos/sin tables for a new latent shape if it changed.
 
         Reached only when :meth:`forward` is called with a ``latent_hw`` that
@@ -375,7 +375,7 @@ class RotaryEmbedding2DTables(Module):
         Float[torch.Tensor, "h w head_dim"],
     ]:
         if latent_hw is not None:
-            self.maybe_rebuild(int(latent_hw[0]), int(latent_hw[1]))
+            self._maybe_rebuild(int(latent_hw[0]), int(latent_hw[1]))
         return self.rope_cos, self.rope_sin
 
 
@@ -415,7 +415,7 @@ class RotaryEmbedding1DTables(Module):
         Number of leading positions to return. If ``None``, the full
         ``max_seq_len`` table is returned.
 
-    Returns
+    Outputs
     -------
     Tuple[torch.Tensor, torch.Tensor]
         ``(cos, sin)``, each of shape :math:`(seq\_len, head\_dim)`.

--- a/physicsnemo/nn/module/rope.py
+++ b/physicsnemo/nn/module/rope.py
@@ -27,29 +27,38 @@ position is woven into the rotation of each head's Q/K projections.
 
 This module exposes two levels of API:
 
-**Ready-to-use modules** (bring-your-own-attention):
-  - :class:`RotaryPositionEmbedding2D` — axial 2D RoPE for global attention over
-    a flattened :math:`h \times w` token grid (ViT / SDPA style, shape
-    :math:`(B, \text{heads}, h \cdot w, head\_dim)`).
-  - :class:`RotaryPositionEmbedding1D` — standard 1D sequence RoPE for general
-    transformers (shape :math:`(B, \text{heads}, \text{seq}, head\_dim)`).
+**Shared table-provider modules** (owners of the cos/sin tables):
+  - :class:`RotaryEmbedding2DTables` — owns axial 2D RoPE cos/sin tables for an
+    :math:`h \times w` token grid, in explicit ``(h, w, head_dim)`` layout.
+  - :class:`RotaryEmbedding1DTables` — owns standard 1D sequence RoPE cos/sin
+    tables of shape ``(max_seq_len, head_dim)``.
+
+  A provider holds *no* projections and applies *no* rotation itself: its
+  ``forward`` simply returns the ``(cos, sin)`` tables. The intended pattern is
+  that a top-level, multi-block model constructs a *single* provider and passes
+  the returned tables into every attention block's ``forward`` (which rotates
+  Q/K with the functional :func:`apply_rotary_pos_emb`), so the tables are
+  built, stored, and — under domain parallelism — sharded exactly once instead
+  of once per block. See
+  :class:`~physicsnemo.nn.module.dit_layers.RopeNatten2DSelfAttention` and
+  :class:`~physicsnemo.models.dit.DiT` for a reference wiring.
 
 **Low-level functional helpers** (:func:`build_axial_rope_cos_sin_2d`,
 :func:`build_rope_cos_sin_1d`, :func:`apply_rotary_pos_emb`):
-  Used internally by the modules above and by attention implementations that
+  Used internally by the providers above and by attention implementations that
   need direct control over the table layout (e.g. NATTEN windowed attention,
   which keeps explicit spatial ``(h, w)`` dimensions, or domain-parallel
   paths that shard the tables across GPUs).
 
 Choosing the right API
 ----------------------
-* Writing a custom attention block that takes a *flattened* sequence from a 2D
-  grid?  Use :class:`RotaryPositionEmbedding2D`.
-* Writing a general-sequence transformer?  Use :class:`RotaryPositionEmbedding1D`.
-* Implementing NATTEN windowed attention or need sharded / domain-parallel
-  tables?  Use the functional helpers directly (see
-  :class:`~physicsnemo.nn.module.dit_layers.RopeNatten2DSelfAttention` for a
-  reference implementation).
+* Building a multi-block transformer (2D grid or 1D sequence)?  Construct one
+  :class:`RotaryEmbedding2DTables` / :class:`RotaryEmbedding1DTables` at the top
+  level of the model and share its tables across every block, applying them
+  with :func:`apply_rotary_pos_emb`.
+* Implementing a single attention block or need full control over the table
+  layout?  Call the functional helpers directly and apply them with
+  :func:`apply_rotary_pos_emb`.
 
 Math (axial 2D RoPE)
 --------------------
@@ -216,11 +225,11 @@ def apply_rotary_pos_emb(
 
     Call this directly when you manage the cos/sin tables
     yourself — for example, inside a custom NATTEN or domain-parallel attention
-    block where you build the tables with :func:`build_axial_rope_cos_sin_2d`
-    or :func:`build_rope_cos_sin_1d` and need to apply them independently to
-    queries and keys.  If you are using :class:`RotaryPositionEmbedding2D` or
-    :class:`RotaryPositionEmbedding1D`, those modules call this function
-    internally and you do not need to invoke it yourself.
+    block where you obtain the tables from a
+    :class:`RotaryEmbedding2DTables` / :class:`RotaryEmbedding1DTables` provider
+    (or build them with :func:`build_axial_rope_cos_sin_2d` /
+    :func:`build_rope_cos_sin_1d`) and need to apply them independently to
+    queries and keys.
 
     Parameters
     ----------
@@ -251,37 +260,28 @@ def apply_rotary_pos_emb(
     return (x * cos + rotate_half * sin).to(in_dtype)
 
 
-class RotaryPositionEmbedding2D(Module):
-    r"""Axial 2D rotary position embedding for flattened-sequence attention.
+class RotaryEmbedding2DTables(Module):
+    r"""Shared owner of axial 2D RoPE cos/sin tables for an :math:`h \times w` grid.
 
-    Encodes the 2D spatial position :math:`(row, col)` of
-    each token by rotating its query and key vectors before the attention
-    dot-product.  The first half of ``head_dim`` is rotated by the row index;
-    the second half by the column index.  Because only the *relative* rotation
-    between query and key enters the dot-product, attention scores are
-    automatically sensitive to relative 2D position — no learned positional
-    vectors are added to the token features.
+    This module *owns* the cos/sin tables and nothing else: it holds no
+    projections and applies no rotation. Its :meth:`forward` returns the
+    ``(cos, sin)`` tables in explicit ``(h, w, head_dim)`` spatial layout, which
+    a consumer applies to its query/key with :func:`apply_rotary_pos_emb`.
 
-    Use it when you are building a *custom attention module* that operates
-    on a *flattened 2D token grid* in the standard
-    :math:`(B, \text{heads}, N, head\_dim)` layout where
-    :math:`N = h \times w`.  Typical examples:
+    The intended pattern is that a top-level, multi-block model constructs a
+    *single* instance and passes the returned tables into every attention
+    block's ``forward`` (see
+    :class:`~physicsnemo.nn.module.dit_layers.RopeNatten2DSelfAttention` and
+    :class:`~physicsnemo.models.dit.DiT`). Building, storing, and — under domain
+    parallelism — sharding the tables then happens exactly once for the whole
+    model instead of once per block.
 
-    * Vision-transformer (ViT) style full-sequence
-      :func:`torch.nn.functional.scaled_dot_product_attention`.
-    * Custom ``timm``-style transformer blocks.
-    * Any attention block that receives a flat token sequence but should
-      respect 2D spatial geometry.
-
-    When *not* to use this class:
-
-    * *NATTEN windowed attention* keeps the spatial axes explicit
-      :math:`(B, h, w, \text{heads}, head\_dim)`, so it needs tables with that
-      layout; use the functional helpers or
-      :class:`~physicsnemo.nn.module.dit_layers.RopeNatten2DSelfAttention`
-      directly.
-    * *Domain-parallel / sharded* attention needs tables that can be sliced
-      along the ``h`` or ``w`` dimension; again use the functional helpers.
+    The tables are stored as ``persistent=False`` buffers named ``rope_cos`` /
+    ``rope_sin``: they are deterministically reconstructed from
+    ``(latent_hw, head_dim, theta)`` and do not need to be saved with the model
+    weights. The names and the height-first ``(h, w, head_dim)`` layout are
+    chosen so that domain-parallel sharding along dimension 0 (height) gives
+    each rank globally-correct rows with no explicit rank offset in model code.
 
     Parameters
     ----------
@@ -295,61 +295,34 @@ class RotaryPositionEmbedding2D(Module):
 
     Forward
     -------
-    q, k : torch.Tensor
-        Query and key tensors of shape :math:`(\ldots, h \cdot w, head\_dim)`.
-        Tokens must be in row-major order (height varies slowest), matching the
-        order produced by ``tensor.flatten(-3, -2)`` from an :math:`(h, w)`
-        spatial grid.
     latent_hw : Tuple[int, int], optional
-        Override the spatial grid size at call time.  If given and different
-        from the construction-time grid, the cos/sin tables are rebuilt in
-        place before rotating (off the ``torch.compile`` fast path).
+        Override the spatial grid size at call time. If given and different from
+        the current grid, the cos/sin tables are rebuilt in place before being
+        returned (off the ``torch.compile`` fast path). Under domain parallelism
+        the in-place rebuild replaces the sharded buffers with plain tensors, so
+        it is only appropriate for single-device variable-resolution inference.
 
     Returns
     -------
     Tuple[torch.Tensor, torch.Tensor]
-        The rotated ``(q, k)``, same shape and dtype as the inputs.
+        ``(rope_cos, rope_sin)``, each of shape :math:`(h, w, head\_dim)`.
 
     Examples
     --------
     >>> import torch
-    >>> from physicsnemo.nn.module.rope import RotaryPositionEmbedding2D
-    >>> rope = RotaryPositionEmbedding2D(head_dim=16, latent_hw=(4, 4))
-    >>> q = torch.randn(2, 8, 16, 16)  # (B, heads, h*w, head_dim)
-    >>> k = torch.randn(2, 8, 16, 16)
-    >>> q_rot, k_rot = rope(q, k)
+    >>> from physicsnemo.nn.module.rope import (
+    ...     RotaryEmbedding2DTables,
+    ...     apply_rotary_pos_emb,
+    ... )
+    >>> rope = RotaryEmbedding2DTables(head_dim=16, latent_hw=(4, 4))
+    >>> cos, sin = rope()
+    >>> cos.shape
+    torch.Size([4, 4, 16])
+    >>> # q reshaped to spatial layout (B, heads, h, w, head_dim)
+    >>> q = torch.randn(2, 8, 4, 4, 16)
+    >>> q_rot = apply_rotary_pos_emb(q, cos.unsqueeze(0).unsqueeze(0), sin.unsqueeze(0).unsqueeze(0))
     >>> q_rot.shape
-    torch.Size([2, 8, 16, 16])
-
-    Wiring to :func:`torch.nn.functional.scaled_dot_product_attention` in a
-    full multi-head self-attention pass over a flattened 2D token grid:
-
-    .. code-block:: python
-
-        import torch
-        import torch.nn.functional as F
-        from physicsnemo.nn.module.rope import RotaryPositionEmbedding2D
-
-        B, num_heads, h, w, head_dim = 1, 4, 8, 8, 32
-        D = num_heads * head_dim  # model dimension
-        rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(h, w))
-        N = h * w  # number of spatial tokens
-
-        # Simulate linear Q/K/V projections from flat token sequence
-        x = torch.randn(B, N, D)
-        Wq = torch.nn.Linear(D, D, bias=False)
-        Wk = torch.nn.Linear(D, D, bias=False)
-        Wv = torch.nn.Linear(D, D, bias=False)
-        q = Wq(x).view(B, N, num_heads, head_dim).transpose(1, 2)  # (B, H, N, head_dim)
-        k = Wk(x).view(B, N, num_heads, head_dim).transpose(1, 2)
-        v = Wv(x).view(B, N, num_heads, head_dim).transpose(1, 2)
-
-        # Rotate queries and keys with axial 2D RoPE before attention
-        q_rot, k_rot = rope(q, k)
-
-        # Scaled dot-product attention; q_rot and k_rot carry position info
-        out = F.scaled_dot_product_attention(q_rot, k_rot, v)  # (B, H, N, head_dim)
-        out = out.transpose(1, 2).reshape(B, N, D)  # merge heads -> (B, N, D)
+    torch.Size([2, 8, 4, 4, 16])
     """
 
     def __init__(
@@ -369,76 +342,59 @@ class RotaryPositionEmbedding2D(Module):
         cos, sin = build_axial_rope_cos_sin_2d(
             *self._latent_hw, self.head_dim, theta=self.theta
         )
-        # Flatten the spatial axes to (h*w, head_dim) so the tables broadcast
-        # against any (..., seq, head_dim) attention layout.
-        self.register_buffer("cos", cos.reshape(-1, self.head_dim), persistent=False)
-        self.register_buffer("sin", sin.reshape(-1, self.head_dim), persistent=False)
+        # persistent=False: not in state_dict (rebuilt deterministically from
+        # latent_hw + head_dim + theta), so checkpoints stay lean. Names
+        # rope_cos/rope_sin and (h, w, head_dim) layout let domain parallelism
+        # shard parameters along desired axes.
+        self.register_buffer("rope_cos", cos, persistent=False)  # (h, w, head_dim)
+        self.register_buffer("rope_sin", sin, persistent=False)  # (h, w, head_dim)
 
-    def _rebuild_for_shape(self, h: int, w: int) -> None:
-        """Rebuild the cos/sin tables for a new latent shape (off the hot path)."""
-        target_dtype = self.cos.dtype
-        target_device = self.cos.device
+    def maybe_rebuild(self, h: int, w: int) -> None:
+        r"""Rebuild the cos/sin tables for a new latent shape if it changed.
+
+        Reached only when :meth:`forward` is called with a ``latent_hw`` that
+        differs from the current grid (e.g. variable-resolution inference); not
+        part of the training-time hot path.
+        """
+        if (int(h), int(w)) == self._latent_hw:
+            return
+        target_dtype = self.rope_cos.dtype
+        target_device = self.rope_cos.device
         cos, sin = build_axial_rope_cos_sin_2d(
             h, w, self.head_dim, theta=self.theta, device=target_device
         )
-        self.register_buffer(
-            "cos", cos.reshape(-1, self.head_dim).to(target_dtype), persistent=False
-        )
-        self.register_buffer(
-            "sin", sin.reshape(-1, self.head_dim).to(target_dtype), persistent=False
-        )
+        self.register_buffer("rope_cos", cos.to(dtype=target_dtype), persistent=False)
+        self.register_buffer("rope_sin", sin.to(dtype=target_dtype), persistent=False)
         self._latent_hw = (int(h), int(w))
 
     def forward(
         self,
-        q: Float[torch.Tensor, "*batch seq head_dim"],
-        k: Float[torch.Tensor, "*batch seq head_dim"],
         latent_hw: Optional[Tuple[int, int]] = None,
-    ) -> Tuple[
-        Float[torch.Tensor, "*batch seq head_dim"],
-        Float[torch.Tensor, "*batch seq head_dim"],
-    ]:
-        if latent_hw is not None and (
-            (int(latent_hw[0]), int(latent_hw[1])) != self._latent_hw
-        ):
-            self._rebuild_for_shape(int(latent_hw[0]), int(latent_hw[1]))
-
-        n = self.cos.shape[0]
-        if not torch.compiler.is_compiling() and (q.shape[-2] != n or k.shape[-2] != n):
-            raise ValueError(
-                f"q/k sequence length must be h*w={n} (latent_hw={self._latent_hw}), "
-                f"but got q={q.shape[-2]}, k={k.shape[-2]}"
-            )
-        return apply_rotary_pos_emb(q, self.cos, self.sin), apply_rotary_pos_emb(
-            k, self.cos, self.sin
-        )
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if latent_hw is not None:
+            self.maybe_rebuild(int(latent_hw[0]), int(latent_hw[1]))
+        return self.rope_cos, self.rope_sin
 
 
-class RotaryPositionEmbedding1D(Module):
-    r"""Standard 1D rotary position embedding for sequence transformers.
+class RotaryEmbedding1DTables(Module):
+    r"""Shared owner of standard 1D RoPE cos/sin tables for a token sequence.
 
-    Encodes each token's absolute sequence position by
-    rotating its query and key vectors before the attention dot-product.
-    Because only the *relative* rotation between query and key enters the
-    dot-product, attention scores are automatically sensitive to relative
-    position — no learned positional vectors are added to the token features.
-    This is the same RoPE variant used by most autoregressive and encoder
-    transformer architectures (LLaMA, GPT-NeoX, etc.).
+    This module *owns* the cos/sin tables and nothing else: it holds no
+    projections and applies no rotation. Its :meth:`forward` returns the
+    ``(cos, sin)`` tables of shape :math:`(seq\_len, head\_dim)`, which a
+    consumer applies to its query/key with :func:`apply_rotary_pos_emb`. This is
+    the same RoPE variant used by most autoregressive and encoder transformer
+    architectures (LLaMA, GPT-NeoX, etc.).
 
-    Use it when your attention module operates on
-    a *1D token sequence* in the standard
-    :math:`(B, \text{heads}, \text{seq}, head\_dim)` layout.  Typical examples:
+    A top-level, multi-block transformer constructs a *single* instance and
+    shares its tables across all blocks, so the tables are built and stored once
+    instead of once per block. Sequences shorter than ``max_seq_len`` are served
+    by returning the leading positions of the precomputed table, so one instance
+    covers any length up to ``max_seq_len`` without rebuilding.
 
-    * General encoder/decoder transformers over variable-length sequences.
-    * Autoregressive language models with a causal attention mask.
-    * Any custom attention block that needs sequence-position awareness.
-
-    Inputs shorter than ``max_seq_len`` are rotated with the leading positions
-    of the precomputed table, so a single module instance can serve any
-    sequence length up to ``max_seq_len`` without rebuilding.  The cos/sin
-    tables are stored as ``persistent=False`` buffers (they are
-    deterministically reconstructed from ``(max_seq_len, head_dim, theta)``
-    and do not need to be saved with the model weights).
+    The tables are stored as ``persistent=False`` buffers (they are
+    deterministically reconstructed from ``(max_seq_len, head_dim, theta)`` and
+    do not need to be saved with the model weights).
 
     Parameters
     ----------
@@ -452,55 +408,30 @@ class RotaryPositionEmbedding1D(Module):
 
     Forward
     -------
-    q, k : torch.Tensor
-        Query and key tensors of shape :math:`(\ldots, \text{seq}, head\_dim)`
-        with ``seq <= max_seq_len``.
+    seq_len : int, optional
+        Number of leading positions to return. If ``None``, the full
+        ``max_seq_len`` table is returned.
 
     Returns
     -------
     Tuple[torch.Tensor, torch.Tensor]
-        The rotated ``(q, k)``, same shape and dtype as the inputs.
+        ``(cos, sin)``, each of shape :math:`(seq\_len, head\_dim)`.
 
     Examples
     --------
     >>> import torch
-    >>> from physicsnemo.nn.module.rope import RotaryPositionEmbedding1D
-    >>> rope = RotaryPositionEmbedding1D(head_dim=16, max_seq_len=128)
+    >>> from physicsnemo.nn.module.rope import (
+    ...     RotaryEmbedding1DTables,
+    ...     apply_rotary_pos_emb,
+    ... )
+    >>> rope = RotaryEmbedding1DTables(head_dim=16, max_seq_len=128)
+    >>> cos, sin = rope(seq_len=100)
+    >>> cos.shape
+    torch.Size([100, 16])
     >>> q = torch.randn(2, 8, 100, 16)  # (B, heads, seq, head_dim)
-    >>> k = torch.randn(2, 8, 100, 16)
-    >>> q_rot, k_rot = rope(q, k)
+    >>> q_rot = apply_rotary_pos_emb(q, cos, sin)
     >>> q_rot.shape
     torch.Size([2, 8, 100, 16])
-
-    Wiring to :func:`torch.nn.functional.scaled_dot_product_attention` with a
-    causal mask, as used in autoregressive transformer decoders:
-
-    .. code-block:: python
-
-        import torch
-        import torch.nn.functional as F
-        from physicsnemo.nn.module.rope import RotaryPositionEmbedding1D
-
-        B, num_heads, seq, head_dim = 2, 4, 64, 32
-        D = num_heads * head_dim  # model dimension
-        rope = RotaryPositionEmbedding1D(head_dim=head_dim, max_seq_len=128)
-
-        # Simulate linear Q/K/V projections from a token sequence
-        x = torch.randn(B, seq, D)
-        Wq = torch.nn.Linear(D, D, bias=False)
-        Wk = torch.nn.Linear(D, D, bias=False)
-        Wv = torch.nn.Linear(D, D, bias=False)
-        q = Wq(x).view(B, seq, num_heads, head_dim).transpose(1, 2)  # (B, H, T, head_dim)
-        k = Wk(x).view(B, seq, num_heads, head_dim).transpose(1, 2)
-        v = Wv(x).view(B, seq, num_heads, head_dim).transpose(1, 2)
-
-        # Rotate queries and keys with 1D RoPE before attention
-        q_rot, k_rot = rope(q, k)
-
-        # Causal self-attention; RoPE makes dot-products sensitive to relative
-        # position between query and key tokens, not absolute positions
-        out = F.scaled_dot_product_attention(q_rot, k_rot, v, is_causal=True)
-        out = out.transpose(1, 2).reshape(B, seq, D)  # merge heads -> (B, T, D)
     """
 
     def __init__(
@@ -523,24 +454,13 @@ class RotaryPositionEmbedding1D(Module):
 
     def forward(
         self,
-        q: Float[torch.Tensor, "*batch seq head_dim"],
-        k: Float[torch.Tensor, "*batch seq head_dim"],
-    ) -> Tuple[
-        Float[torch.Tensor, "*batch seq head_dim"],
-        Float[torch.Tensor, "*batch seq head_dim"],
-    ]:
-        seq_len = q.shape[-2]
-        if not torch.compiler.is_compiling():
-            if k.shape[-2] != seq_len:
-                raise ValueError(
-                    f"q and k must share a sequence length; got q={seq_len}, "
-                    f"k={k.shape[-2]}"
-                )
-            if seq_len > self.max_seq_len:
-                raise ValueError(
-                    f"sequence length {seq_len} exceeds max_seq_len={self.max_seq_len}"
-                )
-        # Slice the leading positions so the module serves any length <= max.
-        cos = self.cos[:seq_len]
-        sin = self.sin[:seq_len]
-        return apply_rotary_pos_emb(q, cos, sin), apply_rotary_pos_emb(k, cos, sin)
+        seq_len: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if seq_len is None:
+            return self.cos, self.sin
+        if not torch.compiler.is_compiling() and seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {seq_len} exceeds max_seq_len={self.max_seq_len}"
+            )
+        # Slice the leading positions so one instance serves any length <= max.
+        return self.cos[:seq_len], self.sin[:seq_len]

--- a/physicsnemo/nn/module/rope.py
+++ b/physicsnemo/nn/module/rope.py
@@ -370,7 +370,10 @@ class RotaryEmbedding2DTables(Module):
     def forward(
         self,
         latent_hw: Optional[Tuple[int, int]] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> Tuple[
+        Float[torch.Tensor, "h w head_dim"],
+        Float[torch.Tensor, "h w head_dim"],
+    ]:
         if latent_hw is not None:
             self.maybe_rebuild(int(latent_hw[0]), int(latent_hw[1]))
         return self.rope_cos, self.rope_sin
@@ -455,7 +458,10 @@ class RotaryEmbedding1DTables(Module):
     def forward(
         self,
         seq_len: Optional[int] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> Tuple[
+        Float[torch.Tensor, "seq head_dim"],
+        Float[torch.Tensor, "seq head_dim"],
+    ]:
         if seq_len is None:
             return self.cos, self.sin
         if not torch.compiler.is_compiling() and seq_len > self.max_seq_len:

--- a/test/models/dit/test_dit.py
+++ b/test/models/dit/test_dit.py
@@ -209,9 +209,14 @@ def test_dit_rope_disables_pos_embed_and_warns(device):
         ).to(device)
     # Additive positional embedding is disabled.
     assert model.tokenizer.pos_embed == 0.0
-    # The RoPE tables were precomputed at the latent grid size.
+    # The RoPE tables are owned by a single top-level provider (built once at the
+    # latent grid size), not duplicated per block.
     head_dim = 64 // 4
-    assert model.blocks[0].attention.rope_cos.shape == (4, 4, head_dim)
+    assert model.rope.rope_cos.shape == (4, 4, head_dim)
+    assert not hasattr(model.blocks[0].attention, "rope_cos")
+    # Exactly one owner of the tables across the whole model.
+    n_owners = sum(1 for m in model.modules() if hasattr(m, "rope_cos"))
+    assert n_owners == 1
 
 
 def test_dit_pixel_mask_to_token_mask(device):

--- a/test/nn/module/test_dit_layers.py
+++ b/test/nn/module/test_dit_layers.py
@@ -172,7 +172,7 @@ def test_ditblock_natten_rope_and_mask_token_forward(device, pytestconfig):
     rope_kwargs = {"latent_hw": (H, W), "rope_cos": rope_cos, "rope_sin": rope_sin}
 
     # Omitting the tables is a clear error (the block cannot run standalone).
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         block(
             torch.randn(B, T, hidden_size, device=device),
             torch.randn(B, hidden_size, device=device),

--- a/test/nn/module/test_dit_layers.py
+++ b/test/nn/module/test_dit_layers.py
@@ -150,6 +150,7 @@ def test_ditblock_natten_rope_and_mask_token_forward(device, pytestconfig):
     hidden_size, num_heads = 64, 4
     B, H, W = 2, 8, 8
     T = H * W
+    head_dim = hidden_size // num_heads
 
     block = (
         DiTBlock(
@@ -158,15 +159,25 @@ def test_ditblock_natten_rope_and_mask_token_forward(device, pytestconfig):
             attention_backend="natten2d_rope",
             layernorm_backend="torch",
             attn_kernel=3,
-            latent_hw=(H, W),
             use_mask_token=True,
         )
         .to(device)
         .eval()
     )
-    # Confirm the RoPE backend was selected and exposes its precomputed tables.
-    assert hasattr(block.attention, "rope_cos")
-    assert block.attention.rope_cos.shape == (H, W, hidden_size // num_heads)
+    # The RoPE block no longer owns the cos/sin tables: they are supplied at
+    # forward time by the top-level model's provider (here, built directly).
+    assert not hasattr(block.attention, "rope_cos")
+    rope_cos, rope_sin = build_axial_rope_cos_sin_2d(H, W, head_dim)
+    rope_cos, rope_sin = rope_cos.to(device), rope_sin.to(device)
+    rope_kwargs = {"latent_hw": (H, W), "rope_cos": rope_cos, "rope_sin": rope_sin}
+
+    # Omitting the tables is a clear error (the block cannot run standalone).
+    with pytest.raises(ValueError):
+        block(
+            torch.randn(B, T, hidden_size, device=device),
+            torch.randn(B, hidden_size, device=device),
+            attn_kwargs={"latent_hw": (H, W)},
+        )
 
     x = torch.randn(B, T, hidden_size, device=device)
     c = torch.randn(B, hidden_size, device=device)
@@ -174,10 +185,8 @@ def test_ditblock_natten_rope_and_mask_token_forward(device, pytestconfig):
     # An all-valid mask must match passing no mask at all (mask token init zero
     # would also match, but we trained none here; pass explicit zeros).
     all_valid = torch.zeros(T, dtype=torch.bool, device=device)
-    y_none = block(x, c, attn_kwargs={"latent_hw": (H, W)})
-    y_valid = block(
-        x, c, attn_kwargs={"latent_hw": (H, W), "invalid_token_mask": all_valid}
-    )
+    y_none = block(x, c, attn_kwargs=dict(rope_kwargs))
+    y_valid = block(x, c, attn_kwargs={**rope_kwargs, "invalid_token_mask": all_valid})
     assert y_none.shape == (B, T, hidden_size)
     assert torch.allclose(y_none, y_valid, atol=1e-5)
 
@@ -185,9 +194,7 @@ def test_ditblock_natten_rope_and_mask_token_forward(device, pytestconfig):
     torch.nn.init.normal_(block.attention.mask_token)
     invalid = all_valid.clone()
     invalid[[0, 9, 33]] = True
-    y_masked = block(
-        x, c, attn_kwargs={"latent_hw": (H, W), "invalid_token_mask": invalid}
-    )
+    y_masked = block(x, c, attn_kwargs={**rope_kwargs, "invalid_token_mask": invalid})
     assert not torch.allclose(y_none, y_masked, atol=1e-5)
 
     # A per-sample (B, T) mask applies a distinct pattern to each sample: mask
@@ -196,7 +203,7 @@ def test_ditblock_natten_rope_and_mask_token_forward(device, pytestconfig):
     per_sample = torch.zeros(B, T, dtype=torch.bool, device=device)
     per_sample[0] = invalid
     y_per_sample = block(
-        x, c, attn_kwargs={"latent_hw": (H, W), "invalid_token_mask": per_sample}
+        x, c, attn_kwargs={**rope_kwargs, "invalid_token_mask": per_sample}
     )
     assert torch.allclose(y_per_sample[0], y_masked[0], atol=1e-5)
     assert torch.allclose(y_per_sample[1], y_none[1], atol=1e-5)

--- a/test/nn/module/test_rope.py
+++ b/test/nn/module/test_rope.py
@@ -21,8 +21,8 @@ import torch
 
 from physicsnemo.core import Module
 from physicsnemo.nn.module.rope import (
-    RotaryPositionEmbedding1D,
-    RotaryPositionEmbedding2D,
+    RotaryEmbedding1DTables,
+    RotaryEmbedding2DTables,
     apply_rotary_pos_emb,
     build_axial_rope_cos_sin_2d,
     build_rope_cos_sin_1d,
@@ -30,77 +30,58 @@ from physicsnemo.nn.module.rope import (
 
 
 @torch.no_grad()
-def test_rotary_module_shapes_and_validation():
+def test_rotary_2d_tables_shapes_and_validation():
     head_dim, h, w = 16, 4, 5
-    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(h, w))
-    # Tables are flattened to (h*w, head_dim) so they broadcast over (..., N, D).
-    assert rope.cos.shape == (h * w, head_dim)
-    assert rope.sin.shape == (h * w, head_dim)
-    assert "cos" not in rope.state_dict()  # persistent=False
+    rope = RotaryEmbedding2DTables(head_dim=head_dim, latent_hw=(h, w))
+    # The provider owns the tables in explicit (h, w, head_dim) spatial layout,
+    # named rope_cos/rope_sin so domain parallelism can shard them along height.
+    assert rope.rope_cos.shape == (h, w, head_dim)
+    assert rope.rope_sin.shape == (h, w, head_dim)
+    assert "rope_cos" not in rope.state_dict()  # persistent=False
 
-    q = torch.randn(2, 8, h * w, head_dim)
-    k = torch.randn(2, 8, h * w, head_dim)
-    q_rot, k_rot = rope(q, k)
-    assert q_rot.shape == q.shape and k_rot.shape == k.shape
+    # forward() returns the owned tables.
+    cos, sin = rope()
+    assert cos.shape == (h, w, head_dim)
+    assert torch.equal(cos, rope.rope_cos) and torch.equal(sin, rope.rope_sin)
 
     # head_dim must be divisible by 4.
     with pytest.raises(ValueError):
-        RotaryPositionEmbedding2D(head_dim=6, latent_hw=(h, w))
-
-    # Wrong sequence length is rejected.
-    with pytest.raises(ValueError):
-        rope(torch.randn(2, 8, h * w + 1, head_dim), k)
+        RotaryEmbedding2DTables(head_dim=6, latent_hw=(h, w))
 
 
 @torch.no_grad()
-def test_rotary_module_matches_flattened_tables():
-    """The module result must equal applying the flattened cos/sin directly."""
-    torch.manual_seed(0)
+def test_rotary_2d_tables_match_builder():
+    """The provider's tables must equal the functional builder's output."""
     head_dim, h, w = 32, 6, 4
-    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(h, w))
-    q = torch.randn(3, 4, h * w, head_dim)
+    rope = RotaryEmbedding2DTables(head_dim=head_dim, latent_hw=(h, w), theta=5000.0)
+    cos, sin = rope()
 
-    cos, sin = build_axial_rope_cos_sin_2d(h, w, head_dim)
-    cos_flat = cos.reshape(-1, head_dim)
-    sin_flat = sin.reshape(-1, head_dim)
-    expected = apply_rotary_pos_emb(q, cos_flat, sin_flat)
+    exp_cos, exp_sin = build_axial_rope_cos_sin_2d(h, w, head_dim, theta=5000.0)
+    assert torch.equal(cos, exp_cos)
+    assert torch.equal(sin, exp_sin)
 
-    q_rot, _ = rope(q, q)
-    assert torch.equal(q_rot, expected)
-
-
-@torch.no_grad()
-def test_rotary_module_layout_matches_spatial_rotation():
-    """Rotating a flattened (B, H, N, D) tensor with the module must match
-    rotating the spatial (B, H, h, w, D) tensor with the raw tables and then
-    flattening — i.e. the module's row-major (h, then w) assumption holds."""
+    # Applying the tables in spatial (B, heads, h, w, head_dim) layout works.
     torch.manual_seed(0)
-    head_dim, h, w = 16, 3, 5
-    B, heads = 2, 4
-
-    cos, sin = build_axial_rope_cos_sin_2d(h, w, head_dim)  # (h, w, head_dim)
-    q_spatial = torch.randn(B, heads, h, w, head_dim)
-    spatial_rot = apply_rotary_pos_emb(
-        q_spatial, cos.unsqueeze(0).unsqueeze(0), sin.unsqueeze(0).unsqueeze(0)
+    q = torch.randn(2, 4, h, w, head_dim)
+    q_rot = apply_rotary_pos_emb(
+        q, cos.unsqueeze(0).unsqueeze(0), sin.unsqueeze(0).unsqueeze(0)
     )
-    spatial_rot_flat = spatial_rot.reshape(B, heads, h * w, head_dim)
-
-    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(h, w))
-    q_flat = q_spatial.reshape(B, heads, h * w, head_dim)
-    module_rot, _ = rope(q_flat, q_flat)
-
-    assert torch.allclose(module_rot, spatial_rot_flat, atol=1e-6)
+    assert q_rot.shape == q.shape
 
 
 @torch.no_grad()
-def test_rotary_module_rebuild_for_new_shape():
+def test_rotary_2d_tables_rebuild_for_new_shape():
     head_dim = 16
-    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(4, 4))
-    q = torch.randn(1, 2, 5 * 6, head_dim)
-    # Passing a new latent_hw rebuilds the tables in place.
-    q_rot, _ = rope(q, q, latent_hw=(5, 6))
-    assert rope.cos.shape == (5 * 6, head_dim)
-    assert q_rot.shape == q.shape
+    rope = RotaryEmbedding2DTables(head_dim=head_dim, latent_hw=(4, 4))
+    # Passing a new latent_hw rebuilds the tables in place and returns them.
+    cos, sin = rope(latent_hw=(5, 6))
+    assert cos.shape == (5, 6, head_dim)
+    assert rope.rope_cos.shape == (5, 6, head_dim)
+    assert rope._latent_hw == (5, 6)
+
+    # Re-requesting the same shape is a no-op (no rebuild).
+    same_cos, _ = rope(latent_hw=(5, 6))
+    assert torch.equal(same_cos, cos)
 
 
 @torch.no_grad()
@@ -174,41 +155,37 @@ def test_build_rope_cos_sin_1d_shape_and_validation():
 
 
 @torch.no_grad()
-def test_rotary_1d_module_shapes_and_validation():
+def test_rotary_1d_tables_shapes_and_validation():
     head_dim, max_seq_len = 16, 32
-    rope = RotaryPositionEmbedding1D(head_dim=head_dim, max_seq_len=max_seq_len)
+    rope = RotaryEmbedding1DTables(head_dim=head_dim, max_seq_len=max_seq_len)
     assert rope.cos.shape == (max_seq_len, head_dim)
     assert "cos" not in rope.state_dict()  # persistent=False
 
-    q = torch.randn(2, 4, 20, head_dim)
-    k = torch.randn(2, 4, 20, head_dim)
-    q_rot, k_rot = rope(q, k)
-    assert q_rot.shape == q.shape and k_rot.shape == k.shape
+    # Full table when no seq_len is given; sliced leading positions otherwise.
+    cos_full, sin_full = rope()
+    assert cos_full.shape == (max_seq_len, head_dim)
+    cos, sin = rope(seq_len=20)
+    assert cos.shape == (20, head_dim) and sin.shape == (20, head_dim)
+    assert torch.equal(cos, cos_full[:20])
 
     with pytest.raises(ValueError):
-        RotaryPositionEmbedding1D(head_dim=15, max_seq_len=max_seq_len)
+        RotaryEmbedding1DTables(head_dim=15, max_seq_len=max_seq_len)
     # Exceeding max_seq_len is rejected.
     with pytest.raises(ValueError):
-        rope(torch.randn(2, 4, max_seq_len + 1, head_dim), k)
-    # Mismatched q/k lengths are rejected.
-    with pytest.raises(ValueError):
-        rope(torch.randn(2, 4, 20, head_dim), torch.randn(2, 4, 19, head_dim))
+        rope(seq_len=max_seq_len + 1)
 
 
 @torch.no_grad()
-def test_rotary_1d_module_matches_sliced_tables():
-    """Shorter inputs use the leading positions of the precomputed tables."""
-    torch.manual_seed(0)
+def test_rotary_1d_tables_match_sliced_builder():
+    """Shorter requests use the leading positions of the precomputed tables."""
     head_dim, max_seq_len = 32, 64
-    rope = RotaryPositionEmbedding1D(head_dim=head_dim, max_seq_len=max_seq_len)
+    rope = RotaryEmbedding1DTables(head_dim=head_dim, max_seq_len=max_seq_len)
 
     seq_len = 40
-    q = torch.randn(3, 4, seq_len, head_dim)
-    cos, sin = build_rope_cos_sin_1d(max_seq_len, head_dim)
-    expected = apply_rotary_pos_emb(q, cos[:seq_len], sin[:seq_len])
-
-    q_rot, _ = rope(q, q)
-    assert torch.equal(q_rot, expected)
+    cos, sin = rope(seq_len=seq_len)
+    exp_cos, exp_sin = build_rope_cos_sin_1d(max_seq_len, head_dim)
+    assert torch.equal(cos, exp_cos[:seq_len])
+    assert torch.equal(sin, exp_sin[:seq_len])
 
 
 @torch.no_grad()
@@ -217,13 +194,15 @@ def test_rotary_1d_relative_phase_is_translation_invariant():
     between positions i and j depends only on (i - j)."""
     torch.manual_seed(0)
     head_dim, max_seq_len = 16, 64
-    rope = RotaryPositionEmbedding1D(head_dim=head_dim, max_seq_len=max_seq_len)
+    rope = RotaryEmbedding1DTables(head_dim=head_dim, max_seq_len=max_seq_len)
+    cos, sin = rope()
 
     # Same content at every position; rotate, then compare inner products of
     # pairs sharing the same offset.
     base = torch.randn(1, 1, 1, head_dim)
     seq = base.expand(1, 1, max_seq_len, head_dim).contiguous()
-    q_rot, k_rot = rope(seq, seq)
+    q_rot = apply_rotary_pos_emb(seq, cos, sin)
+    k_rot = apply_rotary_pos_emb(seq, cos, sin)
 
     def dot(i, j):
         return (q_rot[0, 0, i] * k_rot[0, 0, j]).sum()
@@ -235,51 +214,47 @@ def test_rotary_1d_relative_phase_is_translation_invariant():
 
 # --- physicsnemo.Module checkpoint round-trips ---
 #
-# Both RoPE modules subclass physicsnemo.core.Module, so they must support the
+# Both providers subclass physicsnemo.core.Module, so they must support the
 # .save() / Module.from_checkpoint() recipe. They cache cos/sin as
 # persistent=False buffers (deterministically rebuilt from the __init__ args), so
-# a round-trip reproduces the forward exactly without the tables appearing in the
+# a round-trip reproduces the tables exactly without them appearing in the
 # checkpoint.
 
 
 @torch.no_grad()
-def test_rotary_2d_module_checkpoint_round_trip(tmp_path):
+def test_rotary_2d_tables_checkpoint_round_trip(tmp_path):
     head_dim, h, w = 16, 4, 5
-    rope = RotaryPositionEmbedding2D(head_dim=head_dim, latent_hw=(h, w), theta=5000.0)
+    rope = RotaryEmbedding2DTables(head_dim=head_dim, latent_hw=(h, w), theta=5000.0)
     assert isinstance(rope, Module)
     # persistent=False: tables are not serialized.
-    assert "cos" not in rope.state_dict() and "sin" not in rope.state_dict()
+    assert "rope_cos" not in rope.state_dict() and "rope_sin" not in rope.state_dict()
 
-    q = torch.randn(2, 3, h * w, head_dim)
-    k = torch.randn(2, 3, h * w, head_dim)
-    q_ref, k_ref = rope(q, k)
+    cos_ref, sin_ref = rope()
 
     path = str(tmp_path / "rope2d.mdlus")
     rope.save(path)
     loaded = Module.from_checkpoint(path)
     # Tables were rebuilt at the right shape from the saved __init__ args.
-    assert loaded.cos.shape == (h * w, head_dim)
+    assert loaded.rope_cos.shape == (h, w, head_dim)
     assert loaded.theta == 5000.0
-    q_out, k_out = loaded(q, k)
-    assert torch.equal(q_out, q_ref) and torch.equal(k_out, k_ref)
+    cos_out, sin_out = loaded()
+    assert torch.equal(cos_out, cos_ref) and torch.equal(sin_out, sin_ref)
 
 
 @torch.no_grad()
-def test_rotary_1d_module_checkpoint_round_trip(tmp_path):
+def test_rotary_1d_tables_checkpoint_round_trip(tmp_path):
     head_dim, max_seq_len = 16, 32
-    rope = RotaryPositionEmbedding1D(
+    rope = RotaryEmbedding1DTables(
         head_dim=head_dim, max_seq_len=max_seq_len, theta=5000.0
     )
     assert isinstance(rope, Module)
     assert "cos" not in rope.state_dict() and "sin" not in rope.state_dict()
 
-    q = torch.randn(2, 4, 20, head_dim)
-    k = torch.randn(2, 4, 20, head_dim)
-    q_ref, k_ref = rope(q, k)
+    cos_ref, sin_ref = rope()
 
     path = str(tmp_path / "rope1d.mdlus")
     rope.save(path)
     loaded = Module.from_checkpoint(path)
     assert loaded.cos.shape == (max_seq_len, head_dim)
-    q_out, k_out = loaded(q, k)
-    assert torch.equal(q_out, q_ref) and torch.equal(k_out, k_ref)
+    cos_out, sin_out = loaded()
+    assert torch.equal(cos_out, cos_ref) and torch.equal(sin_out, sin_ref)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Summary

Refactor 2D RoPE so the cos/sin embedding tables are owned once by the top-level
model instead of being rebuilt and stored inside every transformer block.

Previously each `RopeNatten2DSelfAttention` block built and held its own
`rope_cos`/`rope_sin` buffers. Since the tables depend only on
`(latent_hw, head_dim, theta)` — identical across all blocks — a `depth`-block
DiT carried `depth` redundant copies (plus redundant table construction and, under
domain parallelism, redundant per-block sharding). This hoists the tables into a
single shared provider.

## Changes

**`physicsnemo/nn/module/rope.py`**
- Removed the previous `RotaryPositionEmbedding1D` / `RotaryPositionEmbedding2D`
  modules. I'm aware this is technically a breaking change, but they are used nowhere in
  the repo, were introduced last week, and have no known external users. Dropping them
  in favor of the below modules, which have a more clear name.
- Added two table-provider modules that own the buffers and only return tables
  (they hold no projections and apply no rotation):
  - `RotaryEmbedding2DTables` — `rope_cos`/`rope_sin` in `(h, w, head_dim)` layout.
  - `RotaryEmbedding1DTables` — `cos`/`sin` in `(max_seq_len, head_dim)` layout.

**`physicsnemo/nn/module/dit_layers.py`**
- `RopeNatten2DSelfAttention` is now stateless w.r.t. the tables: it no longer
  takes `latent_hw`/`rope_theta` or allocates buffers. Its `forward` requires the
  `rope_cos`/`rope_sin` tables (clear `ValueError` if missing).

**`physicsnemo/models/dit/dit.py`**
- DiT constructs a single `RotaryEmbedding2DTables` provider for the
  `natten2d_rope` backend and injects its tables into every block's `forward`
  (via the existing `attn_kwargs` threading).

**Exports & tests** updated accordingly.

## Rationale / design notes

- **Memory**: `depth` copies of the tables → 1.
- **Checkpoint compatibility**: tables remain `persistent=False` buffers
  (deterministically rebuilt from `(latent_hw, head_dim, theta)`), so `state_dict`
  is unchanged — no migration needed.
- **Domain parallelism**: the provider keeps the `rope_cos`/`rope_sin` names and
  the height-first `(h, w, head_dim)` layout, so the StormCast recipe's
  `shard_dim_selector` shards the single provider buffer along height (dim 0)
  with **no changes to `parallel.py`**. Each rank still gets globally-correct rows
  with no explicit rank offset.
- **`torch.compile`**: tables are fetched once from a stable buffer and passed
  down, keeping the block forward graph constant.

## Behavior change

`RopeNatten2DSelfAttention` (and `DiTBlock(attention_backend="natten2d_rope")`)
can no longer be used standalone — the tables must be supplied at `forward` by
the owning model. The DiT `natten2d_rope` backend does this automatically. Since
standalone usage doesn't make sense (they are blocks) and the
`RopeNatten2DSelfAttention` module was added last week, this change should be fine.


## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
