### PR TITLE
Mesh: fix padding for discrete data and cached centroids

### DIFF
--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -2341,7 +2341,9 @@ class Mesh:
             Target number of cells. If None, no cell padding is applied.
             Must be >= current n_cells if specified. Also accepts SymInt for torch.compile.
         data_padding_value : float
-            Value to use for padding data fields. Defaults to NaN.
+            Value to use for padding data fields. Defaults to NaN for floating
+            and complex fields; integer and boolean fields use 0 when the
+            requested value is NaN, preserving their dtype.
 
         Returns
         -------
@@ -2378,24 +2380,55 @@ class Mesh:
         if target_n_cells is None:
             target_n_cells = self.n_cells
 
+        if (
+            not torch.compiler.is_compiling()
+            and target_n_cells > 0
+            and target_n_points == 0
+        ):
+            raise ValueError("Cannot pad cells without at least one mesh point.")
+
+        def _pad_data(tensor: torch.Tensor, size: int) -> torch.Tensor:
+            value = data_padding_value
+            if (
+                not tensor.is_floating_point()
+                and not tensor.is_complex()
+                and math.isnan(value)
+            ):
+                value = 0.0
+            return _pad_with_value(tensor, size, value)
+
+        padded_cell_cache = self._cache["cell"].apply(
+            lambda x: _pad_with_value(x, target_n_cells, 0.0),
+            batch_size=torch.Size([target_n_cells]),
+        )
+        centroids = self._cache.get(("cell", "centroids"), None)
+        if centroids is not None:
+            n_padding_cells = target_n_cells - self.n_cells
+            if self.n_points == 0:
+                padding_centroid = self.points.new_zeros((1, self.n_spatial_dims))
+            else:
+                padding_centroid = self.points[-1:]
+            padded_cell_cache["centroids"] = torch.cat(
+                [centroids, padding_centroid.expand(n_padding_cells, -1)]
+            )
+
         return self.__class__(
             points=_pad_by_tiling_last(self.points, target_n_points),
-            cells=_pad_with_value(self.cells, target_n_cells, self.n_points - 1),
+            cells=_pad_with_value(
+                self.cells, target_n_cells, max(self.n_points - 1, 0)
+            ),
             point_data=self.point_data.apply(
-                lambda x: _pad_with_value(x, target_n_points, data_padding_value),
+                lambda x: _pad_data(x, target_n_points),
                 batch_size=torch.Size([target_n_points]),
             ),
             cell_data=self.cell_data.apply(
-                lambda x: _pad_with_value(x, target_n_cells, data_padding_value),
+                lambda x: _pad_data(x, target_n_cells),
                 batch_size=torch.Size([target_n_cells]),
             ),
             global_data=self.global_data,
             _cache=TensorDict(
                 {
-                    "cell": self._cache["cell"].apply(
-                        lambda x: _pad_with_value(x, target_n_cells, 0.0),
-                        batch_size=torch.Size([target_n_cells]),
-                    ),
+                    "cell": padded_cell_cache,
                     "point": self._cache["point"].apply(
                         lambda x: _pad_with_value(x, target_n_points, 0.0),
                         batch_size=torch.Size([target_n_points]),
@@ -2424,7 +2457,9 @@ class Mesh:
             Base for computing the next power. Must be > 1.
             Provides a good balance between memory efficiency and compile cache hits.
         data_padding_value : float
-            Value to use for padding data fields. Defaults to NaN.
+            Value to use for padding data fields. Defaults to NaN for floating
+            and complex fields; integer and boolean fields use 0 when the
+            requested value is NaN, preserving their dtype.
 
         Returns
         -------

--- a/physicsnemo/mesh/utilities/_padding.py
+++ b/physicsnemo/mesh/utilities/_padding.py
@@ -33,6 +33,8 @@ def _pad_by_tiling_last(tensor: torch.Tensor, size: int) -> torch.Tensor:
         Padded tensor.
     """
     pad_count = size - tensor.shape[0]
+    if tensor.shape[0] == 0:
+        return tensor.new_zeros((size, *tensor.shape[1:]))
     padding = tensor[-1:].expand(pad_count, -1)
     return torch.cat([tensor, padding], dim=0)
 

--- a/test/mesh/mesh/test_padding.py
+++ b/test/mesh/mesh/test_padding.py
@@ -159,6 +159,19 @@ class TestPadBasic:
         assert torch.all(padded.cells[1] == 2)
         assert torch.all(padded.cells[2] == 2)
 
+    def test_cached_padded_cell_centroids_match_geometry(self):
+        """Padding must not make cell centroids depend on prior cache access."""
+        mesh = Mesh(
+            points=torch.tensor([[2.0, 3.0], [4.0, 3.0], [2.0, 5.0]]),
+            cells=torch.tensor([[0, 1, 2]]),
+        )
+        _ = mesh.cell_centroids
+
+        padded = mesh.pad(target_n_cells=3)
+        uncached = Mesh(points=padded.points, cells=padded.cells)
+
+        torch.testing.assert_close(padded.cell_centroids, uncached.cell_centroids)
+
 
 class TestPadWithData:
     """Tests for padding with point_data and cell_data."""
@@ -217,6 +230,31 @@ class TestPadWithData:
 
         assert torch.allclose(padded.point_data["temperature"][:10], original_temp)
 
+    @pytest.mark.parametrize(
+        ("values", "expected_dtype"),
+        [
+            (torch.tensor([1, 2, 3]), torch.int64),
+            (torch.tensor([True, False, True]), torch.bool),
+        ],
+    )
+    def test_default_padding_preserves_discrete_field_dtype(
+        self, values, expected_dtype
+    ):
+        """NaN defaults to zero for dtypes that cannot represent NaN."""
+        mesh = Mesh(
+            points=torch.tensor([[0.0], [1.0], [2.0]]),
+            cells=torch.tensor([[0, 1], [1, 2]]),
+            point_data={"label": values},
+        )
+
+        padded = mesh.pad(target_n_points=5)
+
+        assert padded.point_data["label"].dtype == expected_dtype
+        torch.testing.assert_close(padded.point_data["label"][:3], values)
+        torch.testing.assert_close(
+            padded.point_data["label"][3:], torch.zeros(2, dtype=expected_dtype)
+        )
+
 
 class TestPadErrors:
     """Tests for error handling in pad()."""
@@ -234,6 +272,15 @@ class TestPadErrors:
 
         with pytest.raises(ValueError, match="target_n_cells=.* must be >= "):
             mesh.pad(target_n_cells=3)
+
+    def test_pad_cells_requires_a_point(self):
+        mesh = Mesh(
+            points=torch.empty((0, 2)),
+            cells=torch.empty((0, 3), dtype=torch.long),
+        )
+
+        with pytest.raises(ValueError, match="without at least one mesh point"):
+            mesh.pad(target_n_cells=1)
 
 
 class TestPadToNextPowerBasic:
@@ -443,6 +490,30 @@ class TestPadEdgeCases:
         assert padded.n_cells == 5
         # All cells should reference the last point index (2)
         assert torch.all(padded.cells == 2)
+
+    def test_pad_empty_mesh(self):
+        mesh = Mesh(
+            points=torch.empty((0, 2)),
+            cells=torch.empty((0, 3), dtype=torch.long),
+        )
+
+        padded = mesh.pad(target_n_points=2, target_n_cells=3)
+
+        torch.testing.assert_close(padded.points, torch.zeros((2, 2)))
+        assert torch.equal(padded.cells, torch.zeros((3, 3), dtype=torch.long))
+        assert torch.equal(padded.cell_areas, torch.zeros(3))
+
+    def test_pad_empty_mesh_to_next_power(self):
+        mesh = Mesh(
+            points=torch.empty((0, 2)),
+            cells=torch.empty((0, 3), dtype=torch.long),
+        )
+
+        padded = mesh.pad_to_next_power(power=2.0)
+
+        assert padded.points.shape == (1, 2)
+        assert padded.cells.shape == (1, 3)
+        assert torch.equal(padded.cells, torch.zeros((1, 3), dtype=torch.long))
 
     def test_pad_preserves_global_data(self):
         """Test that global_data is preserved unchanged."""

--- a/test/mesh/utilities/test_utilities.py
+++ b/test/mesh/utilities/test_utilities.py
@@ -61,6 +61,14 @@ class TestPadding:
         assert padded.shape == (4, 2)
         assert torch.equal(padded[-2:], tensor[-1:].expand(2, -1))
 
+    def test_pad_by_tiling_last_empty_tensor(self):
+        """An empty tensor has no last row, so padding uses zero rows."""
+        tensor = torch.empty((0, 3), dtype=torch.float64)
+
+        padded = _pad_by_tiling_last(tensor, 2)
+
+        torch.testing.assert_close(padded, torch.zeros((2, 3), dtype=torch.float64))
+
     def test_pad_with_value_simple(self):
         """Test padding with constant value."""
         tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.long)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

`Mesh.pad()` previously failed on integer and boolean data with its default `NaN` fill. A previously cached cell centroid could also disagree with the geometry of a padded cell, making the result depend on whether the cache had already been populated.

This PR:

- Uses zero for default padding of fields that cannot represent `NaN`, preserving their dtype.
- Supports empty-mesh padding and rejects the impossible case of creating cells without any point.
- Keeps cached padded-cell centroids consistent with their repeated point.
- Adds regression coverage for discrete fields, empty meshes, cached centroids, and the low-level tiling helper.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.

