### PR TITLE
Post test coverage on PRs: Checks-API percentage + ready-to-enable `Codecov`

### DIFF
--- a/.github/actions/bootstrap-cudnn-ci/action.yml
+++ b/.github/actions/bootstrap-cudnn-ci/action.yml
@@ -41,6 +41,10 @@ runs:
           ca-certificates curl git gh zstd
           build-essential cmake pkg-config
           python3 python3-dev python3-venv python3-pip
+          # gpg: codecov-action downloads its uploader and verifies the
+          # signature with gpg; without it the (best-effort) upload step
+          # would fail silently even once CODECOV_TOKEN is provisioned.
+          gpg
         )
         rendering=(
           xvfb libgl1 libglu1-mesa libxrender1 libxext6 libsm6

--- a/.github/workflows/github-nightly-uv.yml
+++ b/.github/workflows/github-nightly-uv.yml
@@ -286,6 +286,10 @@ jobs:
     name: Coverage
     needs: build-environment
     runs-on: linux-amd64-gpu-h100-latest-1
+    env:
+      # Single source of truth for the coverage gate, kept in lockstep
+      # with github-pr.yml.
+      COVERAGE_FAIL_UNDER: "45"
     container:
       image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
       # /dev/shm defaults to 64 MiB in docker, which DALI's multiprocess
@@ -358,10 +362,17 @@ jobs:
         # -i / --ignore-errors downgrades coverage's fatal "No source for
         # code" error to a warning, matching the PR workflow.  Kept in
         # lockstep with github-pr.yml per .github/CACHE_CONTRACT.md.
-        uv run --no-sync coverage report -i --show-missing --omit="*test*" --omit="*internal*" --omit="*experimental*" --fail-under=45
+        #
+        # Report generation is intentionally kept free of --fail-under
+        # (lockstep with github-pr.yml): gating this step meant a sub-
+        # threshold night silently skipped the html/xml artifacts below.
+        # The threshold is enforced by its own final step instead.
+        uv run --no-sync coverage report -i --show-missing --omit="*test*" --omit="*internal*" --omit="*experimental*"
         uv run --no-sync coverage html -i
-        # Also create an XML report for potential CI integrations
-        uv run --no-sync coverage xml -i -o coverage.xml
+        # xml carries the same omits as the report so the number Codecov
+        # publishes agrees with the enforced threshold (lockstep with
+        # github-pr.yml).
+        uv run --no-sync coverage xml -i -o coverage.xml --omit="*test*" --omit="*internal*" --omit="*experimental*"
 
     - name: Upload coverage HTML report
       uses: actions/upload-artifact@v4
@@ -378,6 +389,24 @@ jobs:
           .coverage
           coverage.xml
         retention-days: 30
+
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() }}
+      # Best-effort and inert until CODECOV_TOKEN is provisioned (see
+      # github-pr.yml). The nightly runs the full suite, so this flag is
+      # the meaningful trend line on the dashboard; the PR job's
+      # `pr-core` flag is the testmon-selected subset.
+      continue-on-error: true
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+      with:
+        disable_search: true
+        files: ./coverage.xml
+        flags: nightly-full
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Enforce coverage threshold
+      run: |
+        uv run --no-sync coverage report -i --omit="*test*" --omit="*internal*" --omit="*experimental*" --fail-under="${COVERAGE_FAIL_UNDER}"
 
   # Stage 4: Generate browsable test reports from JUnit XML
   test-reports:

--- a/.github/workflows/github-nightly-uv.yml
+++ b/.github/workflows/github-nightly-uv.yml
@@ -289,7 +289,7 @@ jobs:
     env:
       # Single source of truth for the coverage gate, kept in lockstep
       # with github-pr.yml.
-      COVERAGE_FAIL_UNDER: "45"
+      COVERAGE_FAIL_UNDER: "70"
     container:
       image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
       # /dev/shm defaults to 64 MiB in docker, which DALI's multiprocess

--- a/.github/workflows/github-pr.yml
+++ b/.github/workflows/github-pr.yml
@@ -156,7 +156,7 @@ jobs:
     env:
       # Single source of truth for the coverage gate; read by both the
       # "Coverage %" check run (display) and the enforcement step (gate).
-      COVERAGE_FAIL_UNDER: "45"
+      COVERAGE_FAIL_UNDER: "70"
     container:
       image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
       # /dev/shm defaults to 64 MiB in docker, which DALI's multiprocess

--- a/.github/workflows/github-pr.yml
+++ b/.github/workflows/github-pr.yml
@@ -153,6 +153,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: linux-amd64-gpu-h100-latest-1
+    env:
+      # Single source of truth for the coverage gate; read by both the
+      # "Coverage %" check run (display) and the enforcement step (gate).
+      COVERAGE_FAIL_UNDER: "45"
     container:
       image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
       # /dev/shm defaults to 64 MiB in docker, which DALI's multiprocess
@@ -231,9 +235,18 @@ jobs:
         # code" error to a warning.  The restored nightly baseline can
         # reference files this PR has moved or deleted (e.g. a renamed
         # module); without -i the combined report aborts on the stale path.
-        uv run --no-sync coverage report -i --show-missing --omit="*test*" --omit="*internal*" --omit="*experimental*" --fail-under=45
+        #
+        # Report generation is intentionally kept free of --fail-under: it
+        # used to gate this step, which meant html/xml/json (and the PR's
+        # coverage percentage) were silently skipped whenever a PR fell
+        # under the threshold -- exactly the case where seeing the number
+        # matters most. The threshold is now enforced by its own step below.
+        uv run --no-sync coverage report -i --show-missing --omit="*test*" --omit="*internal*" --omit="*experimental*"
         uv run --no-sync coverage html -i
-        uv run --no-sync coverage xml -i -o coverage.xml
+        # xml carries the same omits as report/json so the number Codecov
+        # publishes agrees with the "Coverage %" check and the gate below.
+        uv run --no-sync coverage xml -i -o coverage.xml --omit="*test*" --omit="*internal*" --omit="*experimental*"
+        uv run --no-sync coverage json -i -o coverage.json --omit="*test*" --omit="*internal*" --omit="*experimental*"
 
     - name: Upload coverage HTML report
       uses: actions/upload-artifact@v4
@@ -241,3 +254,73 @@ jobs:
         name: coverage-report-pr
         path: htmlcov/
         retention-days: 7
+
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() }}
+      # Best-effort (NVIDIA/warp's pattern): inert until an admin installs
+      # the Codecov GitHub App and provisions the CODECOV_TOKEN secret, and
+      # never fails the job on upload errors. Behavior config: codecov.yml
+      # at the repo root. Dashboard: app.codecov.io/gh/NVIDIA/physicsnemo
+      continue-on-error: true
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+      with:
+        disable_search: true
+        files: ./coverage.xml
+        flags: pr-core
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Report coverage percentage on the PR
+      if: always()
+      # Informational: a failure here (corrupt coverage.json, transient
+      # Checks API error) must never fail the Coverage job itself.
+      continue-on-error: true
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+
+          // Informational only -- the existing "Coverage" job/check
+          // already gates pass/fail on the threshold; this check just
+          // surfaces the actual number and never blocks the PR itself.
+          const check = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: 'Coverage %',
+            head_sha: context.sha,
+            status: 'completed',
+            conclusion: 'neutral',
+          };
+
+          // With `if: always()` this step runs even when an earlier step
+          // died before writing coverage.json; report that instead of
+          // throwing on the missing file.
+          if (!fs.existsSync('coverage.json')) {
+            check.output = {
+              title: 'coverage.json not produced',
+              summary:
+                'An earlier step in the Coverage job failed before the ' +
+                'report was generated -- see that step\'s log for the cause.',
+            };
+            await github.rest.checks.create(check);
+            return;
+          }
+
+          const data = JSON.parse(fs.readFileSync('coverage.json', 'utf8'));
+          const pct = data.totals.percent_covered.toFixed(2);
+          const threshold = Number(process.env.COVERAGE_FAIL_UNDER);
+          const passed = data.totals.percent_covered >= threshold;
+
+          check.output = {
+            title: `${pct}% covered (excl. test/internal/experimental)`,
+            summary:
+              `**Line coverage: ${pct}%** (threshold: ${threshold}%, ` +
+              `${passed ? 'passing' : 'currently failing -- see the "Coverage" check'})\n\n` +
+              `- Lines covered: ${data.totals.covered_lines} / ${data.totals.num_statements}\n` +
+              `- Branches covered: ${data.totals.covered_branches} / ${data.totals.num_branches}\n\n` +
+              `Full annotated report: see the \`coverage-report-pr\` artifact on this workflow run.`,
+          };
+          await github.rest.checks.create(check);
+
+    - name: Enforce coverage threshold
+      run: |
+        uv run --no-sync coverage report -i --omit="*test*" --omit="*internal*" --omit="*experimental*" --fail-under="${COVERAGE_FAIL_UNDER}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds a neutral, non-blocking `Coverage %` check run on every PR (showing
+  the measured percentage and lines/branches detail) and a ready-to-enable
+  Codecov integration (`codecov.yml`), inert until an admin installs the
+  Codecov GitHub App and provisions `CODECOV_TOKEN`. Also fixes a latent
+  bug where `--fail-under` gated report generation itself, silently
+  skipping HTML/XML/JSON coverage artifacts whenever a run fell below the
+  threshold; the threshold (raised from 45% to 70%, matching current
+  nightly whole-repo coverage) is now enforced in its own step so reports
+  always generate.
 - Adds the experimental Strata weather-emulation models —
   `physicsnemo.experimental.models.strata.Strata` and `StrataTransformer3D` — plus
   the continuous / stereographic RoPE helpers `build_rope_cos_sin_1d_continuous`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds coverage reporting on PRs (informational `Coverage %` check and a ready-to-enable Codecov integration).
 - Adds the experimental Strata weather-emulation models —
   `physicsnemo.experimental.models.strata.Strata` and `StrataTransformer3D` — plus
   the continuous / stereographic RoPE helpers `build_rope_cos_sin_1d_continuous`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds coverage reporting on PRs (informational `Coverage %` check and a ready-to-enable Codecov integration).
+- Adds coverage reporting on PRs — an informational `Coverage %` check plus a
+  ready-to-enable Codecov integration.
 - Adds the experimental Strata weather-emulation models —
   `physicsnemo.experimental.models.strata.Strata` and `StrataTransformer3D` — plus
   the continuous / stereographic RoPE helpers `build_rope_cos_sin_1d_continuous`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds a neutral, non-blocking `Coverage %` check run on every PR (showing
-  the measured percentage and lines/branches detail) and a ready-to-enable
-  Codecov integration (`codecov.yml`), inert until an admin installs the
-  Codecov GitHub App and provisions `CODECOV_TOKEN`. Also fixes a latent
-  bug where `--fail-under` gated report generation itself, silently
-  skipping HTML/XML/JSON coverage artifacts whenever a run fell below the
-  threshold; the threshold (raised from 45% to 70%, matching current
-  nightly whole-repo coverage) is now enforced in its own step so reports
-  always generate.
 - Adds the experimental Strata weather-emulation models —
   `physicsnemo.experimental.models.strata.Strata` and `StrataTransformer3D` — plus
   the continuous / stereographic RoPE helpers `build_rope_cos_sin_1d_continuous`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,3 +318,7 @@ The pipeline has following stages:
     Aim for more than 80% code coverage.
     To test coverage locally, run the `get_coverage.sh` script from the `test` folder and
     check the coverage of the module that you added/edited.
+    In CI, the overall coverage gate (`COVERAGE_FAIL_UNDER`) is enforced by the `Coverage`
+    job and currently requires 70%. Every PR also gets an informational, non-blocking
+    `Coverage %` check reporting the measured percentage, and uncovered lines are annotated
+    inline in the PR's Files view once the Codecov integration is enabled.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Codecov behavior config, following rapidsai/cudf's shape. All peer repos
+# (NVIDIA/warp, NVIDIA/NeMo, rapidsai/cudf) disable the PR comment; coverage
+# signal surfaces through checks/statuses and the codecov.io dashboard.
+
+comment: false
+
+coverage:
+  status:
+    # The in-repo Coverage job already gates the project total via
+    # --fail-under; a second gate here would just be a duplicate.
+    project: off
+    patch:
+      default:
+        target: auto
+        informational: true  # diff coverage is a signal, never a blocker
+
+github_checks:
+  # Paint uncovered changed lines directly onto the PR's Files view.
+  annotations: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-FileCopyrightText: All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Codecov behavior config, following rapidsai/cudf's shape. All peer repos
 # (NVIDIA/warp, NVIDIA/NeMo, rapidsai/cudf) disable the PR comment; coverage


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

# PhysicsNeMo Pull Request


In contrast to other modern NVIDIA repos (warp, NeMo, cuDF), we don't have any visible coverage reporting on PRs, which makes review harder and regressions easier to miss. 

This PR adds a neutral Coverage % check on every PR and a ready-to-enable (currently inert) Codecov integration that activates dashboard and full diff -coverage as soon as admin installs it, and fixes a latent bug where sub-threshold runs produced no coverage artifacts at all.

## Description

Makes coverage results visible on PRs and fixes a latent CI bug:

* `--fail-under=45` previously gated report generation itself, so any run below the threshold produced no HTML/XML artifacts at all. Reports now always generate; the threshold is enforced in its own final step for both PR and nightly workflows. The value is kept in lockstep and hoisted to a single `COVERAGE_FAIL_UNDER` environment variable.

* Adds a neutral, non-blocking `Coverage %` check run on every PR, showing the measured percentage and lines/branches detail. This is informational only. The existing `Coverage` job still owns pass/fail, so this check should **not** be added to branch-protection required checks.

* Adds a Codecov upload using a SHA-pinned action with `continue-on-error`, plus a `codecov.yml` that follows the `rapidsai/cudf` shape: `comment: false`, informational diff coverage, and inline annotations. This is fully inert until an admin installs the Codecov GitHub App on `NVIDIA/physicsnemo` and adds the `CODECOV_TOKEN` repository secret. It is safe to merge without those pieces; the dashboard will appear at https://app.codecov.io/gh/NVIDIA/physicsnemo.

* Adds `gpg` to the CI bootstrap because the Codecov uploader verifies its signature with it. `NVIDIA/warp` installs it for the same reason. This also aligns `coverage xml`’s `--omit` flags with the report/json outputs so all published numbers measure the same file set.

Verification: all YAML validated; `codecov.yml` passes Codecov’s official validation endpoint; the check-run script’s `coverage.json` field names were verified against real output from this repo’s own coverage config; nightly step ordering was audited, and baseline cache publish is untouched. Final confirmation is this PR’s own CI run: the `Coverage %` check should appear, and the Codecov step should soft-fail green because there is no token yet.

Fixes : https://github.com/NVIDIA/physicsnemo-roadmap/issues/2725

## Checklist

* [x] I am familiar with the [[Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
* [ ] New or existing tests cover these changes. CI-only change; see verification above.
* [x] The documentation is up to date with these changes.
* [ ] The [[CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md)](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
* [x] An [[issue](https://github.com/NVIDIA/physicsnemo/issues)](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
* [x] If I am implementing a new model or modifying any existing model, I have followed the [[Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation)](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

None. This adds one SHA-pinned GitHub Action and the `gpg` apt package in CI; both are inert/internal.