### PR TITLE
Mesh: make cache initialization compatible with torch.compile()

### DIFF
--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -391,13 +391,14 @@ class Mesh:
 
         ### _cache: default empty cache structure
         if self._cache is None:
+            device = self.points.device
             self._cache = TensorDict(
                 {
-                    "cell": TensorDict({}, batch_size=[self.n_cells]),
-                    "point": TensorDict({}, batch_size=[self.n_points]),
-                    "topology": TensorDict({}),
+                    "cell": TensorDict({}, batch_size=[self.n_cells], device=device),
+                    "point": TensorDict({}, batch_size=[self.n_points], device=device),
+                    "topology": TensorDict({}, device=device),
                 },
-                device=self.points.device,
+                device=device,
             )
 
         ### Validate shapes and dtypes
@@ -1439,13 +1440,16 @@ class Mesh:
         local_cell_cache = self._cache["cell"].select(
             "centroids", "areas", "normals", strict=False
         )
+        device = self.points.device
         new_cache = TensorDict(
             {
                 "cell": local_cell_cache[indices],
-                "point": TensorDict({}, batch_size=torch.Size([self.n_points])),
-                "topology": TensorDict({}),
+                "point": TensorDict(
+                    {}, batch_size=torch.Size([self.n_points]), device=device
+                ),
+                "topology": TensorDict({}, device=device),
             },
-            device=self.points.device,
+            device=device,
         )
         return Mesh(
             points=self.points,
@@ -2400,7 +2404,7 @@ class Mesh:
                         lambda x: _pad_with_value(x, target_n_points, 0.0),
                         batch_size=torch.Size([target_n_points]),
                     ),
-                    "topology": TensorDict({}),
+                    "topology": TensorDict({}, device=self.points.device),
                 },
                 device=self.points.device,
             ),

--- a/physicsnemo/mesh/transformations/geometric.py
+++ b/physicsnemo/mesh/transformations/geometric.py
@@ -491,9 +491,9 @@ def transform(
     device = mesh.points.device
     new_cache = TensorDict(
         {
-            "cell": TensorDict({}, batch_size=[mesh.n_cells]),
-            "point": TensorDict({}, batch_size=[mesh.n_points]),
-            "topology": mesh._cache.get("topology", TensorDict({})),
+            "cell": TensorDict({}, batch_size=[mesh.n_cells], device=device),
+            "point": TensorDict({}, batch_size=[mesh.n_points], device=device),
+            "topology": mesh._cache.get("topology", TensorDict({}, device=device)),
         },
         device=device,
     )
@@ -624,9 +624,9 @@ def translate(
     device = mesh.points.device
     new_cache = TensorDict(
         {
-            "cell": TensorDict({}, batch_size=[mesh.n_cells]),
-            "point": TensorDict({}, batch_size=[mesh.n_points]),
-            "topology": mesh._cache.get("topology", TensorDict({})),
+            "cell": TensorDict({}, batch_size=[mesh.n_cells], device=device),
+            "point": TensorDict({}, batch_size=[mesh.n_points], device=device),
+            "topology": mesh._cache.get("topology", TensorDict({}, device=device)),
         },
         device=device,
     )

--- a/test/mesh/mesh/test_compile.py
+++ b/test/mesh/mesh/test_compile.py
@@ -153,3 +153,51 @@ def test_post_init_runs_under_compile(
     compiled = torch.compile(fn, fullgraph=False)(points, cells)
 
     torch.testing.assert_close(compiled, expected)
+
+
+@pytest.mark.parametrize(
+    "property_name",
+    ["cell_normals", "cell_areas", "cell_centroids"],
+)
+def test_local_cell_geometry_under_fullgraph_compile(
+    property_name: str,
+    triangle_3d: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    """Local cell geometry should be capturable as one complete graph.
+
+    Constructing the nested cache must not trigger a nested ``TensorDict.to``
+    while Dynamo is tracing the ``Mesh`` constructor.
+    """
+    points, cells = triangle_3d
+
+    def fn(p: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        return getattr(Mesh(points=p, cells=c), property_name)
+
+    expected = fn(points, cells)
+    compiled = torch.compile(fn, backend="eager", fullgraph=True)(points, cells)
+
+    torch.testing.assert_close(compiled, expected)
+
+
+def test_cache_rebuild_paths_under_fullgraph_compile(
+    triangle_3d: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    """Operations that rebuild cache containers remain full-graph capturable."""
+    points, cells = triangle_3d
+
+    def fn(p: torch.Tensor, c: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        mesh = Mesh(points=p, cells=c)
+        _ = mesh.cell_areas
+        mesh = mesh.translate([1.0, 2.0, 3.0])
+        mesh = mesh.transform(
+            torch.eye(3, dtype=p.dtype, device=p.device), assume_invertible=True
+        )
+        mesh = mesh.slice_cells(torch.tensor([0], device=c.device))
+        mesh = mesh.pad(target_n_points=4, target_n_cells=2)
+        return mesh.points, mesh.cells, mesh.cell_areas
+
+    expected = fn(points, cells)
+    compiled = torch.compile(fn, backend="eager", fullgraph=True)(points, cells)
+
+    for actual, reference in zip(compiled, expected):
+        torch.testing.assert_close(actual, reference)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

`Mesh` previously placed its outer cache on the mesh device while leaving nested empty `TensorDict` containers device-unspecified. TensorDict then moved those containers during construction, which `torch.compile(fullgraph=True)` could not capture; basic properties such as cell areas, normals, and centroids failed while tracing.

This PR:

- Constructs nested cache containers directly on the mesh device.
- Uses the same pattern when slicing, padding, translating, or transforming a mesh rebuilds its cache.
- Adds full-graph regression coverage for local cell geometry and a chained cache-rebuilding workflow.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.

