### PR TITLE
Mesh SDF: pre-release API cleanup and correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dataloader / collate / metric tooling (refactored into `datasets.py`
   and `utils.py`).
 - Adds a mesh-native signed distance field to `physicsnemo.mesh.spatial`
-  (`physicsnemo.mesh.spatial.signed_distance_field_mesh`), built on the `BVH`
+  (`physicsnemo.mesh.spatial.signed_distance_field`), built on the `BVH`
   and `ClusterTree` spatial structures it lives alongside.
   The nearest-triangle query runs as a single-kernel per-thread BVH traversal
   (Triton on CUDA, a bounded-stack PyTorch DFS as the CPU reference; per-query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `utils.py`).
 - Adds a mesh-native signed distance field to `physicsnemo.mesh.spatial`
   (`physicsnemo.mesh.spatial.signed_distance_field`), built on the `BVH`
-  and `ClusterTree` spatial structures it lives alongside.
+  and `ClusterTree` spatial structures it lives alongside. Returns a
+  `SignedDistanceFieldResult` named tuple: the signed distance, the closest
+  surface point, and the nearest-face index per query.
   The nearest-triangle query runs as a single-kernel per-thread BVH traversal
   (Triton on CUDA, a bounded-stack PyTorch DFS as the CPU reference; per-query
   indices are int64 so query counts past tens of millions do not overflow). The

--- a/docs/api/mesh/spatial.rst
+++ b/docs/api/mesh/spatial.rst
@@ -65,10 +65,11 @@ The **sign** is determined by one of two methods, selected with
     )
 
     query = torch.randn(10000, 3)
-    sdf, hit_points = signed_distance_field(
-        mesh, query, use_sign_winding_number=True
-    )
-    # sdf: (10000,) signed distances; hit_points: (10000, 3) closest surface points.
+    result = signed_distance_field(mesh, query, use_sign_winding_number=True)
+    # A named tuple (positional unpacking also works):
+    # result.sdf:        (10000,)   signed distances
+    # result.hit_points: (10000, 3) closest surface points
+    # result.hit_faces:  (10000,)   nearest-face index into mesh.cells
 
 API Reference
 -------------

--- a/docs/api/mesh/spatial.rst
+++ b/docs/api/mesh/spatial.rst
@@ -33,7 +33,7 @@ search over all cells.
 Signed Distance Field
 ---------------------
 
-:func:`signed_distance_field_mesh` computes the signed distance from a set of
+:func:`signed_distance_field` computes the signed distance from a set of
 query points to a triangle surface mesh, together with the closest point on the
 surface for each query. It is a mesh-native, pure-PyTorch implementation that
 reuses the spatial acceleration structures in this module, so it runs
@@ -56,7 +56,7 @@ The **sign** is determined by one of two methods, selected with
 
     import torch
     from physicsnemo.mesh import Mesh
-    from physicsnemo.mesh.spatial import signed_distance_field_mesh
+    from physicsnemo.mesh.spatial import signed_distance_field
 
     # A triangle surface mesh: (n_vertices, 3) coords + (n_faces, 3) connectivity.
     mesh = Mesh(
@@ -65,7 +65,7 @@ The **sign** is determined by one of two methods, selected with
     )
 
     query = torch.randn(10000, 3)
-    sdf, hit_points = signed_distance_field_mesh(
+    sdf, hit_points = signed_distance_field(
         mesh, query, use_sign_winding_number=True
     )
     # sdf: (10000,) signed distances; hit_points: (10000, 3) closest surface points.

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
@@ -121,7 +121,7 @@ class ComputeSDFFromBoundary(MeshTransform):
 
         query_points = domain.interior.points.float()
 
-        sdf_values, closest_points = signed_distance_field(
+        sdf_values, closest_points, _ = signed_distance_field(
             surface,
             query_points,
             use_sign_winding_number=self.use_winding_number,

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
@@ -56,7 +56,10 @@ class ComputeSDFFromBoundary(MeshTransform):
     ``interior.point_data[sdf_field]``.  If ``normals_field`` is set,
     approximate surface normals ``(N, 3)`` are also stored, computed as
     the normalized direction from each query point to its closest point
-    on the surface (with center-of-mass fallback for on-surface points).
+    on the surface.  Points essentially *on* the surface (boundary-layer
+    points at sub-micron wall distances) instead use the oriented normal
+    of the hit face, since at those distances the closest-point direction
+    is float32 rounding noise.
 
     Parameters
     ----------
@@ -121,7 +124,7 @@ class ComputeSDFFromBoundary(MeshTransform):
 
         query_points = domain.interior.points.float()
 
-        sdf_values, closest_points, _ = signed_distance_field(
+        sdf_values, closest_points, hit_faces = signed_distance_field(
             surface,
             query_points,
             use_sign_winding_number=self.use_winding_number,
@@ -135,17 +138,30 @@ class ComputeSDFFromBoundary(MeshTransform):
         if self.normals_field is not None:
             normals = query_points - closest_points
 
-            # Fallback for points on the surface (zero distance): use direction
-            # from the surface centroid instead. Computed unconditionally and
-            # selected with a mask rather than branching on ``on_surface.any()``
-            # -- that host readback would stall the prefetch stream.
+            # For points essentially on the surface -- boundary-layer points
+            # at sub-micron wall distances -- (query - closest) is float32
+            # rounding noise (or exactly zero) and its direction is
+            # meaningless. Substitute the oriented normal of the hit face:
+            # the exact limit of the closest-point direction at the wall.
+            # Sign-align with the SDF so the rare interior point keeps
+            # pointing into the body like its neighbors (the SDF treats
+            # on-surface as outside, so dist == 0 gets the outward normal).
+            # The band is scale-aware: the closest point carries rounding
+            # noise ~ eps * |coordinate|, so an absolute cutoff under-covers
+            # geometry far from the origin. 128 eps (~1.5e-5 per unit
+            # coordinate) clears that noise floor with a wide margin, and
+            # widening the band is free because the substitute is exact.
+            # Computed unconditionally and selected with a mask rather than
+            # branching on ``near_surface.any()`` -- that host readback would
+            # stall the prefetch stream.
             dist = torch.norm(normals, dim=-1)
-            on_surface = dist < 1e-6
-            # The mesh stays intact; read its points only here, at point of use.
-            centroid = surface.points.float().mean(dim=0, keepdim=True)
-            normals = torch.where(
-                on_surface.unsqueeze(-1), query_points - centroid, normals
+            coord_scale = query_points.abs().amax(dim=-1).clamp(min=1.0)
+            near_surface = dist < (128.0 * torch.finfo(torch.float32).eps * coord_scale)
+            face_normals = surface.cell_normals.to(query_points.dtype)[hit_faces]
+            oriented = torch.where(
+                (sdf_values >= 0).unsqueeze(-1), face_normals, -face_normals
             )
+            normals = torch.where(near_surface.unsqueeze(-1), oriented, normals)
 
             # Normalize to unit vectors
             norm = torch.norm(normals, dim=-1, keepdim=True).clamp(min=1e-8)

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
@@ -158,10 +158,16 @@ class ComputeSDFFromBoundary(MeshTransform):
             coord_scale = query_points.abs().amax(dim=-1).clamp(min=1.0)
             near_surface = dist < (128.0 * torch.finfo(torch.float32).eps * coord_scale)
             face_normals = surface.cell_normals.to(query_points.dtype)[hit_faces]
+            # A degenerate (zero-area) hit face has no meaningful normal --
+            # ``cell_normals`` returns a zero vector for it. Keep the raw
+            # closest-point direction there instead of substituting zeros.
+            face_normal_ok = (face_normals * face_normals).sum(-1) > 0.5
             oriented = torch.where(
                 (sdf_values >= 0).unsqueeze(-1), face_normals, -face_normals
             )
-            normals = torch.where(near_surface.unsqueeze(-1), oriented, normals)
+            normals = torch.where(
+                (near_surface & face_normal_ok).unsqueeze(-1), oriented, normals
+            )
 
             # Normalize to unit vectors
             norm = torch.norm(normals, dim=-1, keepdim=True).clamp(min=1e-8)

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/sdf.py
@@ -40,7 +40,7 @@ import torch
 from physicsnemo.datapipes.registry import register
 from physicsnemo.datapipes.transforms.mesh.base import MeshTransform
 from physicsnemo.mesh import DomainMesh, Mesh
-from physicsnemo.mesh.spatial.sdf import signed_distance_field_mesh
+from physicsnemo.mesh.spatial.sdf import signed_distance_field
 
 
 @register()
@@ -49,7 +49,7 @@ class ComputeSDFFromBoundary(MeshTransform):
 
     Reads the surface mesh from ``domain.boundaries[boundary_name]`` and
     evaluates the signed distance field at every interior point using
-    :func:`physicsnemo.mesh.spatial.sdf.signed_distance_field_mesh`,
+    :func:`physicsnemo.mesh.spatial.sdf.signed_distance_field`,
     a mesh-native, pure-PyTorch implementation backed by a torch BVH.
 
     The computed SDF is stored as a scalar field ``(N, 1)`` in
@@ -121,7 +121,7 @@ class ComputeSDFFromBoundary(MeshTransform):
 
         query_points = domain.interior.points.float()
 
-        sdf_values, closest_points = signed_distance_field_mesh(
+        sdf_values, closest_points = signed_distance_field(
             surface,
             query_points,
             use_sign_winding_number=self.use_winding_number,

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_sdf_transform.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_sdf_transform.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for `src/sdf.py` (ComputeSDFFromBoundary).
+
+The critical contract is the near-wall normals: boundary-layer volume points
+sit at sub-micron wall distances, where the naive normalized
+``query - closest_point`` direction is float32 rounding noise. The transform
+must substitute the oriented hit-face normal there -- a previous
+centroid-direction fallback produced normals *tangent* to the surface for
+1-3% of DrivAerML training points, concentrated exactly in the boundary
+layer.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sdf import ComputeSDFFromBoundary
+
+from physicsnemo.mesh import DomainMesh, Mesh
+
+# A closed, elongated box: x in (0, 10), y in (-0.5, 0.5), z in (0, 1),
+# 12 outward-wound triangles. Near the far end of the top face the direction
+# away from the box centroid is nearly tangent to the face (z-component
+# ~0.1), so the old centroid fallback is maximally wrong there while the
+# winding sign stays well-defined (closed surface), mirroring a car fender.
+_BOX_VERTICES = torch.tensor(
+    [
+        [0.0, -0.5, 0.0],
+        [10.0, -0.5, 0.0],
+        [10.0, 0.5, 0.0],
+        [0.0, 0.5, 0.0],
+        [0.0, -0.5, 1.0],
+        [10.0, -0.5, 1.0],
+        [10.0, 0.5, 1.0],
+        [0.0, 0.5, 1.0],
+    ],
+    dtype=torch.float32,
+)
+_BOX_FACES = torch.tensor(
+    [
+        [0, 2, 1],
+        [0, 3, 2],  # bottom, -z
+        [4, 5, 6],
+        [4, 6, 7],  # top, +z
+        [0, 1, 5],
+        [0, 5, 4],  # -y side
+        [3, 7, 6],
+        [3, 6, 2],  # +y side
+        [0, 4, 7],
+        [0, 7, 3],  # -x side
+        [1, 2, 6],
+        [1, 6, 5],  # +x side
+    ],
+    dtype=torch.int64,
+)
+
+
+def _domain_with_interior(interior_points: torch.Tensor) -> DomainMesh:
+    """Wrap query points and the box surface into a DomainMesh."""
+    return DomainMesh(
+        interior=Mesh(points=interior_points),
+        boundaries={"stl_geometry": Mesh(points=_BOX_VERTICES, cells=_BOX_FACES)},
+        global_data={},
+    )
+
+
+def test_sdf_normals_near_wall_use_face_normal():
+    """Near-wall normals equal the oriented face normal, not tangent junk."""
+    torch.manual_seed(0)
+    n_query = 500
+    # Points hovering over the far end of the top face, at log-distributed
+    # wall distances from 1e-8 (deep boundary layer, below any
+    # float32-meaningful separation) to 1e-3.
+    q_xy = torch.rand(n_query, 2) * torch.tensor([0.9, 0.8]) + torch.tensor([9.0, -0.4])
+    wall_dist = 10 ** (torch.rand(n_query) * 5 - 8)
+    interior = torch.stack([q_xy[:, 0], q_xy[:, 1], 1.0 + wall_dist], -1).float()
+    domain = _domain_with_interior(interior)
+
+    transform = ComputeSDFFromBoundary(
+        boundary_name="stl_geometry",
+        sdf_field="sdf",
+        normals_field="sdf_normals",
+        use_winding_number=True,
+    )
+    result = transform.apply_to_domain(domain)
+
+    sdf = result.interior.point_data["sdf"]
+    normals = result.interior.point_data["sdf_normals"]
+    assert sdf.shape == (n_query, 1)
+    assert normals.shape == (n_query, 3)
+    # All points are outside (or, for the sub-float32-resolution wall
+    # distances, exactly on) the closed box.
+    assert torch.all(sdf >= 0)
+
+    # Unit vectors, and the normal must be +z at ALL wall distances. The old
+    # centroid fallback returned the direction away from the box centroid
+    # (z-component ~0.1, i.e. nearly tangent) for points below 1e-6.
+    torch.testing.assert_close(
+        normals.norm(dim=-1), torch.ones(n_query), atol=1e-4, rtol=0.0
+    )
+    assert torch.all(normals[:, 2] > 0.99)
+
+
+def test_sdf_normals_far_points_keep_closest_point_direction():
+    """Far from the surface the normals stay the closest-point direction."""
+    # Off the +x end (closest point on the box rim/edge) and above the middle
+    # (closest point on the top face).
+    off = torch.tensor([[12.0, 0.0, 2.0], [5.0, 0.0, 3.0]], dtype=torch.float32)
+    domain = _domain_with_interior(off)
+
+    result = ComputeSDFFromBoundary().apply_to_domain(domain)
+    normals = result.interior.point_data["sdf_normals"]
+
+    closest = torch.tensor([[10.0, 0.0, 1.0], [5.0, 0.0, 1.0]])
+    expected = torch.nn.functional.normalize(off - closest, dim=-1)
+    torch.testing.assert_close(normals, expected, atol=1e-5, rtol=1e-5)

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_sdf_transform.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_sdf_transform.py
@@ -28,7 +28,6 @@ layer.
 from __future__ import annotations
 
 import torch
-
 from sdf import ComputeSDFFromBoundary
 
 from physicsnemo.mesh import DomainMesh, Mesh
@@ -129,3 +128,37 @@ def test_sdf_normals_far_points_keep_closest_point_direction():
     closest = torch.tensor([[10.0, 0.0, 1.0], [5.0, 0.0, 1.0]])
     expected = torch.nn.functional.normalize(off - closest, dim=-1)
     torch.testing.assert_close(normals, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_sdf_normals_degenerate_hit_face_stays_finite():
+    """A near-wall query hitting a degenerate face must not get a junk normal.
+
+    A zero-area face has a zero ``cell_normals`` entry, so the face-normal
+    substitution must be skipped for it (keeping the raw closest-point
+    direction) rather than writing zero/NaN normals into the training data.
+    """
+    # The box plus a degenerate "antenna" face: a repeated-vertex face
+    # spanning the segment (10, 0, 1) -> (11, 0, 1), sticking off the box so
+    # it is genuinely the nearest surface for queries above it.
+    vertices = torch.cat(
+        [_BOX_VERTICES, torch.tensor([[10.0, 0.0, 1.0], [11.0, 0.0, 1.0]])]
+    )
+    faces = torch.cat([_BOX_FACES, torch.tensor([[8, 9, 9]])])
+    # Near-wall above the antenna midpoint, plus a regular top-face point.
+    interior = torch.tensor(
+        [[10.5, 0.0, 1.0 + 1e-7], [5.0, 0.0, 1.0 + 1e-7]], dtype=torch.float32
+    )
+    domain = DomainMesh(
+        interior=Mesh(points=interior),
+        boundaries={"stl_geometry": Mesh(points=vertices, cells=faces)},
+        global_data={},
+    )
+
+    result = ComputeSDFFromBoundary().apply_to_domain(domain)
+    normals = result.interior.point_data["sdf_normals"]
+
+    assert torch.isfinite(normals).all()
+    # The regular near-wall point still gets the exact face normal.
+    torch.testing.assert_close(
+        normals[1], torch.tensor([0.0, 0.0, 1.0]), atol=1e-4, rtol=0.0
+    )

--- a/physicsnemo/datapipes/transforms/geometric.py
+++ b/physicsnemo/datapipes/transforms/geometric.py
@@ -31,7 +31,7 @@ from tensordict import TensorDict
 from physicsnemo.datapipes.registry import register
 from physicsnemo.datapipes.transforms.base import Transform
 from physicsnemo.mesh import Mesh
-from physicsnemo.mesh.spatial.sdf import signed_distance_field_mesh
+from physicsnemo.mesh.spatial.sdf import signed_distance_field
 
 
 @register()
@@ -156,7 +156,7 @@ class ComputeSDF(Transform):
             query_points = data[key]
 
             # Compute SDF and closest points
-            sdf, closest_points = signed_distance_field_mesh(
+            sdf, closest_points = signed_distance_field(
                 mesh,
                 query_points,
                 use_sign_winding_number=self.use_winding_number,

--- a/physicsnemo/datapipes/transforms/geometric.py
+++ b/physicsnemo/datapipes/transforms/geometric.py
@@ -156,7 +156,7 @@ class ComputeSDF(Transform):
             query_points = data[key]
 
             # Compute SDF and closest points
-            sdf, closest_points = signed_distance_field(
+            sdf, closest_points, _ = signed_distance_field(
                 mesh,
                 query_points,
                 use_sign_winding_number=self.use_winding_number,

--- a/physicsnemo/mesh/spatial/__init__.py
+++ b/physicsnemo/mesh/spatial/__init__.py
@@ -30,12 +30,16 @@ from physicsnemo.mesh.spatial.cluster_tree import (
     DualInteractionPlan,
     SourceAggregates,
 )
-from physicsnemo.mesh.spatial.sdf import signed_distance_field
+from physicsnemo.mesh.spatial.sdf import (
+    SignedDistanceFieldResult,
+    signed_distance_field,
+)
 
 __all__ = [
     "BVH",
     "ClusterTree",
     "DualInteractionPlan",
+    "SignedDistanceFieldResult",
     "SourceAggregates",
     "signed_distance_field",
 ]

--- a/physicsnemo/mesh/spatial/__init__.py
+++ b/physicsnemo/mesh/spatial/__init__.py
@@ -19,7 +19,7 @@
 This module provides data structures and algorithms for fast spatial queries:
 - BVH (Bounding Volume Hierarchy) for point-in-cell queries
 - ClusterTree for dual-tree Barnes-Hut acceleration of kernel/attention operators
-- Signed distance field (:func:`signed_distance_field_mesh`) over a triangle
+- Signed distance field (:func:`signed_distance_field`) over a triangle
   surface mesh, backed by the BVH (nearest triangle) and the ClusterTree
   (winding-number sign)
 """
@@ -30,12 +30,12 @@ from physicsnemo.mesh.spatial.cluster_tree import (
     DualInteractionPlan,
     SourceAggregates,
 )
-from physicsnemo.mesh.spatial.sdf import signed_distance_field_mesh
+from physicsnemo.mesh.spatial.sdf import signed_distance_field
 
 __all__ = [
     "BVH",
     "ClusterTree",
     "DualInteractionPlan",
     "SourceAggregates",
-    "signed_distance_field_mesh",
+    "signed_distance_field",
 ]

--- a/physicsnemo/mesh/spatial/_sdf_triton.py
+++ b/physicsnemo/mesh/spatial/_sdf_triton.py
@@ -17,7 +17,7 @@
 """Triton per-thread depth-first nearest-triangle search for the torch SDF.
 
 This is the GPU fast path behind
-:func:`physicsnemo.mesh.spatial.sdf.signed_distance_field_mesh`. It reproduces
+:func:`physicsnemo.mesh.spatial.sdf.signed_distance_field`. It reproduces
 the design of a hand-written CUDA mesh-query kernel (one thread per query, a
 small per-thread stack, descend the nearer child first, prune subtrees whose
 AABB is farther than the running best) -- the only structure that achieves

--- a/physicsnemo/mesh/spatial/sdf.py
+++ b/physicsnemo/mesh/spatial/sdf.py
@@ -1220,7 +1220,8 @@ def signed_distance_field(
         return SignedDistanceFieldResult(
             sdf=sdf.reshape(query_shape[:-1]).to(out_dtype),
             hit_points=hit_points.reshape(query_shape).to(out_dtype),
-            hit_faces=torch.zeros(query_shape[:-1], dtype=torch.long, device=device),
+            # Always empty here; -1 keeps the "no valid face" sentinel uniform.
+            hit_faces=torch.full(query_shape[:-1], -1, dtype=torch.long, device=device),
         )
 
     with record_function("sdf/bvh_build"):

--- a/physicsnemo/mesh/spatial/sdf.py
+++ b/physicsnemo/mesh/spatial/sdf.py
@@ -89,6 +89,120 @@ _BVH_LEAF_SIZE = 16
 _WINDING_THETA = 0.5
 _WINDING_LEAF_SIZE = 8
 
+# Relative-height threshold below which a face is treated as degenerate and
+# repaired at build time (see ``_repair_degenerate_faces``): a triangle whose
+# height is less than this fraction of its longest edge has its off-edge vertex
+# displaced perpendicular to that edge by the same fraction of the edge length.
+# Chosen ~1000x float32 epsilon so that float32 rounding of Ericson's region
+# determinants can never misclassify the repaired face, while the repair moves
+# the surface by at most this fraction of the edge length.
+_DEGENERATE_TRI_REL_HEIGHT = 1e-4
+
+
+def _repair_degenerate_faces(
+    face_vertices: Float[torch.Tensor, "n_faces 3 3"],
+) -> Float[torch.Tensor, "n_faces 3 3"]:
+    r"""Displace the off-edge vertex of (near-)degenerate faces off their edge.
+
+    Ericson's Voronoi-region closest-point classification
+    (:func:`_closest_point_on_triangles` and its Triton mirror) assumes a
+    non-degenerate triangle: on a (near-)zero-area face -- repeated vertices or
+    collinear points, which real surface meshes do contain -- several region
+    tests fire vacuously and the cascade can return the wrong feature, silently
+    overestimating the distance. Rather than paying for a degenerate fallback
+    on every ``(query, candidate)`` pair in the hot kernels (~20-25% measured),
+    this repairs the geometry once per call: any face whose height is below
+    :data:`_DEGENERATE_TRI_REL_HEIGHT` times its longest edge has its off-edge
+    vertex moved to the edge midpoint plus a perpendicular offset ``h``, giving
+    an equivalent thin-but-valid triangle over the same edge.
+
+    ``h`` is ``max(rel * L, 8 * eps_f32 * max|coord|)`` with ``L`` the longest
+    edge: the first term keeps the repaired face far above the float32 regime
+    where the region determinants misclassify, and the second keeps the offset
+    representable for small faces far from the origin (where ``rel * L`` would
+    round away against the coordinate magnitude). The closest point, and hence
+    the SDF and hit point, move by at most ``2 h`` -- ``h`` from the repair
+    itself plus up to ``h`` of pruning slack where the repaired face protrudes
+    from its BVH bounds (built from the original geometry) -- and only for
+    queries whose nearest face was degenerate. Point-like faces (all vertices coincident,
+    zero longest edge) are left untouched: every Ericson region returns the
+    single point, so they are already handled exactly.
+
+    Everything is a fixed-shape tensor pass over the faces -- no host
+    readbacks, so the SDF prep stream stays sync-free.
+
+    Parameters
+    ----------
+    face_vertices : torch.Tensor
+        Per-face vertex positions, shape ``(n_faces, 3, 3)`` (float32).
+
+    Returns
+    -------
+    torch.Tensor
+        Repaired per-face vertex positions, shape ``(n_faces, 3, 3)``. Faces
+        above the degeneracy threshold are bit-identical to the input.
+    """
+    a = face_vertices[:, 0, :]
+    b = face_vertices[:, 1, :]
+    c = face_vertices[:, 2, :]
+    ab = b - a
+    ac = c - a
+    bc = c - b
+    ab_sq = (ab * ab).sum(-1)
+    ac_sq = (ac * ac).sum(-1)
+    bc_sq = (bc * bc).sum(-1)
+
+    # degenerate <=> height <= rel * longest edge <=> |ab x ac|^2 <= (rel * L^2)^2
+    area_sq = (torch.linalg.cross(ab, ac, dim=-1) ** 2).sum(-1)
+    scale_sq = torch.maximum(ab_sq, torch.maximum(ac_sq, bc_sq))
+    degenerate = area_sq <= (_DEGENERATE_TRI_REL_HEIGHT * scale_sq) ** 2
+
+    # The longest edge of a (near-)collinear face spans its extreme points, so
+    # the face is (within its height) the segment (e0, e1); the remaining
+    # "off-edge" vertex is the one displaced. 0 -> ab (off c), 1 -> ac (off b),
+    # 2 -> bc (off a). Ties pick either longest edge; both are valid.
+    longest = torch.stack([ab_sq, ac_sq, bc_sq], dim=-1).argmax(dim=-1)
+    is_ab = (longest == 0).unsqueeze(-1)
+    is_ac = (longest == 1).unsqueeze(-1)
+    e0 = torch.where(is_ab | is_ac, a, b)
+    e1 = torch.where(is_ab, b, c)
+
+    # Unit perpendicular to the edge: cross against whichever of x-hat / y-hat
+    # is less aligned with it (at least one of the two always works).
+    edge = e1 - e0
+    x_hat = torch.zeros_like(edge)
+    x_hat[:, 0] = 1.0
+    y_hat = torch.zeros_like(edge)
+    y_hat[:, 1] = 1.0
+    perp = torch.linalg.cross(edge, x_hat, dim=-1)
+    perp_alt = torch.linalg.cross(edge, y_hat, dim=-1)
+    edge_sq = (edge * edge).sum(-1)
+    use_alt = (perp * perp).sum(-1) < 0.5 * edge_sq
+    perp = torch.where(use_alt.unsqueeze(-1), perp_alt, perp)
+    tiny = torch.finfo(face_vertices.dtype).tiny
+    perp = perp / perp.norm(dim=-1, keepdim=True).clamp(min=tiny)
+
+    eps = torch.finfo(face_vertices.dtype).eps
+    coord_scale = face_vertices.abs().amax(dim=(1, 2))
+    h = torch.maximum(
+        _DEGENERATE_TRI_REL_HEIGHT * edge_sq.sqrt(), 8.0 * eps * coord_scale
+    )
+    # Point-like faces (zero longest edge) keep h = 0, i.e. stay untouched.
+    h = torch.where(edge_sq > 0, h, torch.zeros_like(h))
+    off_vertex = 0.5 * (e0 + e1) + perp * h.unsqueeze(-1)
+
+    move_a = (degenerate & (longest == 2)).unsqueeze(-1)
+    move_b = (degenerate & (longest == 1)).unsqueeze(-1)
+    move_c = (degenerate & (longest == 0)).unsqueeze(-1)
+    return torch.stack(
+        [
+            torch.where(move_a, off_vertex, a),
+            torch.where(move_b, off_vertex, b),
+            torch.where(move_c, off_vertex, c),
+        ],
+        dim=1,
+    )
+
 
 def _build_surface_mesh(
     mesh: Mesh,
@@ -98,7 +212,11 @@ def _build_surface_mesh(
     The BVH build and the Triton nearest-triangle kernel assume a float32
     coordinate dtype, so this returns a float32 copy of ``mesh`` alongside the
     per-face vertex positions and the int64 triangle connectivity consumed by
-    the downstream tensor ops.
+    the downstream tensor ops. (Near-)degenerate faces are repaired in the
+    returned ``face_vertices`` (see :func:`_repair_degenerate_faces`) so the
+    closest-point kernels never see a triangle their region classification
+    cannot handle; ``work_mesh`` keeps the original vertices, since the
+    pseudo-normal sign machinery consumes topology, not the repaired geometry.
 
     Parameters
     ----------
@@ -115,7 +233,7 @@ def _build_surface_mesh(
     """
     faces = mesh.cells.to(torch.long)
     work_mesh = Mesh(points=mesh.points.to(torch.float32), cells=faces)
-    face_vertices = work_mesh.points[faces]  # (n_faces, 3, 3)
+    face_vertices = _repair_degenerate_faces(work_mesh.points[faces])
     return work_mesh, face_vertices, faces
 
 
@@ -128,6 +246,15 @@ def _closest_point_on_triangles(
     Vectorized region-classification (Ericson, *Real-Time Collision
     Detection*). Computes, for each ``(query, triangle)`` pair, the point on the
     (closed) triangle nearest to ``query``.
+
+    Ericson's Voronoi-region tests assume a non-degenerate triangle: on a
+    (near-)zero-area face several region tests become vacuously true and the
+    cascade can return the wrong feature (always an overestimate of the
+    distance). The SDF pipeline therefore never feeds this routine a
+    (near-)degenerate triangle: ``_build_surface_mesh`` repairs such faces up
+    front (see :func:`_repair_degenerate_faces`). Point-like faces (all three
+    vertices coincident) are the exception -- every region returns the single
+    point, so they are correct here without repair.
 
     Parameters
     ----------
@@ -997,7 +1124,8 @@ def signed_distance_field(
         ``n_manifold_dims == 2``), if ``query_points`` does not have a trailing
         dimension of size 3, if the mesh has no faces (there is no surface to
         measure distance to), if ``mesh`` and ``query_points`` are on different
-        devices, or if ``winding_backend`` is not a supported backend.
+        devices, if ``winding_backend`` is not a supported backend, or if
+        ``max_dist`` is negative.
 
     Notes
     -----
@@ -1036,6 +1164,8 @@ def signed_distance_field(
             f"winding_backend must be one of {get_args(WindingBackend)}, "
             f"got {winding_backend!r}"
         )
+    if max_dist is not None and max_dist < 0:
+        raise ValueError(f"max_dist must be None or non-negative, got {max_dist}")
 
     query_shape = query_points.shape
     out_dtype = query_points.dtype

--- a/physicsnemo/mesh/spatial/sdf.py
+++ b/physicsnemo/mesh/spatial/sdf.py
@@ -24,7 +24,7 @@ sign is computed with a :class:`physicsnemo.mesh.spatial.ClusterTree` Barnes-Hut
 summation over the mesh, so the whole pipeline reuses the mesh's own spatial
 data structures and runs identically on CPU and GPU.
 
-:func:`signed_distance_field_mesh` returns the signed distance and the closest
+:func:`signed_distance_field` returns the signed distance and the closest
 surface point for each query.
 
 Algorithm
@@ -52,6 +52,8 @@ Algorithm
 
 from __future__ import annotations
 
+from typing import Literal, TypeAlias, get_args
+
 import torch
 from jaxtyping import Float, Int
 from tensordict import TensorDict
@@ -62,6 +64,11 @@ from physicsnemo.mesh.spatial import _sdf_triton
 from physicsnemo.mesh.spatial._ragged import _ragged_arange
 from physicsnemo.mesh.spatial.bvh import BVH
 from physicsnemo.mesh.spatial.cluster_tree import ClusterTree
+
+# Winding-number summation backends for ``use_sign_winding_number=True``. The
+# runtime validation tuple is derived from the typed ``Literal`` via
+# ``get_args`` so the two can never drift apart.
+WindingBackend: TypeAlias = Literal["clustertree", "bruteforce"]
 
 # Chunk sizes keep the pairwise tensors bounded for large inputs. These are
 # product-of-counts limits (rows of the materialized intermediate), not raw
@@ -711,7 +718,7 @@ def _winding_number_sign(
         lc = c.norm(dim=-1)
 
         # Numerator: triple product a . (b x c).
-        triple = (a * torch.cross(b, c, dim=-1)).sum(-1)
+        triple = (a * torch.linalg.cross(b, c, dim=-1)).sum(-1)
         denom = (
             la * lb * lc
             + (a * b).sum(-1) * lc
@@ -839,7 +846,7 @@ def _winding_number_sign_clustertree(
 
     Notes
     -----
-    See :func:`signed_distance_field_mesh` for the end-to-end SDF that consumes
+    See :func:`signed_distance_field` for the end-to-end SDF that consumes
     this sign.
     """
     device = query.device
@@ -937,13 +944,13 @@ def _winding_number_sign_clustertree(
     )
 
 
-def signed_distance_field_mesh(
+def signed_distance_field(
     mesh: Mesh,
     query_points: Float[torch.Tensor, "... 3"],
     max_dist: float | None = None,
     use_sign_winding_number: bool = False,
     *,
-    winding_backend: str = "clustertree",
+    winding_backend: WindingBackend = "clustertree",
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""Compute the signed distance to a triangle surface mesh.
 
@@ -968,8 +975,13 @@ def signed_distance_field_mesh(
         vertex), which stays correct at sharp/non-convex edges where a single
         face normal would flip the sign (see :func:`_pseudo_normal_sign`). The
         mesh should be watertight for reliable signs in the ``False`` case.
-    winding_backend : str, optional
-        Winding-number summation backend when ``use_sign_winding_number=True``: ``"clustertree"`` (default) for the :class:`physicsnemo.mesh.spatial.ClusterTree` Barnes-Hut sum (``O(n_queries * log n_faces)``, best for large meshes), or ``"bruteforce"`` for the exact fused ``O(n_queries * n_faces)`` sum (faster for small/medium meshes).
+    winding_backend : {"clustertree", "bruteforce"}, optional
+        Winding-number summation backend when ``use_sign_winding_number=True``:
+        ``"clustertree"`` (default) for the
+        :class:`physicsnemo.mesh.spatial.ClusterTree` Barnes-Hut sum
+        (``O(n_queries * log n_faces)``, best for large meshes), or
+        ``"bruteforce"`` for the exact fused ``O(n_queries * n_faces)`` sum
+        (faster for small/medium meshes).
 
     Returns
     -------
@@ -983,8 +995,9 @@ def signed_distance_field_mesh(
     ValueError
         If ``mesh`` is not a triangle surface in 3D (``n_spatial_dims == 3`` and
         ``n_manifold_dims == 2``), if ``query_points`` does not have a trailing
-        dimension of size 3, or if the mesh has no faces (there is no surface to
-        measure distance to).
+        dimension of size 3, if the mesh has no faces (there is no surface to
+        measure distance to), if ``mesh`` and ``query_points`` are on different
+        devices, or if ``winding_backend`` is not a supported backend.
 
     Notes
     -----
@@ -1001,17 +1014,27 @@ def signed_distance_field_mesh(
     # mis-typed mesh fails loudly rather than deep inside the BVH/winding kernels.
     if mesh.n_spatial_dims != 3:
         raise ValueError(
-            "signed_distance_field_mesh requires a 3D mesh "
+            "signed_distance_field requires a 3D mesh "
             f"(n_spatial_dims == 3), but got {mesh.n_spatial_dims=}."
         )
     if mesh.n_manifold_dims != 2:
         raise ValueError(
-            "signed_distance_field_mesh requires a triangle mesh "
+            "signed_distance_field requires a triangle mesh "
             f"(n_manifold_dims == 2), but got {mesh.n_manifold_dims=}."
         )
     if mesh.n_cells == 0:
         raise ValueError(
             "mesh has no faces; there is no surface to measure distance to"
+        )
+    if mesh.points.device != query_points.device:
+        raise ValueError(
+            "mesh and query_points must be on the same device, but got "
+            f"{mesh.points.device=} and {query_points.device=}."
+        )
+    if winding_backend not in get_args(WindingBackend):
+        raise ValueError(
+            f"winding_backend must be one of {get_args(WindingBackend)}, "
+            f"got {winding_backend!r}"
         )
 
     query_shape = query_points.shape
@@ -1076,13 +1099,8 @@ def signed_distance_field_mesh(
             # up to the Barnes-Hut approximation.
             if winding_backend == "bruteforce":
                 sign = _winding_number_sign(face_vertices, queries)
-            elif winding_backend == "clustertree":
-                sign = _winding_number_sign_clustertree(face_vertices, queries)
             else:
-                raise ValueError(
-                    "winding_backend must be 'clustertree' or 'bruteforce', "
-                    f"got {winding_backend!r}"
-                )
+                sign = _winding_number_sign_clustertree(face_vertices, queries)
         else:
             sign = _pseudo_normal_sign(work_mesh, queries, best_face, best_point)
 
@@ -1102,28 +1120,28 @@ def signed_distance_field_mesh(
     return sdf, hit_points
 
 
-def _signed_distance_field_mesh_from_arrays(
+def _signed_distance_field_from_arrays(
     mesh_vertices: Float[torch.Tensor, "n_vertices 3"],
     mesh_indices: Int[torch.Tensor, "..."],
     query_points: Float[torch.Tensor, "... 3"],
     max_dist: float | None = None,
     use_sign_winding_number: bool = False,
     *,
-    winding_backend: str = "clustertree",
+    winding_backend: WindingBackend = "clustertree",
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""[INTERNAL - DO NOT USE] Private array-based SDF helper.
 
     .. warning::
 
        **DON'T USE THIS ONE.** This is a private, temporary entry point. Use
-       the public :func:`signed_distance_field_mesh`, which takes a
+       the public :func:`signed_distance_field`, which takes a
        :class:`~physicsnemo.mesh.Mesh`, instead.
 
        This helper is unexported, carries no backward-compatibility guarantee,
        and may be removed without notice.
 
     It wraps the arrays in a :class:`~physicsnemo.mesh.Mesh` and defers to
-    :func:`signed_distance_field_mesh`, so the numerics are identical.
+    :func:`signed_distance_field`, so the numerics are identical.
 
     Parameters
     ----------
@@ -1134,22 +1152,22 @@ def _signed_distance_field_mesh_from_arrays(
     query_points : torch.Tensor
         Query points, shape ``(..., 3)``.
     max_dist : float or None, optional
-        Maximum search radius; see :func:`signed_distance_field_mesh`.
+        Maximum search radius; see :func:`signed_distance_field`.
     use_sign_winding_number : bool, optional
-        Sign method; see :func:`signed_distance_field_mesh`.
-    winding_backend : str, optional
-        Winding-number backend; see :func:`signed_distance_field_mesh`.
+        Sign method; see :func:`signed_distance_field`.
+    winding_backend : {"clustertree", "bruteforce"}, optional
+        Winding-number backend; see :func:`signed_distance_field`.
 
     Returns
     -------
     tuple[torch.Tensor, torch.Tensor]
-        ``(sdf, hit_points)``; see :func:`signed_distance_field_mesh`.
+        ``(sdf, hit_points)``; see :func:`signed_distance_field`.
 
     Raises
     ------
     ValueError
         If ``mesh_indices`` is not 1D-flattened or ``(n_faces, 3)``; the
-        remaining validation is performed by :func:`signed_distance_field_mesh`.
+        remaining validation is performed by :func:`signed_distance_field`.
     """
     if mesh_indices.ndim == 2:
         if mesh_indices.shape[-1] != 3:
@@ -1161,7 +1179,7 @@ def _signed_distance_field_mesh_from_arrays(
             "mesh_indices must be either 1D flattened indices or 2D (n_faces, 3)"
         )
     mesh = Mesh(points=mesh_vertices, cells=mesh_indices.reshape(-1, 3))
-    return signed_distance_field_mesh(
+    return signed_distance_field(
         mesh,
         query_points,
         max_dist,

--- a/physicsnemo/mesh/spatial/sdf.py
+++ b/physicsnemo/mesh/spatial/sdf.py
@@ -24,8 +24,9 @@ sign is computed with a :class:`physicsnemo.mesh.spatial.ClusterTree` Barnes-Hut
 summation over the mesh, so the whole pipeline reuses the mesh's own spatial
 data structures and runs identically on CPU and GPU.
 
-:func:`signed_distance_field` returns the signed distance and the closest
-surface point for each query.
+:func:`signed_distance_field` returns the signed distance, the closest surface
+point, and the nearest face index for each query (as a
+:class:`SignedDistanceFieldResult`).
 
 Algorithm
 ---------
@@ -52,7 +53,7 @@ Algorithm
 
 from __future__ import annotations
 
-from typing import Literal, TypeAlias, get_args
+from typing import Literal, NamedTuple, TypeAlias, get_args
 
 import torch
 from jaxtyping import Float, Int
@@ -69,6 +70,33 @@ from physicsnemo.mesh.spatial.cluster_tree import ClusterTree
 # runtime validation tuple is derived from the typed ``Literal`` via
 # ``get_args`` so the two can never drift apart.
 WindingBackend: TypeAlias = Literal["clustertree", "bruteforce"]
+
+
+class SignedDistanceFieldResult(NamedTuple):
+    """Result of :func:`signed_distance_field`.
+
+    A named tuple: positional unpacking works, and the fields are
+    self-documenting at call sites that only need a subset.
+
+    Attributes
+    ----------
+    sdf : torch.Tensor
+        Signed distance per query, shape ``query_points.shape[:-1]`` (negative
+        inside, positive outside). ``NaN`` for queries beyond a finite
+        ``max_dist``.
+    hit_points : torch.Tensor
+        Closest point on the mesh per query, shape ``query_points.shape``.
+        ``NaN`` for queries beyond a finite ``max_dist``.
+    hit_faces : torch.Tensor
+        Index into ``mesh.cells`` of the nearest face per query (int64), shape
+        ``query_points.shape[:-1]``. ``-1`` for queries beyond a finite
+        ``max_dist``.
+    """
+
+    sdf: torch.Tensor
+    hit_points: torch.Tensor
+    hit_faces: torch.Tensor
+
 
 # Chunk sizes keep the pairwise tensors bounded for large inputs. These are
 # product-of-counts limits (rows of the materialized intermediate), not raw
@@ -1078,10 +1106,11 @@ def signed_distance_field(
     use_sign_winding_number: bool = False,
     *,
     winding_backend: WindingBackend = "clustertree",
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> SignedDistanceFieldResult:
     r"""Compute the signed distance to a triangle surface mesh.
 
-    Returns the signed distance and the closest surface point for each query.
+    Returns the signed distance, the closest surface point, and the nearest
+    face index for each query.
 
     Parameters
     ----------
@@ -1112,10 +1141,13 @@ def signed_distance_field(
 
     Returns
     -------
-    tuple[torch.Tensor, torch.Tensor]
-        ``(sdf, hit_points)``: signed distance per query
-        (shape ``query_points.shape[:-1]``) and the closest point on the mesh
-        per query (shape ``query_points.shape``).
+    SignedDistanceFieldResult
+        Named tuple ``(sdf, hit_points, hit_faces)``: signed distance per query
+        (shape ``query_points.shape[:-1]``), the closest point on the mesh per
+        query (shape ``query_points.shape``), and the index into ``mesh.cells``
+        of the nearest face per query (int64, shape
+        ``query_points.shape[:-1]``; ``-1`` for queries beyond a finite
+        ``max_dist``).
 
     Raises
     ------
@@ -1185,9 +1217,11 @@ def signed_distance_field(
     hit_points = queries.clone()
 
     if n_queries == 0:
-        sdf = sdf.reshape(query_shape[:-1]).to(out_dtype)
-        hit_points = hit_points.reshape(query_shape).to(out_dtype)
-        return sdf, hit_points
+        return SignedDistanceFieldResult(
+            sdf=sdf.reshape(query_shape[:-1]).to(out_dtype),
+            hit_points=hit_points.reshape(query_shape).to(out_dtype),
+            hit_faces=torch.zeros(query_shape[:-1], dtype=torch.long, device=device),
+        )
 
     with record_function("sdf/bvh_build"):
         bvh = BVH.from_mesh(work_mesh, leaf_size=_BVH_LEAF_SIZE)
@@ -1238,16 +1272,20 @@ def signed_distance_field(
     hit_points = best_point
 
     if max_dist is not None:
-        # Out-of-band queries keep the initial bound; flag them NaN, not 0.
+        # Out-of-band queries keep the initial bound; flag them NaN, not 0
+        # (and -1 for the face index, which has no NaN).
         missed = best_dist_sq >= max_dist_eff**2
         sdf = torch.where(missed, sdf.new_full((), float("nan")), sdf)
         hit_points = torch.where(
             missed.unsqueeze(-1), hit_points.new_full((), float("nan")), hit_points
         )
+        best_face = torch.where(missed, best_face.new_full((), -1), best_face)
 
-    sdf = sdf.reshape(query_shape[:-1]).to(out_dtype)
-    hit_points = hit_points.reshape(query_shape).to(out_dtype)
-    return sdf, hit_points
+    return SignedDistanceFieldResult(
+        sdf=sdf.reshape(query_shape[:-1]).to(out_dtype),
+        hit_points=hit_points.reshape(query_shape).to(out_dtype),
+        hit_faces=best_face.reshape(query_shape[:-1]),
+    )
 
 
 def _signed_distance_field_from_arrays(
@@ -1258,7 +1296,7 @@ def _signed_distance_field_from_arrays(
     use_sign_winding_number: bool = False,
     *,
     winding_backend: WindingBackend = "clustertree",
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> SignedDistanceFieldResult:
     r"""[INTERNAL - DO NOT USE] Private array-based SDF helper.
 
     .. warning::
@@ -1290,8 +1328,8 @@ def _signed_distance_field_from_arrays(
 
     Returns
     -------
-    tuple[torch.Tensor, torch.Tensor]
-        ``(sdf, hit_points)``; see :func:`signed_distance_field`.
+    SignedDistanceFieldResult
+        ``(sdf, hit_points, hit_faces)``; see :func:`signed_distance_field`.
 
     Raises
     ------

--- a/test/mesh/spatial/test_mesh_sdf.py
+++ b/test/mesh/spatial/test_mesh_sdf.py
@@ -30,8 +30,8 @@ import torch
 
 from physicsnemo.mesh import Mesh
 from physicsnemo.mesh.spatial.sdf import (
-    _signed_distance_field_mesh_from_arrays,
-    signed_distance_field_mesh,
+    _signed_distance_field_from_arrays,
+    signed_distance_field,
 )
 
 
@@ -255,7 +255,7 @@ def test_sdf_tetrahedron_reference(dtype, use_winding, device):
         [[1.0, 1.0, 1.0], [0.05, 0.1, 0.1]], device=device, dtype=dtype
     )
 
-    sdf_out, hit_points = signed_distance_field_mesh(
+    sdf_out, hit_points = signed_distance_field(
         mesh,
         query_points,
         use_sign_winding_number=use_winding,
@@ -288,10 +288,10 @@ def test_sdf_index_layout_compatibility(device):
     mesh_indices_faces = tet.cells
     query_points = torch.tensor([[0.1, 0.2, 0.3]], device=device, dtype=torch.float32)
 
-    sdf_flat, hit_flat = _signed_distance_field_mesh_from_arrays(
+    sdf_flat, hit_flat = _signed_distance_field_from_arrays(
         tet.points, mesh_indices_flat, query_points
     )
-    sdf_faces, hit_faces = _signed_distance_field_mesh_from_arrays(
+    sdf_faces, hit_faces = _signed_distance_field_from_arrays(
         tet.points, mesh_indices_faces, query_points
     )
     torch.testing.assert_close(sdf_flat, sdf_faces)
@@ -309,7 +309,7 @@ def test_sdf_sphere_analytic(use_winding, device):
     radius = query.norm(dim=-1)
     gt = radius - 1.0
 
-    sdf_out, hit = signed_distance_field_mesh(
+    sdf_out, hit = signed_distance_field(
         mesh, query, use_sign_winding_number=use_winding
     )
 
@@ -333,7 +333,7 @@ def test_sdf_preserves_input_shape(device):
     mesh = _tetrahedron_mesh().to(device)
     query = torch.rand(4, 5, 3, device=device)
 
-    sdf_out, hit = signed_distance_field_mesh(mesh, query)
+    sdf_out, hit = signed_distance_field(mesh, query)
     assert sdf_out.shape == (4, 5)
     assert hit.shape == (4, 5, 3)
 
@@ -346,8 +346,8 @@ def test_sdf_public_matches_private_arrays(device):
     torch.manual_seed(0)
     query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
 
-    sdf_pub, hit_pub = signed_distance_field_mesh(mesh, query)
-    sdf_priv, hit_priv = _signed_distance_field_mesh_from_arrays(
+    sdf_pub, hit_pub = signed_distance_field(mesh, query)
+    sdf_priv, hit_priv = _signed_distance_field_from_arrays(
         mesh.points, mesh.cells, query
     )
     torch.testing.assert_close(sdf_pub, sdf_priv)
@@ -362,17 +362,44 @@ def test_sdf_error_handling(device):
 
     bad_queries = torch.randn(4, 2, device=device)
     with pytest.raises(ValueError, match="last dimension of size 3"):
-        signed_distance_field_mesh(mesh, bad_queries)
+        signed_distance_field(mesh, bad_queries)
 
     # Non-triangle connectivity (cells wider than 3) is rejected up front.
     quad_cells = torch.zeros(2, 4, device=device, dtype=torch.int64)
     with pytest.raises(ValueError, match="triangle mesh"):
-        signed_distance_field_mesh(Mesh(points=mesh.points, cells=quad_cells), query)
+        signed_distance_field(Mesh(points=mesh.points, cells=quad_cells), query)
 
     # A mesh embedded in 2D has no well-defined 3D signed distance.
     flat_points = mesh.points[:, :2].contiguous()
     with pytest.raises(ValueError, match="3D mesh"):
-        signed_distance_field_mesh(Mesh(points=flat_points, cells=mesh.cells), query)
+        signed_distance_field(Mesh(points=flat_points, cells=mesh.cells), query)
+
+    # An unknown winding backend is rejected up front (before any BVH work),
+    # even when the winding-number sign path is not selected.
+    with pytest.raises(ValueError, match="winding_backend"):
+        signed_distance_field(mesh, query, winding_backend="warp")
+
+
+def test_sdf_winding_backend_selection(device):
+    """Both winding backends agree through the public API on a closed surface."""
+    device = torch.device(device)
+    mesh = _uv_sphere_mesh().to(device)
+
+    torch.manual_seed(0)
+    query = (torch.rand(512, 3, device=device) * 3.0 - 1.5).float()
+
+    sdf_tree, hit_tree = signed_distance_field(
+        mesh, query, use_sign_winding_number=True, winding_backend="clustertree"
+    )
+    sdf_brute, hit_brute = signed_distance_field(
+        mesh, query, use_sign_winding_number=True, winding_backend="bruteforce"
+    )
+
+    # The unsigned distance and hit point come from the same nearest-triangle
+    # search; only the sign may differ, and away from the surface it must not.
+    torch.testing.assert_close(hit_tree, hit_brute)
+    near_surface = sdf_brute.abs() < 0.05
+    assert torch.all(sdf_tree[~near_surface] == sdf_brute[~near_surface])
 
 
 def test_sdf_array_connectivity_validation(device):
@@ -383,11 +410,11 @@ def test_sdf_array_connectivity_validation(device):
 
     bad_connectivity_shape = torch.zeros(4, 4, device=device, dtype=torch.int32)
     with pytest.raises(ValueError, match=r"shape \(n_faces, 3\)"):
-        _signed_distance_field_mesh_from_arrays(vertices, bad_connectivity_shape, query)
+        _signed_distance_field_from_arrays(vertices, bad_connectivity_shape, query)
 
     bad_connectivity_rank = torch.zeros(1, 2, 3, device=device, dtype=torch.int32)
     with pytest.raises(ValueError, match="1D flattened indices or 2D"):
-        _signed_distance_field_mesh_from_arrays(vertices, bad_connectivity_rank, query)
+        _signed_distance_field_from_arrays(vertices, bad_connectivity_rank, query)
 
 
 def test_sdf_empty_mesh_raises(device):
@@ -400,7 +427,7 @@ def test_sdf_empty_mesh_raises(device):
     query = torch.tensor([[0.1, 0.2, 0.3]], device=device, dtype=torch.float32)
 
     with pytest.raises(ValueError, match="no faces"):
-        signed_distance_field_mesh(empty_mesh, query)
+        signed_distance_field(empty_mesh, query)
 
 
 def test_sdf_max_dist_unbounded_and_narrow_band(device):
@@ -418,19 +445,19 @@ def test_sdf_max_dist_unbounded_and_narrow_band(device):
     near = torch.tensor([[0.05, 0.1, 0.1]], device=device, dtype=torch.float32)
 
     # Unbounded default: the far query finds its true nearest triangle.
-    sdf_far, hit_far = signed_distance_field_mesh(mesh, far)
+    sdf_far, hit_far = signed_distance_field(mesh, far)
     assert torch.isfinite(sdf_far).all()
     assert sdf_far.abs().item() > 1.0
     assert not torch.allclose(hit_far, far)
 
     # Finite band below the true distance: the far query is out of band -> NaN.
-    sdf_band, hit_band = signed_distance_field_mesh(mesh, far, max_dist=1.0)
+    sdf_band, hit_band = signed_distance_field(mesh, far, max_dist=1.0)
     assert torch.isnan(sdf_band).all()
     assert torch.isnan(hit_band).all()
 
     # An in-band query with a finite max_dist matches the unbounded result.
-    sdf_unbounded, _ = signed_distance_field_mesh(mesh, near)
-    sdf_in_band, _ = signed_distance_field_mesh(mesh, near, max_dist=10.0)
+    sdf_unbounded, _ = signed_distance_field(mesh, near)
+    sdf_in_band, _ = signed_distance_field(mesh, near, max_dist=10.0)
     assert torch.isfinite(sdf_in_band).all()
     torch.testing.assert_close(sdf_in_band, sdf_unbounded, atol=1e-5, rtol=1e-5)
 
@@ -461,7 +488,7 @@ def test_sdf_pseudo_normal_sign_wrong_at_sharp_edges(device):
     reflex[:, 2] = _L_PRISM_HEIGHT * reflex[:, 2]
     query = torch.cat([box, reflex], dim=0).to(device)
 
-    sdf_out, _ = signed_distance_field_mesh(mesh, query, use_sign_winding_number=False)
+    sdf_out, _ = signed_distance_field(mesh, query, use_sign_winding_number=False)
 
     # The distance magnitude is correct; only the sign is in question. Compare to
     # the analytic interior away from the surface, where the sign is unambiguous.
@@ -495,7 +522,7 @@ def test_sdf_winding_sign_correct_at_sharp_edges(device):
     hi = torch.tensor([1.2, 1.2, _L_PRISM_HEIGHT + 0.2])
     query = (lo + (hi - lo) * torch.rand(40_000, 3)).to(device)
 
-    sdf_out, _ = signed_distance_field_mesh(mesh, query, use_sign_winding_number=True)
+    sdf_out, _ = signed_distance_field(mesh, query, use_sign_winding_number=True)
 
     # Exclude a near-surface band: the CUDA Barnes-Hut winding approximation is
     # only loose right at the surface (cf. test_winding_sign_triton_matches_exact).
@@ -592,7 +619,7 @@ def test_sdf_winding_sign_correct_at_sharp_edges_grid(device):
     query = _l_prism_probe_grid(device, thickness)
     gt_inside = _inside_l(query, thickness)
 
-    sdf_out, _ = signed_distance_field_mesh(mesh, query, use_sign_winding_number=True)
+    sdf_out, _ = signed_distance_field(mesh, query, use_sign_winding_number=True)
 
     # Compare signs away from the surface. The default ClusterTree backend is a
     # Barnes-Hut approximation whose winding number is only unreliable in a thin
@@ -619,7 +646,7 @@ def test_sdf_pseudo_normal_sign_correct_at_sharp_edges(device):
     query = _l_prism_probe_grid(device, thickness)
     gt_inside = _inside_l(query, thickness)
 
-    sdf_out, _ = signed_distance_field_mesh(mesh, query, use_sign_winding_number=False)
+    sdf_out, _ = signed_distance_field(mesh, query, use_sign_winding_number=False)
 
     away = sdf_out.abs() > 0.05
     expected = torch.where(
@@ -734,7 +761,7 @@ def test_sdf_triton_nearest_matches_torch_reference():
 @pytest.mark.skipif(not _CUDA, reason="CUDA required for the Triton SDF kernel")
 @pytest.mark.parametrize("use_winding", [False, True])
 def test_sdf_triton_end_to_end_matches_reference(use_winding, monkeypatch):
-    """Full signed_distance_field_mesh: Triton path matches the torch fallback."""
+    """Full signed_distance_field: Triton path matches the torch fallback."""
     if not _triton_available():
         pytest.skip("triton not available")
 
@@ -747,7 +774,7 @@ def test_sdf_triton_end_to_end_matches_reference(use_winding, monkeypatch):
     query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
 
     # Triton fast path (default dispatch on CUDA).
-    sdf_triton, _ = signed_distance_field_mesh(
+    sdf_triton, _ = signed_distance_field(
         mesh, query, use_sign_winding_number=use_winding
     )
 
@@ -755,9 +782,7 @@ def test_sdf_triton_end_to_end_matches_reference(use_winding, monkeypatch):
     # dispatch. The winding-number sign uses the (device-agnostic) ClusterTree
     # path in both cases.
     monkeypatch.setattr(_sdf_triton, "available", lambda: False)
-    sdf_ref, _ = signed_distance_field_mesh(
-        mesh, query, use_sign_winding_number=use_winding
-    )
+    sdf_ref, _ = signed_distance_field(mesh, query, use_sign_winding_number=use_winding)
 
     torch.testing.assert_close(sdf_triton, sdf_ref, atol=1e-4, rtol=1e-4)
 
@@ -784,7 +809,7 @@ def test_sdf_no_winding_path_is_sync_free():
     # lazy module loading, caching-allocator growth) legitimately synchronize.
     # The guarded run below reuses the same query shape so no new autotune key or
     # allocation is triggered.
-    signed_distance_field_mesh(mesh, query, use_sign_winding_number=False)
+    signed_distance_field(mesh, query, use_sign_winding_number=False)
     torch.cuda.synchronize()
 
     # ``error`` mode raises on *implicit* synchronizing ops (``.item()``,
@@ -795,7 +820,7 @@ def test_sdf_no_winding_path_is_sync_free():
     prev = torch.cuda.get_sync_debug_mode()
     torch.cuda.set_sync_debug_mode("error")
     try:
-        signed_distance_field_mesh(mesh, query, use_sign_winding_number=False)
+        signed_distance_field(mesh, query, use_sign_winding_number=False)
     finally:
         torch.cuda.set_sync_debug_mode(prev)
     torch.cuda.synchronize()

--- a/test/mesh/spatial/test_mesh_sdf.py
+++ b/test/mesh/spatial/test_mesh_sdf.py
@@ -255,7 +255,7 @@ def test_sdf_tetrahedron_reference(dtype, use_winding, device):
         [[1.0, 1.0, 1.0], [0.05, 0.1, 0.1]], device=device, dtype=dtype
     )
 
-    sdf_out, hit_points = signed_distance_field(
+    sdf_out, hit_points, _ = signed_distance_field(
         mesh,
         query_points,
         use_sign_winding_number=use_winding,
@@ -288,10 +288,10 @@ def test_sdf_index_layout_compatibility(device):
     mesh_indices_faces = tet.cells
     query_points = torch.tensor([[0.1, 0.2, 0.3]], device=device, dtype=torch.float32)
 
-    sdf_flat, hit_flat = _signed_distance_field_from_arrays(
+    sdf_flat, hit_flat, _ = _signed_distance_field_from_arrays(
         tet.points, mesh_indices_flat, query_points
     )
-    sdf_faces, hit_faces = _signed_distance_field_from_arrays(
+    sdf_faces, hit_faces, _ = _signed_distance_field_from_arrays(
         tet.points, mesh_indices_faces, query_points
     )
     torch.testing.assert_close(sdf_flat, sdf_faces)
@@ -309,7 +309,7 @@ def test_sdf_sphere_analytic(use_winding, device):
     radius = query.norm(dim=-1)
     gt = radius - 1.0
 
-    sdf_out, hit = signed_distance_field(
+    sdf_out, hit, _ = signed_distance_field(
         mesh, query, use_sign_winding_number=use_winding
     )
 
@@ -333,9 +333,11 @@ def test_sdf_preserves_input_shape(device):
     mesh = _tetrahedron_mesh().to(device)
     query = torch.rand(4, 5, 3, device=device)
 
-    sdf_out, hit = signed_distance_field(mesh, query)
+    sdf_out, hit, hit_faces = signed_distance_field(mesh, query)
     assert sdf_out.shape == (4, 5)
     assert hit.shape == (4, 5, 3)
+    assert hit_faces.shape == (4, 5)
+    assert hit_faces.dtype == torch.long
 
 
 def test_sdf_public_matches_private_arrays(device):
@@ -346,8 +348,8 @@ def test_sdf_public_matches_private_arrays(device):
     torch.manual_seed(0)
     query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
 
-    sdf_pub, hit_pub = signed_distance_field(mesh, query)
-    sdf_priv, hit_priv = _signed_distance_field_from_arrays(
+    sdf_pub, hit_pub, _ = signed_distance_field(mesh, query)
+    sdf_priv, hit_priv, _ = _signed_distance_field_from_arrays(
         mesh.points, mesh.cells, query
     )
     torch.testing.assert_close(sdf_pub, sdf_priv)
@@ -393,10 +395,10 @@ def test_sdf_winding_backend_selection(device):
     torch.manual_seed(0)
     query = (torch.rand(512, 3, device=device) * 3.0 - 1.5).float()
 
-    sdf_tree, hit_tree = signed_distance_field(
+    sdf_tree, hit_tree, _ = signed_distance_field(
         mesh, query, use_sign_winding_number=True, winding_backend="clustertree"
     )
-    sdf_brute, hit_brute = signed_distance_field(
+    sdf_brute, hit_brute, _ = signed_distance_field(
         mesh, query, use_sign_winding_number=True, winding_backend="bruteforce"
     )
 
@@ -405,6 +407,34 @@ def test_sdf_winding_backend_selection(device):
     torch.testing.assert_close(hit_tree, hit_brute)
     near_surface = sdf_brute.abs() < 0.05
     assert torch.all(sdf_tree[~near_surface] == sdf_brute[~near_surface])
+
+
+def test_sdf_hit_faces_identify_nearest_face(device):
+    """``hit_faces`` indexes the face that realizes the reported distance.
+
+    Recomputing the closest point on the returned face must reproduce both the
+    hit point and the unsigned distance. On CUDA this also checks the Triton
+    kernel's mapping from BVH-sorted cell order back to input face indices.
+    """
+    from physicsnemo.mesh.spatial.sdf import _closest_point_on_triangles
+
+    device = torch.device(device)
+    mesh = _uv_sphere_mesh().to(device)
+
+    torch.manual_seed(0)
+    query = (torch.rand(2048, 3, device=device) * 3.0 - 1.5).float()
+
+    sdf_out, hit, hit_faces = signed_distance_field(mesh, query)
+
+    assert hit_faces.dtype == torch.long
+    assert hit_faces.min() >= 0
+    assert hit_faces.max() < mesh.n_cells
+    tri = mesh.points.float()[mesh.cells.long()[hit_faces]]
+    closest = _closest_point_on_triangles(query, tri)
+    torch.testing.assert_close(
+        (query - closest).norm(dim=-1), sdf_out.abs(), atol=1e-6, rtol=1e-5
+    )
+    torch.testing.assert_close(closest, hit, atol=1e-6, rtol=1e-5)
 
 
 def test_sdf_array_connectivity_validation(device):
@@ -546,7 +576,7 @@ def test_sdf_degenerate_face_mesh(device):
     mesh = Mesh(points=points, cells=cells)
 
     query = torch.tensor([[4.5, 0.2, 0.0]], dtype=torch.float32, device=device)
-    sdf_out, hit = signed_distance_field(mesh, query, use_sign_winding_number=True)
+    sdf_out, hit, _ = signed_distance_field(mesh, query, use_sign_winding_number=True)
 
     # The repair moves the surface by at most 2 h = 2 * 1e-4 * 4; assert to
     # 1e-3 to leave headroom over float32 arithmetic on top of that bound.
@@ -580,21 +610,25 @@ def test_sdf_max_dist_unbounded_and_narrow_band(device):
     near = torch.tensor([[0.05, 0.1, 0.1]], device=device, dtype=torch.float32)
 
     # Unbounded default: the far query finds its true nearest triangle.
-    sdf_far, hit_far = signed_distance_field(mesh, far)
+    sdf_far, hit_far, _ = signed_distance_field(mesh, far)
     assert torch.isfinite(sdf_far).all()
     assert sdf_far.abs().item() > 1.0
     assert not torch.allclose(hit_far, far)
 
-    # Finite band below the true distance: the far query is out of band -> NaN.
-    sdf_band, hit_band = signed_distance_field(mesh, far, max_dist=1.0)
+    # Finite band below the true distance: the far query is out of band ->
+    # NaN results and a -1 face index (int64 has no NaN).
+    sdf_band, hit_band, faces_band = signed_distance_field(mesh, far, max_dist=1.0)
     assert torch.isnan(sdf_band).all()
     assert torch.isnan(hit_band).all()
+    assert (faces_band == -1).all()
 
     # An in-band query with a finite max_dist matches the unbounded result.
-    sdf_unbounded, _ = signed_distance_field(mesh, near)
-    sdf_in_band, _ = signed_distance_field(mesh, near, max_dist=10.0)
+    sdf_unbounded, _, faces_unbounded = signed_distance_field(mesh, near)
+    sdf_in_band, _, faces_in_band = signed_distance_field(mesh, near, max_dist=10.0)
     assert torch.isfinite(sdf_in_band).all()
     torch.testing.assert_close(sdf_in_band, sdf_unbounded, atol=1e-5, rtol=1e-5)
+    assert (faces_in_band == faces_unbounded).all()
+    assert (faces_in_band >= 0).all()
 
 
 def test_sdf_pseudo_normal_sign_wrong_at_sharp_edges(device):
@@ -623,7 +657,7 @@ def test_sdf_pseudo_normal_sign_wrong_at_sharp_edges(device):
     reflex[:, 2] = _L_PRISM_HEIGHT * reflex[:, 2]
     query = torch.cat([box, reflex], dim=0).to(device)
 
-    sdf_out, _ = signed_distance_field(mesh, query, use_sign_winding_number=False)
+    sdf_out, _, _ = signed_distance_field(mesh, query, use_sign_winding_number=False)
 
     # The distance magnitude is correct; only the sign is in question. Compare to
     # the analytic interior away from the surface, where the sign is unambiguous.
@@ -657,7 +691,7 @@ def test_sdf_winding_sign_correct_at_sharp_edges(device):
     hi = torch.tensor([1.2, 1.2, _L_PRISM_HEIGHT + 0.2])
     query = (lo + (hi - lo) * torch.rand(40_000, 3)).to(device)
 
-    sdf_out, _ = signed_distance_field(mesh, query, use_sign_winding_number=True)
+    sdf_out, _, _ = signed_distance_field(mesh, query, use_sign_winding_number=True)
 
     # Exclude a near-surface band: the CUDA Barnes-Hut winding approximation is
     # only loose right at the surface (cf. test_winding_sign_triton_matches_exact).
@@ -754,7 +788,7 @@ def test_sdf_winding_sign_correct_at_sharp_edges_grid(device):
     query = _l_prism_probe_grid(device, thickness)
     gt_inside = _inside_l(query, thickness)
 
-    sdf_out, _ = signed_distance_field(mesh, query, use_sign_winding_number=True)
+    sdf_out, _, _ = signed_distance_field(mesh, query, use_sign_winding_number=True)
 
     # Compare signs away from the surface. The default ClusterTree backend is a
     # Barnes-Hut approximation whose winding number is only unreliable in a thin
@@ -781,7 +815,7 @@ def test_sdf_pseudo_normal_sign_correct_at_sharp_edges(device):
     query = _l_prism_probe_grid(device, thickness)
     gt_inside = _inside_l(query, thickness)
 
-    sdf_out, _ = signed_distance_field(mesh, query, use_sign_winding_number=False)
+    sdf_out, _, _ = signed_distance_field(mesh, query, use_sign_winding_number=False)
 
     away = sdf_out.abs() > 0.05
     expected = torch.where(
@@ -909,7 +943,7 @@ def test_sdf_triton_end_to_end_matches_reference(use_winding, monkeypatch):
     query = (torch.rand(4096, 3, device=device) * 3.0 - 1.5).float()
 
     # Triton fast path (default dispatch on CUDA).
-    sdf_triton, _ = signed_distance_field(
+    sdf_triton, _, _ = signed_distance_field(
         mesh, query, use_sign_winding_number=use_winding
     )
 
@@ -917,7 +951,9 @@ def test_sdf_triton_end_to_end_matches_reference(use_winding, monkeypatch):
     # dispatch. The winding-number sign uses the (device-agnostic) ClusterTree
     # path in both cases.
     monkeypatch.setattr(_sdf_triton, "available", lambda: False)
-    sdf_ref, _ = signed_distance_field(mesh, query, use_sign_winding_number=use_winding)
+    sdf_ref, _, _ = signed_distance_field(
+        mesh, query, use_sign_winding_number=use_winding
+    )
 
     torch.testing.assert_close(sdf_triton, sdf_ref, atol=1e-4, rtol=1e-4)
 

--- a/test/mesh/spatial/test_mesh_sdf.py
+++ b/test/mesh/spatial/test_mesh_sdf.py
@@ -379,6 +379,11 @@ def test_sdf_error_handling(device):
     with pytest.raises(ValueError, match="winding_backend"):
         signed_distance_field(mesh, query, winding_backend="warp")
 
+    # A negative search radius is rejected rather than silently behaving
+    # like its absolute value.
+    with pytest.raises(ValueError, match="max_dist"):
+        signed_distance_field(mesh, query, max_dist=-1.0)
+
 
 def test_sdf_winding_backend_selection(device):
     """Both winding backends agree through the public API on a closed surface."""
@@ -428,6 +433,136 @@ def test_sdf_empty_mesh_raises(device):
 
     with pytest.raises(ValueError, match="no faces"):
         signed_distance_field(empty_mesh, query)
+
+
+def test_repair_degenerate_faces(device):
+    """Degenerate faces are repaired into valid thin triangles; others untouched.
+
+    Ericson's Voronoi-region cascade assumes a non-degenerate triangle: on
+    zero-area faces several region tests fire vacuously and the cascade can
+    return the wrong feature (an overestimated distance). The build step must
+    therefore replace every repeated-vertex or collinear face with a valid
+    thin triangle spanning the same longest edge, moving the surface by no
+    more than the documented offset ``h``, while leaving valid faces
+    bit-identical and point-like faces (exact under Ericson) alone.
+    """
+    from physicsnemo.mesh.spatial.sdf import (
+        _DEGENERATE_TRI_REL_HEIGHT,
+        _repair_degenerate_faces,
+    )
+
+    device = torch.device(device)
+    torch.manual_seed(0)
+    n = 10_000
+    a = torch.randn(n, 3, device=device)
+    b = torch.randn(n, 3, device=device)
+    t_mid = torch.rand(n, 1, device=device) * 2 - 0.5
+    mid = a + (b - a) * t_mid  # collinear, inside and beyond the a-b span
+
+    def seg_dist(p, s0, s1):
+        d = s1 - s0
+        denom = (d * d).sum(-1)
+        t = ((p - s0) * d).sum(-1) / denom.clamp(min=1e-30)
+        t = torch.where(denom > 0, t.clamp(0.0, 1.0), torch.zeros_like(t))
+        return (p - (s0 + d * t.unsqueeze(-1))).norm(dim=-1)
+
+    degenerate_tris = [
+        torch.stack([a, a, b], dim=1),
+        torch.stack([a, b, a], dim=1),
+        torch.stack([b, a, a], dim=1),
+        torch.stack([a, mid, b], dim=1),
+    ]
+    for tri in degenerate_tris:
+        repaired = _repair_degenerate_faces(tri)
+        ra, rb, rc = repaired[:, 0], repaired[:, 1], repaired[:, 2]
+        # Valid now: relative height comfortably above the float32 danger zone.
+        area2 = torch.linalg.cross(rb - ra, rc - ra, dim=-1).norm(dim=-1)
+        edge_max = torch.stack(
+            [(rb - ra).norm(dim=-1), (rc - ra).norm(dim=-1), (rc - rb).norm(dim=-1)],
+            dim=-1,
+        ).amax(dim=-1)
+        rel_height = area2 / edge_max.clamp(min=1e-30) ** 2
+        assert torch.all(rel_height > 0.5 * _DEGENERATE_TRI_REL_HEIGHT)
+        # The repaired surface stays within h of the original geometry: every
+        # repaired vertex lies within h of the union of the original edges.
+        # (Individual vertices may travel far -- a repeated vertex moves to
+        # the edge midpoint -- but never off the original segment by more
+        # than h.)
+        h = (_DEGENERATE_TRI_REL_HEIGHT * edge_max + 1e-5).unsqueeze(-1)
+        dist_to_orig = torch.stack(
+            [
+                torch.minimum(
+                    torch.minimum(
+                        seg_dist(repaired[:, k], tri[:, 0], tri[:, 1]),
+                        seg_dist(repaired[:, k], tri[:, 1], tri[:, 2]),
+                    ),
+                    seg_dist(repaired[:, k], tri[:, 2], tri[:, 0]),
+                )
+                for k in range(3)
+            ],
+            dim=-1,
+        )
+        assert torch.all(dist_to_orig <= h)
+
+    # Point-like faces are exact under Ericson already: left untouched.
+    point_tri = torch.stack([a, a, a], dim=1)
+    assert torch.equal(_repair_degenerate_faces(point_tri), point_tri)
+
+    # Valid faces come back bit-identical.
+    c = torch.randn(n, 3, device=device)
+    valid = torch.stack([a, b, c], dim=1)
+    area2 = torch.linalg.cross(b - a, c - a, dim=-1).norm(dim=-1)
+    edge_max = torch.stack(
+        [(b - a).norm(dim=-1), (c - a).norm(dim=-1), (c - b).norm(dim=-1)], dim=-1
+    ).amax(dim=-1)
+    valid = valid[area2 / edge_max**2 > 10 * _DEGENERATE_TRI_REL_HEIGHT]
+    assert torch.equal(_repair_degenerate_faces(valid), valid)
+
+
+def test_sdf_degenerate_face_mesh(device):
+    """An isolated degenerate face reports the distance to its segment.
+
+    End-to-end regression: a repeated-vertex face spanning the segment
+    (0,0,0)-(4,0,0) must report the distance to that segment (nearest point
+    (4,0,0) here) to within the documented repair offset -- not the distance
+    to one of its vertices (an error of ~4 here before the fix). On CUDA this
+    exercises the Triton kernel path; on CPU the torch DFS.
+    """
+    device = torch.device(device)
+    # One repeated-vertex face spanning a segment, plus a far valid triangle so
+    # the mesh also contains non-degenerate geometry.
+    points = torch.tensor(
+        [
+            [0.0, 0.0, 0.0],
+            [4.0, 0.0, 0.0],
+            [100.0, 0.0, 0.0],
+            [101.0, 0.0, 0.0],
+            [100.0, 1.0, 0.0],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    cells = torch.tensor([[0, 1, 1], [2, 3, 4]], dtype=torch.int64, device=device)
+    mesh = Mesh(points=points, cells=cells)
+
+    query = torch.tensor([[4.5, 0.2, 0.0]], dtype=torch.float32, device=device)
+    sdf_out, hit = signed_distance_field(mesh, query, use_sign_winding_number=True)
+
+    # The repair moves the surface by at most 2 h = 2 * 1e-4 * 4; assert to
+    # 1e-3 to leave headroom over float32 arithmetic on top of that bound.
+    true_dist = math.hypot(0.5, 0.2)
+    torch.testing.assert_close(
+        sdf_out.abs(),
+        torch.tensor([true_dist], device=device),
+        atol=1e-3,
+        rtol=0.0,
+    )
+    torch.testing.assert_close(
+        hit,
+        torch.tensor([[4.0, 0.0, 0.0]], device=device),
+        atol=1e-3,
+        rtol=0.0,
+    )
 
 
 def test_sdf_max_dist_unbounded_and_narrow_band(device):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

Pre-release cleanup and hardening of the mesh-native SDF (`physicsnemo.mesh.spatial`), which landed after v2.1.1 and has not yet shipped in a release — so these API changes are still free. Four commits, independently revertable:

**1. API cleanup (`4e32f65`)**

- Rename `signed_distance_field_mesh` → `signed_distance_field`: the function lives in `physicsnemo.mesh.spatial`, so the `_mesh` suffix was redundant. (The array-based custom op `physicsnemo.nn.functional.signed_distance_field` is a different function with a different signature; the namespaces disambiguate, as in `torch.norm` / `torch.linalg.norm`.)
- Type `winding_backend` as `Literal["clustertree", "bruteforce"]` (`WindingBackend` type alias) instead of `str`, so type checkers validate call sites; runtime validation derives from the same `Literal` via `get_args` and now runs at function entry — before the BVH build and nearest-triangle search — instead of after them.
- Validate mesh/query device mismatch and negative `max_dist` up front with clear messages.
- Reflow a docstring line that ran far past the line width (`E501` is disabled repo-wide and `ruff format` does not reflow docstrings, which is how it slipped through).

**2. Degenerate-triangle correctness fix (`70c96fe`)**

Ericson's Voronoi-region closest-point classification assumes a non-degenerate triangle. On zero-area faces (repeated vertices or collinear points) several region tests fire vacuously and the cascade returns the wrong feature — always overestimating the distance. Measured against an exact union-of-edges oracle: ~30–70% wrong closest points for isolated repeated-vertex faces (distance errors up to ~7% relative), 1.5% for exactly-collinear faces, plus float32 misclassification of eps-scale slivers. The Triton kernel mirrors the same cascade and shared the bug. Degenerate junk faces coincident with valid geometry are masked by the distance min; isolated ones silently corrupt the SDF.

Fix: repair the geometry once per call instead of guarding the hot kernels — `_build_surface_mesh` displaces the off-edge vertex of any face with relative height < 1e-4 to the longest-edge midpoint plus a perpendicular offset `h = max(1e-4·L, 8·eps_f32·max|coord|)`. SDF and hit points move by at most `2h`, only for queries whose nearest face was degenerate; the pass is fixed-shape tensor code (sync-free) and leaves valid faces bit-identical. An exact per-pair in-kernel fallback was implemented first and rejected: it measured **20–25% slower kernel-only** (SIMT straight-line code pays for it on every candidate), whereas this approach keeps both closest-point kernels byte-identical to `main`.

**3. Hit-face indices via a named tuple (`d99c194`)**

`signed_distance_field` now returns `SignedDistanceFieldResult(sdf, hit_points, hit_faces)`. Both backends already computed the nearest-face index and threw it away; exposing it enables oriented face-normal lookups at the hit point (needed by commit 4). `hit_faces` is `-1` for queries beyond a finite `max_dist`. Doing this pre-release keeps it a clean signature change rather than a compatibility shim.

**4. Near-wall SDF normals fix in the unified aero recipe (`4336b05`)**

`ComputeSDFFromBoundary` fell back to the direction-away-from-surface-centroid for points within an absolute 1e-6 of the surface. That direction is unrelated to the wall normal — on a fender-like panel it is *tangent* to the surface (~80–90° median error vs the true normal) — and DrivAerML boundary layers put 1–3% of every 200k-point batch inside the band, so every volume model trained on this pipeline received corrupted normals concentrated exactly in the boundary layer. (The pattern traces to DoMINO, where direction-from-center-of-mass was a *separate* positional-encoding input, not a normals fallback.) The fix substitutes the oriented hit-face normal — exact at any wall distance including zero — inside a scale-aware band (`128·eps` per unit coordinate magnitude, since closest-point rounding noise grows with coordinate scale and an absolute cutoff under-covers geometry far from the origin).

**Verification**

- Existing SDF suite extended: 50+ tests pass on CPU and CUDA (Triton path included), plus new tests for the winding backends, degenerate-face repair (unit + end-to-end), hit-face indices (including the Triton sorted-order mapping), and the recipe's near-wall normals (closed elongated box mirroring the fender failure mode, wall distances down to 1e-8).
- Degenerate closest-point behavior fuzzed against an exact union-of-edges oracle (500k queries across repeated-vertex/collinear/collapsed patterns: 0 wrong) and a float32 sliver sweep (200k queries, heights 1e-3…1e-12: 0 over 1e-4 error).
- The `test_sdf_no_winding_path_is_sync_free` guard confirms the repair pass introduces no host synchronization.

**Known follow-up (out of scope here):** `physicsnemo.datapipes.transforms.geometric.ComputeNormals` has the same centroid-fallback pattern, but it is a raw-TensorDict transform with no mesh access, so the face-normal fix needs a data-contract change there.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

None.
