### PR TITLE
Add VolumeConservationLoss to physicsnemo.experimental.losses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the continuous / stereographic RoPE helpers `build_rope_cos_sin_1d_continuous`,
   `build_axial_rope_cos_sin_2d_continuous`, `stereographic_projection`, and
   `spherical_centroid` in `physicsnemo.experimental.nn`.
+- Adds `VolumeConservationLoss` to `physicsnemo.experimental.losses`, a generic,
+  dimension-agnostic weak-conservation loss. It compares the (optionally
+  volume-weighted) spatial integral of a prediction and a target at each step of
+  a trailing feature/time axis using an injectable data-fitting metric, with
+  optional inactive-cell masking. It enforces conservation of a volume-weighted
+  integral (not true mass; no density/porosity is applied).
 - Adds `SpatialDerivativeLoss` to `physicsnemo.experimental.losses`, a generic,
   dimension-agnostic spatial-derivative regularization loss. It compares the
   interior (non-periodic) central-difference gradients of a prediction and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the continuous / stereographic RoPE helpers `build_rope_cos_sin_1d_continuous`,
   `build_axial_rope_cos_sin_2d_continuous`, `stereographic_projection`, and
   `spherical_centroid` in `physicsnemo.experimental.nn`.
+- Adds `SpatialDerivativeLoss` to `physicsnemo.experimental.losses`, a generic,
+  dimension-agnostic spatial-derivative regularization loss. It compares the
+  interior (non-periodic) central-difference gradients of a prediction and a
+  target on a non-uniform grid (per-axis cell widths) using an injectable
+  data-fitting metric, with optional inactive-cell masking for sparse grids.
+  The reusable `central_difference` / `cell_centre_distance` helpers are also
+  exported.
 - Adds Point-Transformer local vector-attention blocks to `physicsnemo.nn`.
 - Adds an `is_causal` option to `TimmSelfAttention` in `physicsnemo.nn` for
   causal self-attention.

--- a/physicsnemo/experimental/losses/__init__.py
+++ b/physicsnemo/experimental/losses/__init__.py
@@ -19,9 +19,11 @@ from .derivative import (
     cell_centre_distance,
     central_difference,
 )
+from .volume_conservation import VolumeConservationLoss
 
 __all__ = [
     "SpatialDerivativeLoss",
+    "VolumeConservationLoss",
     "cell_centre_distance",
     "central_difference",
 ]

--- a/physicsnemo/experimental/losses/__init__.py
+++ b/physicsnemo/experimental/losses/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .derivative import (
+    SpatialDerivativeLoss,
+    cell_centre_distance,
+    central_difference,
+)
+
+__all__ = [
+    "SpatialDerivativeLoss",
+    "cell_centre_distance",
+    "central_difference",
+]

--- a/physicsnemo/experimental/losses/derivative.py
+++ b/physicsnemo/experimental/losses/derivative.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Spatial-derivative regularization loss.
+
+Penalizes the discrepancy between the spatial gradients of a prediction and a
+target field. This is a common regularizer for neural-operator surrogates on
+structured grids, where matching the field *and* its derivatives yields sharper,
+more physical solutions.
+
+.. note::
+
+    PhysicsNeMo already provides several grid derivative operators in
+    :mod:`physicsnemo.nn.functional.derivatives` (e.g. ``rectilinear_grid_gradient``,
+    ``uniform_grid_gradient``). Those operators are *periodic*, coordinate-based,
+    and act on a single scalar field, which makes them unsuitable for this loss:
+    the regularizer must operate on *batched* fields with a trailing feature/time
+    axis, use *non-periodic* interior central differences (so boundary cells are
+    not wrapped), and support an inactive-cell *mask* (sparse grids such as the
+    Norne reservoir). The self-contained :func:`central_difference` /
+    :func:`cell_centre_distance` helpers below cover exactly that regime.
+"""
+
+from typing import Callable, Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from physicsnemo.metrics.general.mse import mse
+
+Tensor = torch.Tensor
+
+
+def cell_centre_distance(cell_widths: Tensor, min_spacing: float = 1e-6) -> Tensor:
+    r"""Distance between the centres of cell :math:`i` and cell :math:`i+2`.
+
+    For a non-uniform 1-D grid with cell widths :math:`w`, the distance used by
+    the interior central-difference stencil is
+
+    .. math::
+
+        d_i = \tfrac{1}{2} w_i + w_{i+1} + \tfrac{1}{2} w_{i+2}.
+
+    A minimum floor is applied to avoid division-by-zero when widths are zero
+    (inactive cells) or very small (e.g. normalized grids).
+
+    Parameters
+    ----------
+    cell_widths : Tensor
+        1-D tensor of cell widths with shape :math:`(N,)`.
+    min_spacing : float, optional
+        Lower bound applied to the output distances, by default ``1e-6``.
+
+    Returns
+    -------
+    Tensor
+        Cell-centre distances with shape :math:`(N - 2,)`.
+    """
+    d = cell_widths[:-2] / 2.0 + cell_widths[1:-1] + cell_widths[2:] / 2.0
+    return d.clamp(min=min_spacing)
+
+
+def central_difference(field: Tensor, axis: int, spacing: Tensor) -> Tensor:
+    r"""Interior central-difference derivative of ``field`` along ``axis``.
+
+    Computes :math:`(f_{i+2} - f_i) / d_i` for every interior point, where
+    :math:`d` are the cell-centre distances from :func:`cell_centre_distance`.
+    The output is *non-periodic*: the differentiated axis is reduced by two
+    (no boundary wrap-around).
+
+    Parameters
+    ----------
+    field : Tensor
+        Arbitrary-rank tensor to differentiate.
+    axis : int
+        Dimension along which to differentiate.
+    spacing : Tensor
+        1-D cell-centre distances with shape :math:`(N - 2,)`, where
+        :math:`N` is ``field.shape[axis]``.
+
+    Returns
+    -------
+    Tensor
+        Derivative tensor with ``field.shape[axis]`` reduced by two.
+    """
+    n = field.shape[axis]
+    f_right = field.narrow(axis, 2, n - 2)
+    f_left = field.narrow(axis, 0, n - 2)
+
+    shape = [1] * field.dim()
+    shape[axis] = -1
+    sp = spacing.reshape(shape)
+
+    return (f_right - f_left) / sp
+
+
+class SpatialDerivativeLoss(nn.Module):
+    r"""Regularization loss on the spatial derivatives of a field.
+
+    For each requested spatial axis, the interior central-difference derivative
+    (see :func:`central_difference`) of both ``pred`` and ``target`` is computed
+    on a non-uniform grid defined by per-axis cell widths, and the two are
+    compared with a data-fitting ``metric``. The per-axis losses are averaged.
+
+    The loss is dimension-agnostic: it works for any number of spatial axes
+    (e.g. 2-D :math:`(B, H, W, T)` or 3-D :math:`(B, X, Y, Z, T)` fields with a
+    trailing feature/time axis), and it supports an optional boolean mask that
+    excludes inactive cells (useful for sparse grids). Inactive cells are zeroed
+    before differentiation and any derivative sample whose central-difference
+    stencil touches an inactive cell is excluded from the comparison.
+
+    Parameters
+    ----------
+    metric : Callable[[Tensor, Tensor], Tensor], optional
+        Data-fitting metric used to compare the predicted and target
+        derivatives. Any of the :mod:`physicsnemo.metrics.general` functions
+        (e.g. :func:`~physicsnemo.metrics.general.mse.mse`,
+        :func:`~physicsnemo.metrics.general.relative.relative_l2`) or a custom
+        callable can be injected. Defaults to
+        :func:`~physicsnemo.metrics.general.mse.mse`.
+    min_spacing : float, optional
+        Lower bound on the cell-centre distances used by the derivative stencil,
+        by default ``1e-6``.
+
+    Forward
+    -------
+    pred : Tensor
+        Predicted field of shape :math:`(B, *\mathrm{spatial}, T)`.
+    target : Tensor
+        Target field with the same shape as ``pred``.
+    cell_widths : Dict[int, Tensor]
+        Mapping from a ``pred`` tensor axis (a spatial axis, i.e. one of
+        :math:`1 \ldots N_\mathrm{spatial}`) to the 1-D cell widths along that
+        axis. The keys select which axes are differentiated.
+    mask : Tensor, optional
+        Boolean tensor marking active cells, either static ``(*spatial)`` (shared
+        across the batch) or per-sample ``(B, *spatial)`` (each sample uses its
+        own mask). When ``None`` all cells are active.
+
+    Outputs
+    -------
+    Tensor
+        Scalar derivative-regularization loss, averaged over the axes that
+        contribute at least one valid derivative sample. An axis whose
+        central-difference stencil is fully masked out contributes nothing and
+        is excluded from the average; if no axis contributes, the loss is zero.
+
+    Notes
+    -----
+    When a ``mask`` is supplied, the loss selects active derivative samples via
+    boolean indexing, which produces data-dependent shapes. The masked path is
+    therefore **not traceable by** :func:`torch.compile` (it triggers a graph
+    break / eager fallback); the unmasked path compiles normally.
+
+    Example
+    -------
+    >>> import torch
+    >>> from physicsnemo.experimental.losses import SpatialDerivativeLoss
+    >>> loss = SpatialDerivativeLoss()
+    >>> pred = torch.randn(2, 8, 16, 4)
+    >>> target = torch.randn(2, 8, 16, 4)
+    >>> widths = {1: torch.ones(8), 2: torch.ones(16)}  # differentiate H and W
+    >>> value = loss(pred, target, widths)
+    >>> value.ndim
+    0
+    """
+
+    def __init__(
+        self,
+        metric: Callable[[Tensor, Tensor], Tensor] = mse,
+        min_spacing: float = 1e-6,
+    ):
+        super().__init__()
+        self.metric = metric
+        self.min_spacing = min_spacing
+
+    @staticmethod
+    def _is_per_sample_mask(mask: Tensor, pred: Tensor) -> bool:
+        """True when ``mask`` has a leading batch dimension matching ``pred``.
+
+        A per-sample mask has shape ``(B, *spatial)`` (rank ``pred.dim() - 1``);
+        a static mask has shape ``(*spatial)`` (rank ``pred.dim() - 2``) and is
+        shared across the batch.
+        """
+        return mask.dim() == pred.dim() - 1 and mask.shape[0] == pred.shape[0]
+
+    def forward(
+        self,
+        pred: Tensor,
+        target: Tensor,
+        cell_widths: Dict[int, Tensor],
+        mask: Optional[Tensor] = None,
+    ) -> Tensor:
+        if not torch.compiler.is_compiling():
+            if pred.shape != target.shape:
+                raise ValueError(
+                    f"pred and target must have the same shape, got "
+                    f"{tuple(pred.shape)} and {tuple(target.shape)}"
+                )
+            if not cell_widths:
+                raise ValueError("cell_widths must specify at least one axis")
+            # Keys must be spatial axes: the batch axis (0) and the trailing
+            # feature/time axis are excluded, otherwise the stencil would
+            # silently differentiate the wrong dimension.
+            valid_axes = range(1, pred.dim() - 1)
+            for axis, widths in cell_widths.items():
+                if axis not in valid_axes:
+                    raise ValueError(
+                        f"cell_widths keys must be spatial axes in "
+                        f"[1, {pred.dim() - 2}] (the batch axis 0 and the "
+                        f"trailing feature/time axis are excluded), got {axis}"
+                    )
+                # The 1-D cell widths must span the full axis, otherwise the
+                # derivative stencil/spacing would mismatch the field extent.
+                if widths.shape != (pred.shape[axis],):
+                    raise ValueError(
+                        f"cell_widths[{axis}] must be a 1-D tensor of length "
+                        f"{pred.shape[axis]} (pred.shape[{axis}]), got shape "
+                        f"{tuple(widths.shape)}"
+                    )
+
+        # Masks are applied per-sample when a ``(B, *spatial)`` mask is given, so a
+        # cell inactive in one sample never contributes to that sample's loss.
+        per_sample_mask = mask is not None and self._is_per_sample_mask(mask, pred)
+        if mask is not None:
+            # Zero inactive cells so the stencil does not read garbage across the
+            # active/inactive boundary. Per-sample: ``(B, *spatial, 1)``;
+            # static: ``(1, *spatial, 1)``.
+            if per_sample_mask:
+                zero_w = mask.unsqueeze(-1)
+            else:
+                zero_w = mask.unsqueeze(0).unsqueeze(-1)
+            pred = pred * zero_w
+            target = target * zero_w
+
+        total = torch.zeros((), device=pred.device, dtype=pred.dtype)
+        n_contributing = 0
+        for axis, widths in cell_widths.items():
+            spacing = cell_centre_distance(widths, min_spacing=self.min_spacing)
+            d_pred = central_difference(pred, axis, spacing)
+            d_target = central_difference(target, axis, spacing)
+
+            if mask is not None:
+                # Stencil-safe mask: a derivative sample is valid only when all
+                # three stencil cells (i, i+1, i+2) along ``axis`` are active. The
+                # mask axis is offset by the batch dim for per-sample masks.
+                mask_axis = axis if per_sample_mask else axis - 1
+                n = mask.shape[mask_axis]
+                m_left = mask.narrow(mask_axis, 0, n - 2)
+                m_centre = mask.narrow(mask_axis, 1, n - 2)
+                m_right = mask.narrow(mask_axis, 2, n - 2)
+                deriv_mask = m_left & m_centre & m_right
+                if per_sample_mask:
+                    sel = deriv_mask.unsqueeze(-1).expand_as(d_pred)
+                else:
+                    sel = deriv_mask.unsqueeze(0).unsqueeze(-1).expand_as(d_pred)
+                p = d_pred[sel]
+                t = d_target[sel]
+            else:
+                p = d_pred
+                t = d_target
+
+            # Skip axes with no active derivative samples (e.g. a fully-masked
+            # region) so that reducing an empty tensor cannot produce NaN.
+            if p.numel() == 0:
+                continue
+
+            total = total + self.metric(p, t)
+            n_contributing += 1
+
+        # Average over the axes that actually contributed, so that a fully-masked
+        # axis does not silently shrink the loss magnitude. Returns 0 when no
+        # axis has any valid derivative sample.
+        if n_contributing == 0:
+            return total
+        return total / n_contributing

--- a/physicsnemo/experimental/losses/volume_conservation.py
+++ b/physicsnemo/experimental/losses/volume_conservation.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Volume-conservation enforcement loss.
+
+Penalizes the discrepancy between the (optionally volume-weighted) spatial
+integral of a prediction and a target field at each step of a trailing
+feature/time axis. Matching the spatially-integrated quantity is a weak
+conservation constraint used to regularize neural-operator surrogates.
+
+.. important::
+
+    This enforces conservation of a *volume-weighted spatial integral*
+    :math:`\int u \, \mathrm{d}V`, not true mass conservation: no material
+    density or porosity is applied, so the constraint is physically meaningful
+    only for quantities whose spatial integral is (approximately) conserved.
+"""
+
+from typing import Callable, Optional
+
+import torch
+import torch.nn as nn
+
+from physicsnemo.metrics.general.mse import mse
+
+Tensor = torch.Tensor
+
+
+class VolumeConservationLoss(nn.Module):
+    r"""Enforces conservation of a field's volume-weighted spatial integral.
+
+    For a prediction and target of shape :math:`(B, *\mathrm{spatial}, T)`, the
+    loss integrates each field over the spatial dimensions using per-cell
+    volume weights, producing a conserved-quantity time series of shape
+    :math:`(B, T)`, and compares the two series with a data-fitting ``metric``:
+
+    .. math::
+
+        Q_b^{\,t} = \sum_{\mathrm{spatial}} w \, u_b^{\,t}, \qquad
+        \mathcal{L} = \mathrm{mean}_b\; \mathrm{metric}\big(Q^{\,\mathrm{pred}}_b,
+        Q^{\,\mathrm{true}}_b\big),
+
+    where :math:`w` are the cell volumes (uniform when not provided). The loss
+    is dimension-agnostic (2-D or 3-D spatial fields) and supports an optional
+    inactive-cell mask for sparse grids.
+
+    Parameters
+    ----------
+    metric : Callable[..., Tensor], optional
+        Per-sample data-fitting metric applied to the conserved-quantity time
+        series. It is called as ``metric(pred, target, dim=-1)`` and must return
+        one value per sample; any :mod:`physicsnemo.metrics.general` function
+        (e.g. :func:`~physicsnemo.metrics.general.mse.mse`) or a compatible
+        callable (such as a relative-error metric) can be injected. Defaults to
+        :func:`~physicsnemo.metrics.general.mse.mse`.
+
+    Forward
+    -------
+    pred : Tensor
+        Predicted field of shape :math:`(B, *\mathrm{spatial}, T)`.
+    target : Tensor
+        Target field with the same shape as ``pred``.
+    cell_volumes : Tensor, optional
+        Per-cell volume weights of shape ``(*spatial)``. When ``None`` uniform
+        weights of one are used.
+    mask : Tensor, optional
+        Boolean tensor marking active cells, either static ``(*spatial)`` (shared
+        across the batch) or per-sample ``(B, *spatial)`` (each sample uses its
+        own mask). Inactive cells receive zero weight in that sample's integral.
+
+    Outputs
+    -------
+    Tensor
+        Scalar volume-conservation loss.
+
+    Example
+    -------
+    >>> import torch
+    >>> from physicsnemo.experimental.losses import VolumeConservationLoss
+    >>> loss = VolumeConservationLoss()
+    >>> pred = torch.randn(2, 8, 16, 4)
+    >>> target = torch.randn(2, 8, 16, 4)
+    >>> volumes = torch.ones(8, 16)
+    >>> value = loss(pred, target, volumes)
+    >>> value.ndim
+    0
+    """
+
+    def __init__(
+        self,
+        metric: Callable[..., Tensor] = mse,
+    ):
+        super().__init__()
+        self.metric = metric
+
+    @staticmethod
+    def _is_per_sample_mask(mask: Tensor, pred: Tensor) -> bool:
+        """True when ``mask`` has a leading batch dim matching ``pred``.
+
+        A per-sample mask has shape ``(B, *spatial)``; a static mask has shape
+        ``(*spatial)`` and is shared across the batch.
+        """
+        return mask.dim() == pred.dim() - 1 and mask.shape[0] == pred.shape[0]
+
+    def forward(
+        self,
+        pred: Tensor,
+        target: Tensor,
+        cell_volumes: Optional[Tensor] = None,
+        mask: Optional[Tensor] = None,
+    ) -> Tensor:
+        # Integrate over all spatial axes between the batch axis and the
+        # trailing feature/time axis.
+        spatial_dims = tuple(range(1, pred.dim() - 1))
+        spatial_shape = tuple(pred.shape[1 : pred.dim() - 1])
+
+        if not torch.compiler.is_compiling():
+            if pred.shape != target.shape:
+                raise ValueError(
+                    f"pred and target must have the same shape, got "
+                    f"{tuple(pred.shape)} and {tuple(target.shape)}"
+                )
+            if pred.dim() < 3:
+                raise ValueError(
+                    "pred must have shape (B, *spatial, T) with at least one "
+                    f"spatial dimension, got {tuple(pred.shape)}"
+                )
+            # cell_volumes must span exactly the spatial dims, otherwise the
+            # weight broadcast would mismatch the field extent.
+            if cell_volumes is not None and tuple(cell_volumes.shape) != spatial_shape:
+                raise ValueError(
+                    f"cell_volumes must have shape {spatial_shape} (pred's spatial "
+                    f"dims), got {tuple(cell_volumes.shape)}"
+                )
+            # mask must be static (*spatial) or per-sample (B, *spatial).
+            if mask is not None and tuple(mask.shape) not in (
+                spatial_shape,
+                (pred.shape[0], *spatial_shape),
+            ):
+                raise ValueError(
+                    f"mask must have shape {spatial_shape} (static) or "
+                    f"{(pred.shape[0], *spatial_shape)} (per-sample), got "
+                    f"{tuple(mask.shape)}"
+                )
+
+        if cell_volumes is None:
+            vol = torch.ones(spatial_shape, device=pred.device, dtype=pred.dtype)
+        else:
+            vol = cell_volumes
+
+        # Build per-cell weights, applying the mask per-sample when a
+        # ``(B, *spatial)`` mask is given so a cell inactive in one sample does
+        # not contribute to that sample's integral.
+        if mask is not None and self._is_per_sample_mask(mask, pred):
+            # (*spatial) * (B, *spatial) -> (B, *spatial, 1)
+            w = (vol.unsqueeze(0) * mask.to(vol.dtype)).unsqueeze(-1)
+        elif mask is not None:
+            # static (*spatial) mask -> (1, *spatial, 1)
+            w = (vol * mask.to(vol.dtype)).unsqueeze(0).unsqueeze(-1)
+        else:
+            w = vol.unsqueeze(0).unsqueeze(-1)
+
+        m_pred = (pred * w).sum(dim=spatial_dims)  # (B, T)
+        m_true = (target * w).sum(dim=spatial_dims)  # (B, T)
+
+        per_sample = self.metric(m_pred, m_true, dim=-1)
+        return per_sample.mean()

--- a/test/experimental/losses/__init__.py
+++ b/test/experimental/losses/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/experimental/losses/test_derivative_loss.py
+++ b/test/experimental/losses/test_derivative_loss.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the generic spatial-derivative regularization loss."""
+
+import functools
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from physicsnemo.experimental.losses import (
+    SpatialDerivativeLoss,
+    cell_centre_distance,
+    central_difference,
+)
+from physicsnemo.metrics.general.mse import mse
+
+
+# Small, self-contained comparison metrics used to exercise dependency injection
+# (the loss accepts any ``metric(pred, target, dim=...)`` callable).
+def _l1(pred, target, dim=None):
+    return torch.mean(torch.abs(pred - target), dim=dim)
+
+
+def _relative_l2(pred, target, dim=None, eps=1e-8):
+    diff = torch.linalg.vector_norm(pred - target, dim=dim)
+    denom = torch.linalg.vector_norm(target, dim=dim)
+    return diff / (denom + eps)
+
+
+def _huber(pred, target, delta=1.0, dim=None):
+    return torch.mean(
+        F.huber_loss(pred, target, reduction="none", delta=delta), dim=dim
+    )
+
+
+METRICS = {
+    "mse": mse,
+    "l1": _l1,
+    "relative_l2": _relative_l2,
+    "huber": _huber,
+}
+
+
+# ---------------------------------------------------------------------------
+# Finite-difference helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCellCentreDistance:
+    def test_uniform_grid(self, device):
+        widths = torch.tensor([2.0, 2.0, 2.0, 2.0], device=device)
+        d = cell_centre_distance(widths)
+        # d[i] = w[i]/2 + w[i+1] + w[i+2]/2 = 1 + 2 + 1 = 4
+        assert d.shape == (2,)
+        assert torch.allclose(d, torch.tensor([4.0, 4.0], device=device))
+
+    def test_non_uniform(self, device):
+        widths = torch.tensor([10.0, 20.0, 30.0, 15.0, 25.0, 10.0], device=device)
+        d = cell_centre_distance(widths)
+        assert d.shape == (4,)
+        # d[0] = 10/2 + 20 + 30/2 = 40 ; d[1] = 20/2 + 30 + 15/2 = 47.5
+        assert torch.isclose(d[0], torch.tensor(40.0, device=device))
+        assert torch.isclose(d[1], torch.tensor(47.5, device=device))
+
+    def test_min_spacing_floor(self, device):
+        widths = torch.zeros(4, device=device)
+        d = cell_centre_distance(widths, min_spacing=1e-3)
+        assert torch.all(d >= 1e-3)
+
+
+class TestCentralDifference:
+    def test_linear_field(self, device):
+        # Derivative of a linear field f(w)=w on a uniform grid is 1.
+        field = (
+            torch.arange(6, dtype=torch.float, device=device)
+            .view(1, 1, 6, 1)
+            .expand(1, 4, 6, 2)
+        )
+        spacing = cell_centre_distance(torch.ones(6, device=device))
+        deriv = central_difference(field, axis=2, spacing=spacing)
+        assert deriv.shape == (1, 4, 4, 2)
+        assert torch.allclose(deriv, torch.ones_like(deriv))
+
+    def test_non_uniform_spacing(self, device):
+        field = torch.tensor([0.0, 1.0, 3.0, 6.0, 10.0, 15.0], device=device).view(
+            1, 1, 6, 1
+        )
+        widths = torch.tensor([10.0, 20.0, 30.0, 15.0, 25.0, 10.0], device=device)
+        spacing = cell_centre_distance(widths)
+        deriv = central_difference(field, axis=2, spacing=spacing)
+        # d[0] = (f[2]-f[0])/40 = 3/40 ; d[1] = (f[3]-f[1])/47.5 = 5/47.5
+        assert torch.isclose(deriv[0, 0, 0, 0], torch.tensor(3.0 / 40.0, device=device))
+        assert torch.isclose(deriv[0, 0, 1, 0], torch.tensor(5.0 / 47.5, device=device))
+
+    def test_3d_axis(self, device):
+        field = torch.randn(1, 6, 4, 3, 2, device=device)
+        spacing = cell_centre_distance(torch.ones(6, device=device))
+        deriv = central_difference(field, axis=1, spacing=spacing)
+        assert deriv.shape == (1, 4, 4, 3, 2)
+
+
+# ---------------------------------------------------------------------------
+# SpatialDerivativeLoss
+# ---------------------------------------------------------------------------
+
+
+def _uniform_widths(shape, axes, device):
+    return {ax: torch.ones(shape[ax], device=device) for ax in axes}
+
+
+class TestSpatialDerivativeLoss:
+    def test_constructor_defaults(self):
+        loss = SpatialDerivativeLoss()
+        assert loss.metric is mse
+        assert loss.min_spacing == 1e-6
+
+    def test_zero_for_identical_2d(self, device):
+        loss = SpatialDerivativeLoss()
+        target = torch.randn(1, 8, 16, 4, device=device)
+        widths = _uniform_widths((1, 8, 16, 4), (1, 2), device)
+        value = loss(target.clone(), target, widths)
+        assert torch.isclose(value, torch.tensor(0.0, device=device), atol=1e-6)
+
+    def test_zero_for_identical_3d(self, device):
+        loss = SpatialDerivativeLoss()
+        target = torch.randn(1, 6, 8, 4, 3, device=device)
+        widths = _uniform_widths((1, 6, 8, 4, 3), (1, 2, 3), device)
+        value = loss(target.clone(), target, widths)
+        assert torch.isclose(value, torch.tensor(0.0, device=device), atol=1e-6)
+
+    @pytest.mark.parametrize("metric_name", list(METRICS))
+    def test_all_metrics_2d(self, metric_name, device):
+        loss = SpatialDerivativeLoss(metric=METRICS[metric_name])
+        target = torch.randn(2, 8, 16, 4, device=device) + 1.0
+        pred = target + 0.05 * torch.randn_like(target)
+        widths = _uniform_widths((2, 8, 16, 4), (1, 2), device)
+        value = loss(pred, target, widths)
+        assert torch.isfinite(value)
+        assert value > 0
+
+    def test_single_axis(self, device):
+        loss = SpatialDerivativeLoss()
+        pred = torch.randn(2, 8, 16, 4, device=device)
+        target = torch.randn(2, 8, 16, 4, device=device)
+        for ax in (1, 2):
+            value = loss(pred, target, {ax: torch.ones(pred.shape[ax], device=device)})
+            assert torch.isfinite(value)
+
+    def test_non_uniform_grid(self, device):
+        loss = SpatialDerivativeLoss()
+        dx = torch.tensor([10.0, 20.0, 30.0, 15.0, 25.0, 10.0], device=device)
+        target = torch.zeros(1, 4, 6, 2, device=device)
+        pred = torch.zeros(1, 4, 6, 2, device=device)
+        pred[0, :, :, 0] = torch.arange(6, device=device).float()
+        value = loss(pred, target, {2: dx})
+        assert torch.isfinite(value)
+        assert value > 0
+
+    def test_gradient_flow(self, device):
+        loss = SpatialDerivativeLoss()
+        target = torch.randn(2, 8, 16, 4, device=device)
+        pred = torch.randn(2, 8, 16, 4, device=device, requires_grad=True)
+        widths = _uniform_widths((2, 8, 16, 4), (1, 2), device)
+        loss(pred, target, widths).backward()
+        assert pred.grad is not None
+        assert torch.isfinite(pred.grad).all()
+
+    def test_mask_excludes_boundary_artifacts(self, device):
+        # Large error only in the masked-out region -> loss ~ 0.
+        loss = SpatialDerivativeLoss()
+        target = torch.randn(1, 8, 12, 2, device=device)
+        pred = target.clone()
+        pred[:, :3, :, :] += 100.0
+        mask = torch.zeros(8, 12, dtype=torch.bool, device=device)
+        mask[4:, :] = True
+        widths = _uniform_widths((1, 8, 12, 2), (1, 2), device)
+        value = loss(pred, target, widths, mask=mask)
+        assert torch.isclose(value, torch.tensor(0.0, device=device), atol=1e-4)
+
+    def test_per_sample_mask_finite(self, device):
+        # A per-sample mask with different active regions per sample is accepted
+        # and produces a finite loss.
+        loss = SpatialDerivativeLoss()
+        target = torch.randn(2, 8, 10, 3, device=device) + 1.0
+        pred = target + 0.05 * torch.randn_like(target)
+        mask = torch.zeros(2, 8, 10, dtype=torch.bool, device=device)
+        mask[0, 1:6, 2:8] = True
+        mask[1, 2:7, 1:6] = True
+        widths = _uniform_widths((2, 8, 10, 3), (1, 2), device)
+        value = loss(pred, target, widths, mask=mask)
+        assert torch.isfinite(value)
+
+    def test_per_sample_mask_is_not_global(self, device):
+        # A per-sample mask must not leak across samples: a large error confined
+        # to masked-out rows of sample 0 (which are unperturbed and active for
+        # sample 1) must leave the loss at zero.
+        loss = SpatialDerivativeLoss()
+        target = torch.randn(2, 8, 10, 2, device=device)
+        pred = target.clone()
+        pred[0, :3, :, :] += 100.0  # error in rows 0..2 of sample 0 only
+        mask = torch.ones(2, 8, 10, dtype=torch.bool, device=device)
+        mask[0, :4, :] = False  # sample 0: rows 0..3 inactive (cover error+stencil)
+        widths = _uniform_widths((2, 8, 10, 2), (1, 2), device)
+        value = loss(pred, target, widths, mask=mask)
+        assert torch.isclose(value, torch.tensor(0.0, device=device), atol=1e-4)
+
+    def test_sparse_mask_no_nan(self, device):
+        # Norne-like sparse grid with relative_l2 must not produce NaN/Inf.
+        loss = SpatialDerivativeLoss(metric=_relative_l2)
+        dx = torch.tensor(
+            [10.0, 20.0, 15.0, 10.0, 25.0, 30.0, 10.0, 20.0, 15.0, 10.0],
+            device=device,
+        )
+        target = torch.randn(1, 10, 12, 3, device=device)
+        pred = target + 0.1 * torch.randn_like(target)
+        mask = torch.zeros(10, 12, dtype=torch.bool, device=device)
+        mask[2:5, 3:8] = True
+        value = loss(pred, target, {1: dx}, mask=mask)
+        assert torch.isfinite(value)
+
+    def test_single_timestep(self, device):
+        loss = SpatialDerivativeLoss(metric=_relative_l2)
+        pred = torch.randn(2, 8, 16, 1, device=device)
+        target = torch.randn(2, 8, 16, 1, device=device)
+        widths = _uniform_widths((2, 8, 16, 1), (1, 2), device)
+        assert torch.isfinite(loss(pred, target, widths))
+
+    def test_minimum_grid(self, device):
+        # 3 cells along an axis is the minimum for a central difference.
+        loss = SpatialDerivativeLoss()
+        target = torch.randn(1, 3, 3, 2, device=device) + 1.0
+        pred = target + 0.1
+        widths = _uniform_widths((1, 3, 3, 2), (1, 2), device)
+        value = loss(pred, target, widths)
+        assert torch.isfinite(value)
+
+    def test_custom_metric_eps(self, device):
+        # A metric with a custom keyword can be injected via functools.partial.
+        loss = SpatialDerivativeLoss(metric=functools.partial(_relative_l2, eps=1e-3))
+        pred = torch.randn(1, 6, 6, 2, device=device)
+        target = torch.zeros(1, 6, 6, 2, device=device)
+        value = loss(pred, target, _uniform_widths((1, 6, 6, 2), (1, 2), device))
+        assert torch.isfinite(value)
+
+    def test_shape_mismatch_raises(self, device):
+        loss = SpatialDerivativeLoss()
+        pred = torch.randn(1, 8, 8, 2, device=device)
+        target = torch.randn(1, 8, 8, 3, device=device)
+        with pytest.raises(ValueError, match="same shape"):
+            loss(pred, target, {1: torch.ones(8, device=device)})
+
+    def test_empty_widths_raises(self, device):
+        loss = SpatialDerivativeLoss()
+        pred = torch.randn(1, 8, 8, 2, device=device)
+        with pytest.raises(ValueError, match="at least one axis"):
+            loss(pred, pred, {})
+
+    def test_fully_masked_returns_zero(self, device):
+        # No active cell anywhere -> no contributing axis -> zero (not NaN).
+        loss = SpatialDerivativeLoss()
+        pred = torch.randn(1, 8, 10, 2, device=device)
+        target = torch.randn(1, 8, 10, 2, device=device)
+        mask = torch.zeros(8, 10, dtype=torch.bool, device=device)
+        widths = _uniform_widths((1, 8, 10, 2), (1, 2), device)
+        value = loss(pred, target, widths, mask=mask)
+        assert torch.isfinite(value)
+        assert torch.isclose(value, torch.tensor(0.0, device=device))
+
+    def test_masked_axis_excluded_from_average(self, device):
+        # A mask that leaves no valid stencil along axis 2 (only two active
+        # columns) but valid samples along axis 1. The fully-masked axis must be
+        # excluded from the average, so differentiating {1, 2} equals {1} alone.
+        loss = SpatialDerivativeLoss()
+        pred = torch.randn(1, 6, 6, 2, device=device)
+        target = torch.randn(1, 6, 6, 2, device=device)
+        mask = torch.zeros(6, 6, dtype=torch.bool, device=device)
+        mask[:, 2:4] = True  # two active columns -> no 3-wide window along W
+        both = loss(
+            pred, target, _uniform_widths((1, 6, 6, 2), (1, 2), device), mask=mask
+        )
+        only_axis1 = loss(
+            pred, target, _uniform_widths((1, 6, 6, 2), (1,), device), mask=mask
+        )
+        assert torch.isclose(both, only_axis1)
+
+    @pytest.mark.parametrize("bad_axis", [0, 3])
+    def test_invalid_axis_key_raises(self, bad_axis, device):
+        # axis 0 is the batch axis and axis 3 is the trailing feature/time axis;
+        # neither is a valid spatial axis for a (B, H, W, T) field.
+        loss = SpatialDerivativeLoss()
+        pred = torch.randn(1, 8, 8, 2, device=device)
+        with pytest.raises(ValueError, match="spatial axes"):
+            loss(
+                pred, pred, {bad_axis: torch.ones(pred.shape[bad_axis], device=device)}
+            )
+
+    def test_widths_length_mismatch_raises(self, device):
+        # cell widths must span the full axis (length == pred.shape[axis]).
+        loss = SpatialDerivativeLoss()
+        pred = torch.randn(1, 8, 8, 2, device=device)
+        with pytest.raises(ValueError, match="must be a 1-D tensor of length"):
+            loss(pred, pred, {1: torch.ones(5, device=device)})
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/experimental/losses/test_volume_conservation.py
+++ b/test/experimental/losses/test_volume_conservation.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the generic volume-conservation enforcement loss.
+
+Uses analytically-verifiable dummy reservoirs with known cell volumes, passed
+explicitly to the (grid-convention-agnostic) loss.
+"""
+
+import functools
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from physicsnemo.experimental.losses import VolumeConservationLoss
+from physicsnemo.metrics.general.mse import mse
+
+
+# Small, self-contained comparison metrics used to exercise dependency injection
+# (the loss accepts any ``metric(pred, target, dim=...)`` callable). Each reduces
+# over the trailing (time) axis so the loss can average over the batch.
+def _l1(pred, target, dim=None):
+    return torch.mean(torch.abs(pred - target), dim=dim)
+
+
+def _relative_l2(pred, target, dim=None, eps=1e-8):
+    diff = torch.linalg.vector_norm(pred - target, dim=dim)
+    denom = torch.linalg.vector_norm(target, dim=dim)
+    return diff / (denom + eps)
+
+
+def _huber(pred, target, delta=1.0, dim=None):
+    return torch.mean(
+        F.huber_loss(pred, target, reduction="none", delta=delta), dim=dim
+    )
+
+
+# 2D reservoir: cell widths -> volumes (areas); total area = 30 * 110 = 3300.
+DX_2D = torch.tensor([10.0, 20.0, 30.0, 15.0, 25.0, 10.0])
+DY_2D = torch.tensor([5.0, 10.0, 5.0, 10.0])
+# 3D reservoir: total volume = 45 * 30 * 20 = 27000.
+DX_3D = torch.tensor([10.0, 20.0, 15.0])
+DY_3D = torch.tensor([5.0, 10.0, 5.0, 10.0])
+DZ_3D = torch.tensor([8.0, 12.0])
+
+METRICS = {"mse": mse, "l1": _l1, "relative_l2": _relative_l2, "huber": _huber}
+
+
+def _volumes_2d(device):
+    return (DY_2D.to(device).unsqueeze(1) * DX_2D.to(device).unsqueeze(0)).contiguous()
+
+
+def _volumes_3d(device):
+    return (
+        DX_3D.to(device)[:, None, None]
+        * DY_3D.to(device)[None, :, None]
+        * DZ_3D.to(device)[None, None, :]
+    ).contiguous()
+
+
+class TestConstructor:
+    def test_defaults(self):
+        loss = VolumeConservationLoss()
+        assert loss.metric is mse
+
+
+class TestVolumeConservation2D:
+    def test_zero_for_identical(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 3, device=device) * 0.5
+        loss = VolumeConservationLoss()(target.clone(), target, vol)
+        assert torch.isclose(loss, torch.tensor(0.0, device=device), atol=1e-6)
+
+    def test_known_imbalance_relative_l2(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 1, device=device) * 0.5  # total mass 1650
+        pred = target.clone()
+        pred[0, 0, 0, 0] += 1.0  # cell volume 50 -> total 1700
+        loss = VolumeConservationLoss(metric=_relative_l2)(pred, target, vol)
+        assert abs(loss.item() - 50.0 / 1650.0) < 1e-4
+
+    def test_known_imbalance_mse(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 1, device=device) * 0.5
+        pred = target.clone()
+        pred[0, 0, 0, 0] += 1.0
+        loss = VolumeConservationLoss(metric=mse)(pred, target, vol)
+        assert abs(loss.item() - 2500.0) < 1.0  # (1650 - 1700)^2
+
+    def test_known_imbalance_l1(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 1, device=device) * 0.5
+        pred = target.clone()
+        pred[0, 0, 0, 0] += 1.0
+        loss = VolumeConservationLoss(metric=_l1)(pred, target, vol)
+        assert abs(loss.item() - 50.0) < 0.1
+
+    @pytest.mark.parametrize("metric_name", list(METRICS))
+    def test_all_metrics_run(self, metric_name, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 3, device=device) * 0.5
+        pred = target + 0.05 * torch.randn_like(target)
+        loss = VolumeConservationLoss(metric=METRICS[metric_name])(pred, target, vol)
+        assert torch.isfinite(loss)
+        assert loss > 0
+
+    def test_volume_weighting_vs_uniform(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 1, device=device) * 0.5
+        pred_small = target.clone()
+        pred_small[0, 0, 0, 0] += 1.0  # small cell (volume 50)
+        pred_large = target.clone()
+        pred_large[0, 1, 2, 0] += 1.0  # large cell (volume 300)
+
+        fn = VolumeConservationLoss(metric=_relative_l2)
+        assert fn(pred_large, target, vol) > fn(pred_small, target, vol)
+
+        # Without volume weighting both perturbations add +1 to the sum.
+        assert torch.isclose(fn(pred_small, target, None), fn(pred_large, target, None))
+
+    def test_multi_timestep(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 3, device=device) * 0.5
+        pred = target.clone()
+        pred[0, 0, 0, 0] += 1.0
+        fn = VolumeConservationLoss(metric=_relative_l2)
+        loss_t0 = fn(pred, target, vol)
+        pred[0, 0, 0, 1] += 1.0
+        loss_t01 = fn(pred, target, vol)
+        assert loss_t01 > loss_t0
+
+    def test_mask_excludes_perturbed_cell(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 1, device=device) * 0.5
+        pred = target.clone()
+        pred[0, 0, 0, 0] += 10.0
+        mask = torch.ones(4, 6, dtype=torch.bool, device=device)
+        mask[0, 0] = False
+        loss = VolumeConservationLoss(metric=_relative_l2)(pred, target, vol, mask=mask)
+        assert torch.isclose(loss, torch.tensor(0.0, device=device), atol=1e-5)
+
+
+class TestVolumeConservation3D:
+    def test_zero_for_identical(self, device):
+        vol = _volumes_3d(device)
+        target = torch.ones(1, 3, 4, 2, 2, device=device) * 0.3
+        loss = VolumeConservationLoss()(target.clone(), target, vol)
+        assert torch.isclose(loss, torch.tensor(0.0, device=device), atol=1e-6)
+
+    def test_known_imbalance(self, device):
+        vol = _volumes_3d(device)
+        target = torch.ones(1, 3, 4, 2, 1, device=device) * 0.3  # total mass 8100
+        pred = target.clone()
+        pred[0, 0, 0, 0, 0] += 1.0  # cell volume 400 -> total 8500
+        loss = VolumeConservationLoss(metric=_relative_l2)(pred, target, vol)
+        assert abs(loss.item() - 400.0 / 8100.0) < 1e-3
+
+    def test_gradient_flow(self, device):
+        vol = _volumes_3d(device)
+        target = torch.ones(1, 3, 4, 2, 2, device=device) * 0.3
+        pred = torch.randn_like(target).requires_grad_(True)
+        VolumeConservationLoss(metric=_relative_l2)(pred, target, vol).backward()
+        assert pred.grad is not None
+        assert torch.isfinite(pred.grad).all()
+
+    def test_scale_invariance(self, device):
+        vol = _volumes_3d(device)
+        target = torch.ones(1, 3, 4, 2, 2, device=device) * 0.3
+        pred = target + 0.1 * torch.randn_like(target)
+        fn = VolumeConservationLoss(metric=_relative_l2)
+        assert torch.isclose(
+            fn(pred, target, vol), fn(pred * 5, target * 5, vol), rtol=1e-4
+        )
+
+
+class TestEdgeCases:
+    def test_uniform_default_volumes(self, device):
+        target = torch.ones(2, 4, 6, 3, device=device) * 0.5
+        pred = target + 0.05 * torch.randn_like(target)
+        loss = VolumeConservationLoss(metric=_relative_l2)(pred, target)
+        assert torch.isfinite(loss)
+
+    def test_single_timestep(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 1, device=device) * 0.5
+        pred = target.clone()
+        pred[0, 0, 0, 0] += 1.0
+        loss = VolumeConservationLoss(metric=_relative_l2)(pred, target, vol)
+        assert torch.isfinite(loss)
+        assert loss > 0
+
+    def test_custom_metric_partial(self, device):
+        vol = _volumes_2d(device)
+        target = torch.ones(1, 4, 6, 3, device=device) * 0.5
+        pred = target + 0.05 * torch.randn_like(target)
+        fn = VolumeConservationLoss(metric=functools.partial(_huber, delta=0.5))
+        assert torch.isfinite(fn(pred, target, vol))
+
+    def test_shape_mismatch_raises(self, device):
+        pred = torch.randn(1, 4, 6, 2, device=device)
+        target = torch.randn(1, 4, 6, 3, device=device)
+        with pytest.raises(ValueError, match="same shape"):
+            VolumeConservationLoss()(pred, target)
+
+    def test_cell_volumes_shape_mismatch_raises(self, device):
+        pred = torch.randn(1, 4, 6, 2, device=device)
+        bad_vol = torch.ones(4, 5, device=device)  # spatial is (4, 6)
+        with pytest.raises(ValueError, match="cell_volumes must have shape"):
+            VolumeConservationLoss()(pred, pred, bad_vol)
+
+    def test_mask_shape_mismatch_raises(self, device):
+        pred = torch.randn(2, 4, 6, 2, device=device)
+        bad_mask = torch.ones(4, 5, dtype=torch.bool, device=device)
+        with pytest.raises(ValueError, match="mask must have shape"):
+            VolumeConservationLoss()(pred, pred, mask=bad_mask)
+
+    def test_per_sample_mask_accepted(self, device):
+        # A (B, *spatial) per-sample mask is valid and produces a finite loss.
+        pred = torch.ones(2, 4, 6, 3, device=device) * 0.5
+        target = pred.clone()
+        mask = torch.ones(2, 4, 6, dtype=torch.bool, device=device)
+        value = VolumeConservationLoss()(pred, target, mask=mask)
+        assert torch.isfinite(value)
+
+    def test_per_sample_mask_is_not_global(self, device):
+        # A per-sample mask must not leak across samples: a perturbation in a cell
+        # that is masked-out for sample 0 (but active for the unperturbed sample 1)
+        # must leave the loss at zero.
+        vol = _volumes_2d(device)
+        target = torch.ones(2, 4, 6, 1, device=device) * 0.5
+        pred = target.clone()
+        pred[0, 0, 0, 0] += 1.0  # perturb sample 0 only, cell (0, 0)
+        mask = torch.ones(2, 4, 6, dtype=torch.bool, device=device)
+        mask[0, 0, 0] = False  # exclude that cell for sample 0 only
+        loss = VolumeConservationLoss(metric=mse)(pred, target, vol, mask=mask)
+        assert torch.isclose(loss, torch.tensor(0.0, device=device), atol=1e-5)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds `VolumeConservationLoss` to `physicsnemo.experimental.losses`: a generic,
dimension-agnostic weak-conservation loss. It compares the (optionally
volume-weighted) spatial integral of `pred` and `target` at each step of a
trailing feature/time axis, using a dependency-injected data-fitting `metric`
callable and an optional inactive-cell mask.

The default `metric` is `mse` (always available); any `physicsnemo.metrics.general`
function — or a relative-error metric such as the one proposed in #1746 once it
lands — can be dependency-injected. Inputs are validated (pred/target shape,
`cell_volumes` shape, and static/per-sample `mask` shape) under a
`torch.compiler.is_compiling()` guard; the masking path uses static-shape
weighting (no boolean indexing), so it is `torch.compile`-compatible.

Named **volume conservation** (not "mass conservation") on purpose: it conserves
a volume-weighted spatial integral, not true mass — no material density or
porosity is applied.

> **Stacked PR.** Depends on #1808, which creates the `physicsnemo.experimental.losses`
> package. This branch is based on `nof/pr3b-spatial-derivative-loss`, so the diff
> also shows #1808's files until it merges; the change owned by *this* PR is the top
> commit (`physicsnemo/experimental/losses/volume_conservation.py` + its test, plus
> the `__init__` export). Once #1808 merges I'll rebase this onto `main`.

Closes #1806

## Test plan

- [x] `test/experimental/losses/test_volume_conservation.py`: analytic 2D/3D
      reservoir integrals (known totals), dependency-injected metric sweep,
      volume-weighted vs uniform, multi-timestep, masking (static + per-sample),
      gradient flow, scale invariance, uniform-default, and error paths
      (pred/target, cell_volumes, and mask shape mismatches).
- [x] `interrogate` 100%, `ruff` check+format clean, doctest, license headers, CHANGELOG.