### PR TITLE
fix(datapipes): resume-reproducible set_epoch across readers and transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `set_epoch` seed drift in datapipes readers and transforms:
+  reseeding used `initial_seed() + epoch`, which compounds across calls
+  (manual_seed updates initial_seed), so resuming from a checkpoint drew
+  different subsample blocks and augmentations than an uninterrupted run.
+  Epoch reseeding now uses a base seed captured at `set_generator` time.
 - `physicsnemo.mesh.sampling.sample_data_at_points` now handles integer and
   boolean fields by returning `float64`, so NaN sentinels and non-integral
   interpolation or multi-cell means are representable (subject to the usual

--- a/physicsnemo/datapipes/RNG.md
+++ b/physicsnemo/datapipes/RNG.md
@@ -70,9 +70,11 @@ sub-dataset.
 ### Epoch reseeding
 
 `DataLoader.set_epoch(epoch)` propagates to the sampler and dataset.
-Each component with a generator reseeds it with
-`initial_seed() + epoch`, producing a different but deterministic
-random sequence every epoch.
+Each component with a generator reseeds it with `base_seed + epoch`,
+where the base seed is captured once when the generator is assigned
+(`set_generator`). The epoch->seed mapping therefore depends only on
+the base seed and the epoch — resuming a run at epoch *N* reproduces
+the same random sequence as reaching epoch *N* sequentially.
 
 ## Generator tree
 
@@ -122,7 +124,8 @@ define the same generator protocol:
 
 - **`stochastic`** — property; `True` when `self._generator` exists.
 - **`set_generator(g)`** — assigns `g` if stochastic; no-op otherwise.
-- **`set_epoch(epoch)`** — reseeds with `initial_seed() + epoch`.
+- **`set_epoch(epoch)`** — reseeds with `base_seed + epoch` (base
+  seed captured at `set_generator` time; resume-reproducible).
 
 To make a transform stochastic, declare
 `self._generator: torch.Generator | None = None` in `__init__`.

--- a/physicsnemo/datapipes/readers/mesh.py
+++ b/physicsnemo/datapipes/readers/mesh.py
@@ -189,6 +189,7 @@ class MeshReader:
         self.subsample_n_points = subsample_n_points
         self.subsample_n_cells = subsample_n_cells
         self._subsample_generator: torch.Generator | None = None
+        self._subsample_base_seed: int | None = None
 
         if not self._root.exists():
             raise FileNotFoundError(f"Path not found: {self._root}")
@@ -223,17 +224,24 @@ class MeshReader:
             Generator to use for contiguous block selection.
         """
         self._subsample_generator = generator
+        # Capture the base seed once: reseeding from initial_seed() each
+        # epoch would drift (manual_seed updates initial_seed), making the
+        # epoch->seed mapping depend on call history and breaking
+        # checkpoint-resume reproducibility.
+        self._subsample_base_seed = generator.initial_seed()
 
     def set_epoch(self, epoch: int) -> None:
-        """Reseed the subsample RNG for a new epoch.
+        """Reseed the subsample RNG for a new epoch (base seed + epoch).
 
         Produces a different (but deterministic) sequence of contiguous
         blocks each epoch when a generator has been assigned via
-        :meth:`set_generator`.
+        :meth:`set_generator`. The mapping depends only on the base seed
+        and ``epoch``, so resuming at epoch *N* reproduces the same
+        blocks as reaching epoch *N* sequentially.
         """
         if self._subsample_generator is not None:
             self._subsample_generator.manual_seed(
-                self._subsample_generator.initial_seed() + epoch
+                self._subsample_base_seed + epoch
             )
 
     def __getitem__(self, index: int) -> tuple[Mesh, dict[str, Any]]:
@@ -340,6 +348,7 @@ class DomainMeshReader:
         self.subsample_n_points = subsample_n_points
         self.subsample_n_cells = subsample_n_cells
         self._subsample_generator: torch.Generator | None = None
+        self._subsample_base_seed: int | None = None
         self._extra_boundaries = extra_boundaries or {}
 
         if not self._root.exists():
@@ -370,17 +379,24 @@ class DomainMeshReader:
             Generator to use for contiguous block selection.
         """
         self._subsample_generator = generator
+        # Capture the base seed once: reseeding from initial_seed() each
+        # epoch would drift (manual_seed updates initial_seed), making the
+        # epoch->seed mapping depend on call history and breaking
+        # checkpoint-resume reproducibility.
+        self._subsample_base_seed = generator.initial_seed()
 
     def set_epoch(self, epoch: int) -> None:
-        """Reseed the subsample RNG for a new epoch.
+        """Reseed the subsample RNG for a new epoch (base seed + epoch).
 
         Produces a different (but deterministic) sequence of contiguous
         blocks each epoch when a generator has been assigned via
-        :meth:`set_generator`.
+        :meth:`set_generator`. The mapping depends only on the base seed
+        and ``epoch``, so resuming at epoch *N* reproduces the same
+        blocks as reaching epoch *N* sequentially.
         """
         if self._subsample_generator is not None:
             self._subsample_generator.manual_seed(
-                self._subsample_generator.initial_seed() + epoch
+                self._subsample_base_seed + epoch
             )
 
     def __getitem__(self, index: int) -> tuple[DomainMesh, dict[str, Any]]:

--- a/physicsnemo/datapipes/readers/mesh.py
+++ b/physicsnemo/datapipes/readers/mesh.py
@@ -240,9 +240,7 @@ class MeshReader:
         blocks as reaching epoch *N* sequentially.
         """
         if self._subsample_generator is not None:
-            self._subsample_generator.manual_seed(
-                self._subsample_base_seed + epoch
-            )
+            self._subsample_generator.manual_seed(self._subsample_base_seed + epoch)
 
     def __getitem__(self, index: int) -> tuple[Mesh, dict[str, Any]]:
         mesh = self._load_sample(index)
@@ -395,9 +393,7 @@ class DomainMeshReader:
         blocks as reaching epoch *N* sequentially.
         """
         if self._subsample_generator is not None:
-            self._subsample_generator.manual_seed(
-                self._subsample_base_seed + epoch
-            )
+            self._subsample_generator.manual_seed(self._subsample_base_seed + epoch)
 
     def __getitem__(self, index: int) -> tuple[DomainMesh, dict[str, Any]]:
         dm = self._load_sample(index)

--- a/physicsnemo/datapipes/readers/numpy.py
+++ b/physicsnemo/datapipes/readers/numpy.py
@@ -181,9 +181,7 @@ class NumpyReader(Reader):
     def set_epoch(self, epoch: int) -> None:
         """Reseed the subsample RNG for a new epoch (base seed + epoch)."""
         if self._subsample_generator is not None:
-            self._subsample_generator.manual_seed(
-                self._subsample_base_seed + epoch
-            )
+            self._subsample_generator.manual_seed(self._subsample_base_seed + epoch)
 
     def _select_random_sections_from_slice(
         self,

--- a/physicsnemo/datapipes/readers/numpy.py
+++ b/physicsnemo/datapipes/readers/numpy.py
@@ -113,6 +113,7 @@ class NumpyReader(Reader):
         self.file_pattern = file_pattern
         self.index_key = index_key
         self._subsample_generator: torch.Generator | None = None
+        self._subsample_base_seed: int | None = None
 
         if not self.path.exists():
             raise FileNotFoundError(f"Path not found: {self.path}")
@@ -171,12 +172,17 @@ class NumpyReader(Reader):
     def set_generator(self, generator: torch.Generator) -> None:
         """Assign a ``torch.Generator`` for reproducible subsampling."""
         self._subsample_generator = generator
+        # Capture the base seed once: reseeding from initial_seed() each
+        # epoch would drift (manual_seed updates initial_seed), making the
+        # epoch->seed mapping depend on call history and breaking
+        # checkpoint-resume reproducibility.
+        self._subsample_base_seed = generator.initial_seed()
 
     def set_epoch(self, epoch: int) -> None:
-        """Reseed the subsample RNG for a new epoch."""
+        """Reseed the subsample RNG for a new epoch (base seed + epoch)."""
         if self._subsample_generator is not None:
             self._subsample_generator.manual_seed(
-                self._subsample_generator.initial_seed() + epoch
+                self._subsample_base_seed + epoch
             )
 
     def _select_random_sections_from_slice(

--- a/physicsnemo/datapipes/readers/tensorstore_zarr.py
+++ b/physicsnemo/datapipes/readers/tensorstore_zarr.py
@@ -156,6 +156,7 @@ class TensorStoreZarrReader(Reader):
         self.default_values = default_values or {}
         self.group_pattern = group_pattern
         self._subsample_generator: torch.Generator | None = None
+        self._subsample_base_seed: int | None = None
 
         if not self.path.exists():
             raise FileNotFoundError(f"Path not found: {self.path}")
@@ -238,12 +239,17 @@ class TensorStoreZarrReader(Reader):
     def set_generator(self, generator: torch.Generator) -> None:
         """Assign a ``torch.Generator`` for reproducible subsampling."""
         self._subsample_generator = generator
+        # Capture the base seed once: reseeding from initial_seed() each
+        # epoch would drift (manual_seed updates initial_seed), making the
+        # epoch->seed mapping depend on call history and breaking
+        # checkpoint-resume reproducibility.
+        self._subsample_base_seed = generator.initial_seed()
 
     def set_epoch(self, epoch: int) -> None:
-        """Reseed the subsample RNG for a new epoch."""
+        """Reseed the subsample RNG for a new epoch (base seed + epoch)."""
         if self._subsample_generator is not None:
             self._subsample_generator.manual_seed(
-                self._subsample_generator.initial_seed() + epoch
+                self._subsample_base_seed + epoch
             )
 
     def _read_attributes(self, group_path: Path) -> dict[str, Any]:

--- a/physicsnemo/datapipes/readers/tensorstore_zarr.py
+++ b/physicsnemo/datapipes/readers/tensorstore_zarr.py
@@ -248,9 +248,7 @@ class TensorStoreZarrReader(Reader):
     def set_epoch(self, epoch: int) -> None:
         """Reseed the subsample RNG for a new epoch (base seed + epoch)."""
         if self._subsample_generator is not None:
-            self._subsample_generator.manual_seed(
-                self._subsample_base_seed + epoch
-            )
+            self._subsample_generator.manual_seed(self._subsample_base_seed + epoch)
 
     def _read_attributes(self, group_path: Path) -> dict[str, Any]:
         """Read attributes from a Zarr group (v2 or v3)."""

--- a/physicsnemo/datapipes/readers/zarr.py
+++ b/physicsnemo/datapipes/readers/zarr.py
@@ -219,9 +219,7 @@ class ZarrReader(Reader):
     def set_epoch(self, epoch: int) -> None:
         """Reseed the subsample RNG for a new epoch (base seed + epoch)."""
         if self._subsample_generator is not None:
-            self._subsample_generator.manual_seed(
-                self._subsample_base_seed + epoch
-            )
+            self._subsample_generator.manual_seed(self._subsample_base_seed + epoch)
 
     def _open_zarr_store(self, path: Path) -> Any:
         """

--- a/physicsnemo/datapipes/readers/zarr.py
+++ b/physicsnemo/datapipes/readers/zarr.py
@@ -145,6 +145,7 @@ class ZarrReader(Reader):
         self._cache_stores = cache_stores
         self._cached_stores: dict[Path, Any] = {}  # Cache for opened zarr stores
         self._subsample_generator: torch.Generator | None = None
+        self._subsample_base_seed: int | None = None
 
         if not self.path.exists():
             raise FileNotFoundError(f"Path not found: {self.path}")
@@ -209,12 +210,17 @@ class ZarrReader(Reader):
     def set_generator(self, generator: torch.Generator) -> None:
         """Assign a ``torch.Generator`` for reproducible subsampling."""
         self._subsample_generator = generator
+        # Capture the base seed once: reseeding from initial_seed() each
+        # epoch would drift (manual_seed updates initial_seed), making the
+        # epoch->seed mapping depend on call history and breaking
+        # checkpoint-resume reproducibility.
+        self._subsample_base_seed = generator.initial_seed()
 
     def set_epoch(self, epoch: int) -> None:
-        """Reseed the subsample RNG for a new epoch."""
+        """Reseed the subsample RNG for a new epoch (base seed + epoch)."""
         if self._subsample_generator is not None:
             self._subsample_generator.manual_seed(
-                self._subsample_generator.initial_seed() + epoch
+                self._subsample_base_seed + epoch
             )
 
     def _open_zarr_store(self, path: Path) -> Any:

--- a/physicsnemo/datapipes/transforms/base.py
+++ b/physicsnemo/datapipes/transforms/base.py
@@ -102,13 +102,19 @@ class Transform(ABC):
         """
         if self.stochastic:
             self._generator = generator
+            # Capture the base seed once: reseeding from initial_seed()
+            # each epoch would drift (manual_seed updates initial_seed),
+            # making the epoch->seed mapping depend on call history and
+            # breaking checkpoint-resume reproducibility.
+            self._epoch_base_seed = generator.initial_seed()
 
     def set_epoch(self, epoch: int) -> None:
-        """Reseed the generator for a new epoch.
+        """Reseed the generator for a new epoch (base seed + epoch).
 
-        Reseeds ``self._generator`` with ``initial_seed() + epoch`` so
-        each epoch produces a different but deterministic random
-        sequence.  No-op for deterministic transforms or when no
+        The base seed is captured when the generator is assigned, so the
+        epoch->seed mapping depends only on ``epoch``: resuming at epoch
+        *N* reproduces the same random sequence as reaching epoch *N*
+        sequentially.  No-op for deterministic transforms or when no
         generator has been assigned.
 
         Parameters
@@ -117,7 +123,10 @@ class Transform(ABC):
             Current epoch number.
         """
         if self.stochastic and self._generator is not None:
-            self._generator.manual_seed(self._generator.initial_seed() + epoch)
+            if getattr(self, "_epoch_base_seed", None) is None:
+                # Generator declared by the subclass without set_generator.
+                self._epoch_base_seed = self._generator.initial_seed()
+            self._generator.manual_seed(self._epoch_base_seed + epoch)
 
     def to(self, device: torch.device | str) -> Transform:
         """Move any internal tensors, generators, and distributions to *device*.

--- a/physicsnemo/datapipes/transforms/mesh/DISTRIBUTIONS.md
+++ b/physicsnemo/datapipes/transforms/mesh/DISTRIBUTIONS.md
@@ -60,8 +60,10 @@ master `torch.Generator` and passes it to
 `MeshDataset.set_generator(parent_gen)`, which forks the parent
 into independent children — one for the reader and one per
 transform.  `MeshDataset.set_epoch(epoch)` reseeds every child
-with `initial_seed() + epoch` so each epoch is different but
-deterministic.  Deterministic transforms silently ignore both calls.
+with `base_seed + epoch` (the base seed is captured when the child is
+assigned) so each epoch is different but deterministic, and resuming
+at an epoch reproduces the same sequence as reaching it sequentially.
+Deterministic transforms silently ignore both calls.
 
 For standalone usage outside a `DataLoader`, call `set_generator`
 on the transform directly:

--- a/physicsnemo/datapipes/transforms/mesh/base.py
+++ b/physicsnemo/datapipes/transforms/mesh/base.py
@@ -108,13 +108,19 @@ class MeshTransform(ABC):
         """
         if self.stochastic:
             self._generator = generator
+            # Capture the base seed once: reseeding from initial_seed()
+            # each epoch would drift (manual_seed updates initial_seed),
+            # making the epoch->seed mapping depend on call history and
+            # breaking checkpoint-resume reproducibility.
+            self._epoch_base_seed = generator.initial_seed()
 
     def set_epoch(self, epoch: int) -> None:
-        """Reseed the generator for a new epoch.
+        """Reseed the generator for a new epoch (base seed + epoch).
 
-        Reseeds ``self._generator`` with ``initial_seed() + epoch`` so
-        each epoch produces a different but deterministic random
-        sequence.  No-op for deterministic transforms or when no
+        The base seed is captured when the generator is assigned, so the
+        epoch->seed mapping depends only on ``epoch``: resuming at epoch
+        *N* reproduces the same random sequence as reaching epoch *N*
+        sequentially.  No-op for deterministic transforms or when no
         generator has been assigned.
 
         Parameters
@@ -123,7 +129,10 @@ class MeshTransform(ABC):
             Current epoch number.
         """
         if self.stochastic and self._generator is not None:
-            self._generator.manual_seed(self._generator.initial_seed() + epoch)
+            if getattr(self, "_epoch_base_seed", None) is None:
+                # Generator declared by the subclass without set_generator.
+                self._epoch_base_seed = self._generator.initial_seed()
+            self._generator.manual_seed(self._epoch_base_seed + epoch)
 
     def to(self, device: torch.device | str) -> MeshTransform:
         """Move any internal tensors, generators, and distributions to *device*.

--- a/test/datapipes/readers/test_mesh_readers.py
+++ b/test/datapipes/readers/test_mesh_readers.py
@@ -422,9 +422,7 @@ class TestMeshReaderSubsamplingRNG:
         mesh.save(tmp_path / "m.pmsh")
 
         def block(epochs):
-            reader = MeshReader(
-                tmp_path, pattern="*.pmsh", subsample_n_points=10
-            )
+            reader = MeshReader(tmp_path, pattern="*.pmsh", subsample_n_points=10)
             reader.set_generator(torch.Generator().manual_seed(42))
             for e in epochs:
                 reader.set_epoch(e)

--- a/test/datapipes/readers/test_mesh_readers.py
+++ b/test/datapipes/readers/test_mesh_readers.py
@@ -410,6 +410,29 @@ class TestMeshReaderSubsamplingRNG:
 
         assert not torch.equal(data_e0.points, data_e1.points)
 
+    def test_set_epoch_resume_reproducible(self, tmp_path):
+        """set_epoch(n) after resume == reaching epoch n sequentially.
+
+        Guards against base-seed drift: reseeding from initial_seed()
+        each epoch compounds (manual_seed updates initial_seed), so a
+        checkpoint resume would draw different blocks than an
+        uninterrupted run.
+        """
+        mesh = Mesh(points=torch.randn(100, 3))
+        mesh.save(tmp_path / "m.pmsh")
+
+        def block(epochs):
+            reader = MeshReader(
+                tmp_path, pattern="*.pmsh", subsample_n_points=10
+            )
+            reader.set_generator(torch.Generator().manual_seed(42))
+            for e in epochs:
+                reader.set_epoch(e)
+            data, _ = reader[0]
+            return data.points
+
+        assert torch.equal(block([1, 2, 3]), block([3]))
+
 
 class TestDomainMeshReaderExtraBoundaries:
     """Tests for DomainMeshReader extra_boundaries feature."""

--- a/test/datapipes/readers/test_zarr.py
+++ b/test/datapipes/readers/test_zarr.py
@@ -70,6 +70,30 @@ class TestZarrReaderCoordinatedSubsampling:
         # Non-target arrays should have original size
         assert data["metadata_scalar"].shape == (1,)
 
+    def test_set_epoch_resume_reproducible(self, zarr_large_data_dir):
+        """set_epoch(n) after resume == reaching epoch n sequentially.
+
+        Guards against base-seed drift: reseeding from initial_seed()
+        each epoch compounds (manual_seed updates initial_seed).
+        """
+
+        def block(epochs):
+            reader = dp.ZarrReader(
+                zarr_large_data_dir,
+                group_pattern="sample_*.zarr",
+                coordinated_subsampling={
+                    "n_points": 100,
+                    "target_keys": ["volume_coords", "volume_fields"],
+                },
+            )
+            reader.set_generator(torch.Generator().manual_seed(42))
+            for e in epochs:
+                reader.set_epoch(e)
+            data, _ = reader[0]
+            return data["volume_coords"]
+
+        assert torch.equal(block([1, 2, 3]), block([3]))
+
     def test_coordinated_subsampling_consistency(self, zarr_large_data_dir):
         """Test that coordinated subsampling is consistent across target keys."""
         reader = dp.ZarrReader(

--- a/test/datapipes/transforms/test_mesh_augmentations.py
+++ b/test/datapipes/transforms/test_mesh_augmentations.py
@@ -837,3 +837,28 @@ class TestDataLoaderDrivenReproducibility:
         pts_a = _run_epoch(42, 5)
         pts_b = _run_epoch(42, 5)
         assert torch.allclose(pts_a, pts_b)
+
+    def test_set_epoch_resume_reproducible(self, tmp_path):
+        """set_epoch(n) after resume == reaching epoch n sequentially.
+
+        Guards against base-seed drift in Transform.set_epoch: reseeding
+        from initial_seed() each epoch compounds, so a checkpoint resume
+        would apply different augmentations than an uninterrupted run.
+        """
+        from physicsnemo.datapipes.mesh_dataset import MeshDataset
+        from physicsnemo.datapipes.readers.mesh import MeshReader
+
+        mesh = _simple_mesh_3d()
+        mesh.save(tmp_path / "s0.pt")
+
+        def _run_epochs(epochs):
+            reader = MeshReader(tmp_path, pattern="*.pt")
+            transforms = [RandomScaleMesh(distribution=D.Uniform(0.5, 2.0))]
+            ds = MeshDataset(reader, transforms=transforms)
+            ds.set_generator(torch.Generator().manual_seed(42))
+            for e in epochs:
+                ds.set_epoch(e)
+            m, _ = ds[0]
+            return m.points.clone()
+
+        assert torch.allclose(_run_epochs([1, 2, 3]), _run_epochs([3]))


### PR DESCRIPTION
## Description

Every `set_epoch` implementation in the datapipes stack reseeded its generator with `initial_seed() + epoch`. That idiom compounds: `manual_seed` updates `initial_seed`, so the epoch→seed mapping depends on call history. With base seed 42, sequential `set_epoch(1..5)` produces seeds 43, 45, 48, 52, 57 — while a run resumed from a checkpoint that calls `set_epoch(5)` directly gets 47. A resumed run therefore silently draws **different subsample blocks and augmentations** than an uninterrupted run, breaking seed-matched A/B protocols. Within a single uninterrupted run nothing is wrong (still deterministic), which is why this went unnoticed.

**Fix**: capture the base seed once at `set_generator` time and reseed with `base_seed + epoch`. Applied to all sites:

- `readers/mesh.py` (`MeshReader`, `DomainMeshReader`) — cherry-picked byte-identical from #1798 (which applies the same fix to its new zarr mesh readers), so the two PRs merge cleanly in either order
- `readers/numpy.py`, `readers/zarr.py`, `readers/tensorstore_zarr.py`
- `transforms/base.py` (`Transform`), `transforms/mesh/base.py` (`MeshTransform`) — with a lazy fallback for generators declared by subclasses without going through `set_generator`

`RNG.md` and `DISTRIBUTIONS.md` documented the drifting idiom as the contract; both are updated to the resume-reproducible semantics. `Compose` only delegates and needed no change.

**Behavior note**: epoch ≥ 2 now draws different (finally history-independent) blocks/augmentations than before the fix, so bitwise loss-curve comparisons across this change will differ; training statistics are unaffected.

**Tests**: sequential-vs-direct `set_epoch` equivalence (`block([1,2,3]) == block([3])`) pinned for `MeshReader`, `ZarrReader` coordinated subsampling, and the `MeshDataset` transform pipeline. Full `test/datapipes/readers/` + `test_mesh_augmentations.py` suites pass (114 passed).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

None.