### PR TITLE
Add generic data-fitting error metrics (MAE/L1, relative L2, Huber) to physicsnemo.metrics.general

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the continuous / stereographic RoPE helpers `build_rope_cos_sin_1d_continuous`,
   `build_axial_rope_cos_sin_2d_continuous`, `stereographic_projection`, and
   `spherical_centroid` in `physicsnemo.experimental.nn`.
+- Adds general data-fitting error metrics to `physicsnemo.metrics.general`:
+  `mae` (mean absolute error, aliased as `l1`), `relative_l2` / `relative_lp`
+  (scale-invariant relative :math:`L_p` error, a.k.a. `LpLoss`), and `huber`
+  (smooth :math:`L_1` error). These complement the existing `mse` / `rmse` and
+  provide the common regression losses used by neural-operator training loops.
 - Adds Point-Transformer local vector-attention blocks to `physicsnemo.nn`.
 - Adds an `is_causal` option to `TimmSelfAttention` in `physicsnemo.nn` for
   causal self-attention.

--- a/docs/api/physicsnemo.metrics.rst
+++ b/docs/api/physicsnemo.metrics.rst
@@ -26,6 +26,14 @@ Below is a summary of general purpose statistical methods and metrics that are a
      - Mean Squared error between two tensors
    * - `physicsnemo.metrics.general.mse.rmse <#physicsnemo.metrics.general.mse.rmse>`_
      - Root Mean Squared error between two tensors
+   * - `physicsnemo.metrics.general.mae.mae <#physicsnemo.metrics.general.mae.mae>`_
+     - Mean Absolute error (a.k.a. ``l1``) between two tensors
+   * - `physicsnemo.metrics.general.relative.relative_l2 <#physicsnemo.metrics.general.relative.relative_l2>`_
+     - Scale-invariant relative :math:`L_2` error between two tensors
+   * - `physicsnemo.metrics.general.relative.relative_lp <#physicsnemo.metrics.general.relative.relative_lp>`_
+     - Scale-invariant relative :math:`L_p` error between two tensors
+   * - `physicsnemo.metrics.general.huber.huber <#physicsnemo.metrics.general.huber.huber>`_
+     - Huber (smooth :math:`L_1`) error between two tensors
    * - `physicsnemo.metrics.general.histogram.histogram <#physicsnemo.metrics.general.histogram.histogram>`_
      - Histogram of a set of tensors over the leading dimension
    * - `physicsnemo.metrics.general.histogram.cdf <#physicsnemo.metrics.general.histogram.cdf>`_
@@ -228,6 +236,18 @@ General
 ---------
 
 .. automodule:: physicsnemo.metrics.general.mse
+    :members:
+    :show-inheritance:
+
+.. automodule:: physicsnemo.metrics.general.mae
+    :members:
+    :show-inheritance:
+
+.. automodule:: physicsnemo.metrics.general.relative
+    :members:
+    :show-inheritance:
+
+.. automodule:: physicsnemo.metrics.general.huber
     :members:
     :show-inheritance:
 

--- a/physicsnemo/metrics/general/huber.py
+++ b/physicsnemo/metrics/general/huber.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Union
+
+import torch
+import torch.nn.functional as F
+
+Tensor = torch.Tensor
+
+
+def huber(
+    pred: Tensor,
+    target: Tensor,
+    delta: float = 1.0,
+    dim: Optional[Union[int, tuple]] = None,
+) -> Union[Tensor, float]:
+    r"""Calculates the Huber error between two tensors.
+
+    The Huber error behaves quadratically for element-wise errors smaller than
+    ``delta`` and linearly for larger errors, combining the sensitivity of the
+    mean squared error near zero with the robustness of the mean absolute error
+    for outliers:
+
+    .. math::
+
+        \mathrm{Huber}(x) = \begin{cases}
+            \tfrac{1}{2} x^2 & |x| \le \delta \\
+            \delta (|x| - \tfrac{1}{2}\delta) & |x| > \delta,
+        \end{cases}
+
+    where :math:`x = \mathrm{pred} - \mathrm{target}`.
+
+    Parameters
+    ----------
+    pred : Tensor
+        Input prediction tensor.
+    target : Tensor
+        Target tensor.
+    delta : float, optional
+        Threshold at which the error transitions from quadratic to linear,
+        by default ``1.0``.
+    dim : int or tuple of int, optional
+        Reduction dimension(s). When ``None`` the error is averaged over all
+        observations, by default ``None``.
+
+    Returns
+    -------
+    Union[Tensor, float]
+        Huber error value(s).
+    """
+    unreduced = F.huber_loss(pred, target, reduction="none", delta=delta)
+    return torch.mean(unreduced, dim=dim)

--- a/physicsnemo/metrics/general/mae.py
+++ b/physicsnemo/metrics/general/mae.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Union
+
+import torch
+
+Tensor = torch.Tensor
+
+
+def mae(
+    pred: Tensor, target: Tensor, dim: Optional[Union[int, tuple]] = None
+) -> Union[Tensor, float]:
+    r"""Calculates the Mean Absolute Error (MAE) between two tensors.
+
+    The mean absolute error, also known as the :math:`L_1` error, is
+
+    .. math::
+
+        \mathrm{MAE} = \mathrm{mean}(|\mathrm{pred} - \mathrm{target}|).
+
+    Parameters
+    ----------
+    pred : Tensor
+        Input prediction tensor.
+    target : Tensor
+        Target tensor.
+    dim : int or tuple of int, optional
+        Reduction dimension(s). When ``None`` the error is averaged over all
+        observations, by default ``None``.
+
+    Returns
+    -------
+    Union[Tensor, float]
+        Mean absolute error value(s).
+    """
+    return torch.mean(torch.abs(pred - target), dim=dim)
+
+
+# ``l1`` is a common alias for the mean absolute error.
+l1 = mae

--- a/physicsnemo/metrics/general/relative.py
+++ b/physicsnemo/metrics/general/relative.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Union
+
+import torch
+
+Tensor = torch.Tensor
+
+
+def relative_lp(
+    pred: Tensor,
+    target: Tensor,
+    p: float = 2.0,
+    dim: Optional[Union[int, tuple]] = None,
+    eps: float = 1e-8,
+) -> Tensor:
+    r"""Calculates the relative :math:`L_p` error between two tensors.
+
+    The relative :math:`L_p` error is scale-invariant and is defined as
+
+    .. math::
+
+        \frac{\lVert \mathrm{pred} - \mathrm{target} \rVert_p}
+             {\lVert \mathrm{target} \rVert_p + \epsilon}.
+
+    This is a common error measure in neural-operator learning where the
+    output magnitude varies across samples (sometimes referred to as the
+    ``LpLoss``).
+
+    Parameters
+    ----------
+    pred : Tensor
+        Input prediction tensor.
+    target : Tensor
+        Target tensor.
+    p : float, optional
+        Order of the norm, by default ``2.0``.
+    dim : int or tuple of int, optional
+        Dimension(s) over which to compute the norms. When ``None`` the norms
+        are computed over the flattened tensors, by default ``None``.
+    eps : float, optional
+        Small value added to the denominator for numerical stability,
+        by default ``1e-8``.
+
+    Returns
+    -------
+    Tensor
+        Relative :math:`L_p` error value(s).
+    """
+    # ``torch.linalg.vector_norm`` treats ``dim=None`` as "flatten then reduce",
+    # so a single call handles both the global and per-dimension cases.
+    diff_norm = torch.linalg.vector_norm(pred - target, ord=p, dim=dim)
+    target_norm = torch.linalg.vector_norm(target, ord=p, dim=dim)
+    return diff_norm / (target_norm + eps)
+
+
+def relative_l2(
+    pred: Tensor,
+    target: Tensor,
+    dim: Optional[Union[int, tuple]] = None,
+    eps: float = 1e-8,
+) -> Tensor:
+    r"""Calculates the relative :math:`L_2` error between two tensors.
+
+    Convenience wrapper around :func:`relative_lp` with ``p=2``:
+
+    .. math::
+
+        \frac{\lVert \mathrm{pred} - \mathrm{target} \rVert_2}
+             {\lVert \mathrm{target} \rVert_2 + \epsilon}.
+
+    Parameters
+    ----------
+    pred : Tensor
+        Input prediction tensor.
+    target : Tensor
+        Target tensor.
+    dim : int or tuple of int, optional
+        Dimension(s) over which to compute the norms. When ``None`` the norms
+        are computed over the flattened tensors, by default ``None``.
+    eps : float, optional
+        Small value added to the denominator for numerical stability,
+        by default ``1e-8``.
+
+    Returns
+    -------
+    Tensor
+        Relative :math:`L_2` error value(s).
+    """
+    return relative_lp(pred, target, p=2.0, dim=dim, eps=eps)

--- a/test/metrics/test_metrics_general.py
+++ b/test/metrics/test_metrics_general.py
@@ -28,6 +28,9 @@ import physicsnemo.metrics.general.histogram as hist
 import physicsnemo.metrics.general.power_spectrum as ps
 import physicsnemo.metrics.general.wasserstein as w
 from physicsnemo.distributed.manager import DistributedManager
+from physicsnemo.metrics.general.huber import huber
+from physicsnemo.metrics.general.mae import l1, mae
+from physicsnemo.metrics.general.relative import relative_l2, relative_lp
 
 Tensor = torch.Tensor
 
@@ -853,3 +856,95 @@ def test_power_spectrum(device):
     assert (power[0, 0] < 1e-6).sum() > (
         power[0, 0].numel() * 0.9
     )  # Most bins are zero
+
+
+# ---------------------------------------------------------------------------
+# Data-fitting losses: mae / l1, relative_l2 / relative_lp, huber
+# ---------------------------------------------------------------------------
+
+
+def test_mae(device):
+    # Known value: constant offset of 1 -> MAE = 1.
+    target = torch.zeros(1, 4, 4, 2, device=device)
+    pred = torch.ones(1, 4, 4, 2, device=device)
+    assert torch.isclose(mae(pred, target), torch.tensor(1.0, device=device))
+
+    # ``l1`` is an alias of ``mae``.
+    assert l1 is mae
+
+    # A known offset of 2 -> MAE = 2.
+    pred2 = torch.full_like(target, 2.0)
+    assert torch.isclose(l1(pred2, target), torch.tensor(2.0, device=device))
+
+    # Zero for identical inputs.
+    x = torch.randn(2, 8, 16, 4, device=device)
+    assert torch.isclose(mae(x.clone(), x), torch.tensor(0.0, device=device), atol=1e-6)
+
+    # Per-dimension reduction preserves the batch dimension.
+    assert mae(x, torch.randn_like(x), dim=(1, 2, 3)).shape == (2,)
+
+
+def test_relative_l2(device):
+    # Zero for identical inputs.
+    target = torch.randn(2, 8, 16, 4, device=device)
+    assert torch.isclose(
+        relative_l2(target.clone(), target), torch.tensor(0.0, device=device), atol=1e-6
+    )
+
+    # Positive for different inputs.
+    pred = target + 0.1 * torch.randn_like(target)
+    assert relative_l2(pred, target) > 0
+
+    # Scale invariance: relative error is unchanged under a common rescale.
+    shifted = torch.randn(2, 8, 16, 4, device=device) + 2.0
+    pred_s = shifted + 0.1 * torch.randn_like(shifted)
+    assert torch.isclose(
+        relative_l2(pred_s, shifted), relative_l2(pred_s * 5, shifted * 5), rtol=1e-4
+    )
+
+    # ``eps`` prevents NaN/Inf when the target norm is zero.
+    zero_target = torch.zeros(2, 4, 4, 2, device=device)
+    ones = torch.ones(2, 4, 4, 2, device=device)
+    loss = relative_l2(zero_target + ones, zero_target, eps=1e-6)
+    assert not torch.isnan(loss) and not torch.isinf(loss)
+
+    # Per-sample reduction over non-batch dimensions.
+    assert relative_l2(pred, target, dim=(1, 2, 3)).shape == (2,)
+
+
+def test_relative_lp(device):
+    # ``relative_l2`` matches ``relative_lp`` with p=2.
+    target = torch.randn(3, 6, 6, device=device) + 1.0
+    pred = target + 0.2 * torch.randn_like(target)
+    assert torch.isclose(relative_lp(pred, target, p=2.0), relative_l2(pred, target))
+
+    # Relative L1 is scale-invariant and non-negative.
+    rel_l1 = relative_lp(pred, target, p=1.0)
+    assert rel_l1 >= 0
+    assert torch.isclose(rel_l1, relative_lp(pred * 3, target * 3, p=1.0), rtol=1e-4)
+
+
+def test_huber(device):
+    # For small element-wise errors and delta=1, Huber ~= 0.5 * MSE.
+    target = torch.randn(2, 8, 8, 4, device=device)
+    pred = target + 0.01 * torch.randn_like(target)
+    mse_val = torch.mean((pred - target) ** 2)
+    huber_val = huber(pred, target, delta=1.0)
+    assert torch.isclose(mse_val, huber_val * 2, rtol=0.1)
+
+    # Zero for identical inputs.
+    assert torch.isclose(
+        huber(target.clone(), target), torch.tensor(0.0, device=device), atol=1e-6
+    )
+
+    # For large errors, Huber grows linearly: delta*(|x| - 0.5*delta).
+    target0 = torch.zeros(1, 4, 4, device=device)
+    pred_big = torch.full_like(target0, 10.0)
+    expected = 1.0 * (10.0 - 0.5 * 1.0)
+    assert torch.isclose(
+        huber(pred_big, target0, delta=1.0),
+        torch.tensor(expected, device=device),
+    )
+
+    # Per-dimension reduction preserves the batch dimension.
+    assert huber(pred, target, dim=(1, 2, 3)).shape == (2,)


### PR DESCRIPTION
## Summary

Adds three commonly-needed data-fitting error metrics to the canonical
`physicsnemo.metrics.general`, complementing the existing `mse` / `rmse`:

- `mae` (mean absolute error), aliased as `l1` — `physicsnemo/metrics/general/mae.py`
- `relative_l2` and a general `relative_lp` (scale-invariant relative Lp error,
  a.k.a. `LpLoss`) — `physicsnemo/metrics/general/relative.py`
- `huber` (smooth L1 error) — `physicsnemo/metrics/general/huber.py`

All follow the existing functional `mse(pred, target, dim=None)` signature style.
An audit confirmed none of these existed anywhere in the library (only `mse`/`rmse`),
so this is purely additive with no duplication.

This is the first of three small, stacked PRs upstreaming reusable, generic
components discovered while developing a reservoir-simulation example.

Closes #1804

## Test plan

- [x] `test/metrics/test_metrics_general.py` extended with analytic value checks,
      zero-for-identical, `relative_l2` scale-invariance, eps-guard, and
      per-dimension reduction tests.
- [x] `interrogate` docstring coverage 100% on the new files.
- [x] `ruff check` (E/F/S/I/PERF) and `ruff format` clean.
- [x] License headers present; CHANGELOG updated.