### PR TITLE
Add Dependabot for GitHub Actions and uv dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dependabot keeps CI action pins and Python dependencies fresh so they do not
+# silently rot (e.g. Node-20 action deprecations, stale pre-commit hook revs).
+# Updates are grouped to minimize PR noise and scheduled weekly.
+
+version: 2
+updates:
+  # GitHub Actions used by the workflows in .github/workflows and the composite
+  # actions under .github/actions. Keeps SHA/tag pins current and patches
+  # deprecated runner (Node) versions.
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Python dependencies managed by uv (pyproject.toml + uv.lock).
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    groups:
+      # One PR for routine patch/minor bumps; majors still open individually
+      # so they get deliberate review.
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description

Adds a `.github/dependabot.yml` so CI action pins and Python dependencies stay current automatically, instead of drifting until something breaks (we already see Node-20 deprecation warnings on `checkout@v4`/`cache@v4`/`setup-python@v5`, and a `pre-commit-hooks` rev pinned years behind).

Two update streams, both weekly and grouped to minimize PR noise:

* **`github-actions`** — scans `.github/workflows/` and the composite actions under `.github/actions/*`; keeps action SHA/tag pins fresh and patches deprecated runner (Node) versions. All bumps grouped into a single PR (`ci` commit prefix).
* **`uv`** — Python deps from `pyproject.toml` + `uv.lock`; minor/patch bumps grouped into one PR while majors open individually for deliberate review (`deps` commit prefix).

PR limits are capped (5 for actions, 10 for Python) to keep the queue manageable.

> Note: Dependabot only activates once this file is on the **default branch**, so the first update PRs will appear after merge — nothing runs on this PR itself.

## Checklist

* [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
* [x] New or existing tests cover these changes. — N/A, CI-config only.
* [x] The documentation is up to date with these changes. — self-documented in the config comments.
* [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes. — CI-only change, no user-facing entry.
* [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
* [x] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation). — N/A.

## Dependencies

None. This adds a GitHub-native automation config; no runtime or build dependencies.
