### PR TITLE
Tune Codecov: enable PR comment, carryforward flags, threshold, components

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![GitHub](https://img.shields.io/github/license/NVIDIA/physicsnemo)](https://github.com/NVIDIA/physicsnemo/blob/master/LICENSE.txt)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Install CI](https://github.com/NVIDIA/physicsnemo/actions/workflows/install-ci.yml/badge.svg?event=schedule)](https://github.com/NVIDIA/physicsnemo/actions/workflows/install-ci.yml)
+[![codecov](https://codecov.io/gh/NVIDIA/physicsnemo/branch/main/graph/badge.svg)](https://app.codecov.io/gh/NVIDIA/physicsnemo)
 
 <!-- markdownlint-enable -->
 [**NVIDIA PhysicsNeMo**](#what-is-physicsnemo)

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Codecov behavior config, following rapidsai/cudf's shape. All peer repos
-# (NVIDIA/warp, NVIDIA/NeMo, rapidsai/cudf) disable the PR comment; coverage
-# signal surfaces through checks/statuses and the codecov.io dashboard.
+# Codecov behavior config, following the rapidsai/cudf + zarr shapes.
 
-comment: false
+# Post a coverage summary comment on PRs. Kept low-noise: only when
+# coverage actually changes, and only after the coverage upload(s) land.
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: true  # only comment when coverage changes vs base
 
 coverage:
   status:
@@ -28,7 +31,49 @@ coverage:
     patch:
       default:
         target: auto
+        threshold: 5%        # tolerance band so small diffs don't flip status
         informational: true  # diff coverage is a signal, never a blocker
+
+# Flags let Codecov combine partial coverage uploads correctly. The PR
+# Coverage job runs a testmon-selected subset, so without carryforward a
+# PR that runs only a few tests would report artificially low coverage;
+# carryforward reuses the last-known coverage for anything not re-run.
+flags:
+  pr-core:
+    paths:
+      - physicsnemo/
+    carryforward: true
+
+# Wait for coverage upload(s) before computing/notifying. Bump this as
+# GPU / multi-GPU coverage uploads are added so no status reports early.
+codecov:
+  notify:
+    after_n_builds: 1
+    wait_for_ci: true
+
+# Per-subsystem coverage so under-tested modules are visible, not just a
+# single repo-wide number.
+component_management:
+  individual_components:
+    - component_id: models
+      paths:
+        - physicsnemo/models/**
+    - component_id: distributed
+      paths:
+        - physicsnemo/distributed/**
+        - physicsnemo/domain_parallel/**
+    - component_id: datapipes
+      paths:
+        - physicsnemo/datapipes/**
+    - component_id: mesh
+      paths:
+        - physicsnemo/mesh/**
+    - component_id: nn
+      paths:
+        - physicsnemo/nn/**
+    - component_id: diffusion
+      paths:
+        - physicsnemo/diffusion/**
 
 github_checks:
   # Paint uncovered changed lines directly onto the PR's Files view.


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description

Tunes `codecov.yml` now that the Codecov app + `CODECOV_TOKEN` are live. Main user-facing change: **Codecov now posts a coverage summary comment on PRs** (previously `comment: false`). It's kept low-noise:

* `comment.require_changes: true` — only comments when coverage actually changes vs base.
* `layout: "diff, files"` — concise diff + per-file summary.

Also adds coverage-accuracy and auditing improvements:

* **Carryforward on the `pr-core` flag** — the PR `Coverage` job runs a testmon-selected subset, so without carryforward a PR that re-runs only a few tests reports artificially low coverage. Carryforward reuses the last-known coverage for anything not re-run, so the reported number stays accurate under change-based selection.
* **5% patch threshold** — tolerance band so tiny diffs don't flip status (still `informational`, never blocking).
* **Per-subsystem components** (`models`, `distributed`, `datapipes`, `mesh`, `nn`, `diffusion`) — module-level coverage auditing instead of one repo-wide number.
* **`after_n_builds` / `wait_for_ci`** — wait for the coverage upload before notifying (bump as GPU/multi-GPU uploads are added).

Inline diff annotations (`github_checks.annotations: true`) are retained. Validated against Codecov's official validation endpoint (`Valid!`).

## Checklist

* [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
* [ ] New or existing tests cover these changes. — N/A, CI-config only.
* [x] The documentation is up to date with these changes. — self-documented in the config comments.
* [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes. — CI-only change.
* [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
* [x] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation). — N/A.

## Dependencies

None. Config-only; behavior is inert without the already-provisioned Codecov app + `CODECOV_TOKEN`.
