### PR TITLE
fix(datapipes): write domain-level global_data in SetGlobalField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and interior elements equal inclusion probability.
 - Cell-subsampled GLOBE inputs now retain their effective integration measure,
   preventing area-weighted outputs and gradients from collapsing.
+- `SetGlobalField` now writes injected fields to the domain-level `global_data`
+  of a `DomainMesh`, in addition to the existing per-sub-mesh broadcast.
+  Previously, code reading `DomainMesh.global_data` never saw the injected
+  fields.
 - `physicsnemo.mesh.io.from_pyvista(..., force_copy=True)` now copies attached
   point, cell, and global data as well as geometry. The matching new
   `to_pyvista(..., force_copy=True)` option prevents exported PyVista geometry

--- a/physicsnemo/datapipes/transforms/mesh/transforms.py
+++ b/physicsnemo/datapipes/transforms/mesh/transforms.py
@@ -445,6 +445,10 @@ class SetGlobalField(MeshTransform):
     Typical use: inject a per-dataset inlet velocity vector so that
     downstream rotation transforms (with ``transform_global_data=True``)
     rotate it consistently with the mesh geometry.
+
+    On a :class:`~physicsnemo.mesh.DomainMesh`, the fields are written to
+    the domain-level ``global_data`` as well as to every sub-mesh's
+    ``global_data``.
     """
 
     def __init__(
@@ -472,6 +476,34 @@ class SetGlobalField(MeshTransform):
             cells=mesh.cells,
             point_data=mesh.point_data,
             cell_data=mesh.cell_data,
+            global_data=new_gd,
+        )
+
+    def apply_to_domain(self, domain: DomainMesh) -> DomainMesh:
+        """Inject the fields into a :class:`DomainMesh`.
+
+        Writes the fields to the domain-level ``global_data`` in addition
+        to the base-class broadcast, which only reaches sub-mesh
+        ``global_data``.
+
+        Parameters
+        ----------
+        domain : DomainMesh
+            Input domain mesh (interior + boundaries).
+
+        Returns
+        -------
+        DomainMesh
+            Domain mesh with the fields set in the domain-level and every
+            sub-mesh ``global_data``.
+        """
+        domain = super().apply_to_domain(domain)
+        reference = domain.interior.points
+        new_gd = domain.global_data.clone()
+        new_gd.update(self._fields.to(device=reference.device, dtype=reference.dtype))
+        return DomainMesh(
+            interior=domain.interior,
+            boundaries=domain.boundaries,
             global_data=new_gd,
         )
 

--- a/test/datapipes/transforms/test_set_global_field.py
+++ b/test/datapipes/transforms/test_set_global_field.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the SetGlobalField transform's DomainMesh path."""
+
+import torch
+
+from physicsnemo.datapipes.transforms.mesh import SetGlobalField
+from physicsnemo.mesh import DomainMesh, Mesh
+from physicsnemo.mesh.primitives.basic import single_triangle_3d
+
+
+def _domain():
+    return DomainMesh(
+        interior=Mesh(points=torch.randn(12, 3)),
+        boundaries={"wall": single_triangle_3d.load()},
+        global_data={"U_inf": torch.tensor([3.0, 0.0, 4.0])},
+    )
+
+
+class TestSetGlobalFieldDomainLevel:
+    def test_domain_level_record_written(self):
+        transform = SetGlobalField(fields={"reference_length": [1.0]})
+        out = transform.apply_to_domain(_domain())
+        # The domain-level global_data carries the field...
+        assert "reference_length" in out.global_data.keys()
+        torch.testing.assert_close(
+            out.global_data["reference_length"],
+            torch.tensor([1.0]),
+        )
+        # ...and the sub-mesh broadcast is preserved.
+        assert "reference_length" in out.interior.global_data.keys()
+        assert "reference_length" in out.boundaries["wall"].global_data.keys()
+
+    def test_existing_domain_fields_preserved(self):
+        out = SetGlobalField(fields={"x": [2.0]}).apply_to_domain(_domain())
+        torch.testing.assert_close(
+            out.global_data["U_inf"], torch.tensor([3.0, 0.0, 4.0])
+        )
+
+    def test_plain_mesh_path_unchanged(self):
+        mesh = Mesh(points=torch.randn(5, 3))
+        out = SetGlobalField(fields={"x": [2.0]})(mesh)
+        torch.testing.assert_close(out.global_data["x"], torch.tensor([2.0]))

--- a/test/datapipes/transforms/test_set_global_field.py
+++ b/test/datapipes/transforms/test_set_global_field.py
@@ -39,13 +39,25 @@ class TestSetGlobalFieldDomainLevel:
         """The injected field lands in domain-level and sub-mesh global_data."""
         transform = SetGlobalField(fields={"reference_length": [1.0]})
         out = transform.apply_to_domain(_domain())
-        assert "reference_length" in out.global_data.keys()
-        torch.testing.assert_close(
-            out.global_data["reference_length"],
-            torch.tensor([1.0]),
-        )
-        assert "reference_length" in out.interior.global_data.keys()
-        assert "reference_length" in out.boundaries["wall"].global_data.keys()
+        expected = torch.tensor([1.0])
+        for global_data in (
+            out.global_data,
+            out.interior.global_data,
+            out.boundaries["wall"].global_data,
+        ):
+            torch.testing.assert_close(global_data["reference_length"], expected)
+
+    def test_input_domain_is_not_modified(self):
+        """Injection returns new metadata without mutating the input domain."""
+        domain = _domain()
+        original_u_inf = domain.global_data["U_inf"].clone()
+
+        SetGlobalField(fields={"reference_length": [1.0]}).apply_to_domain(domain)
+
+        assert "reference_length" not in domain.global_data.keys()
+        assert "reference_length" not in domain.interior.global_data.keys()
+        assert "reference_length" not in domain.boundaries["wall"].global_data.keys()
+        torch.testing.assert_close(domain.global_data["U_inf"], original_u_inf)
 
     def test_existing_domain_fields_preserved(self):
         """Fields already in domain-level global_data survive injection."""

--- a/test/datapipes/transforms/test_set_global_field.py
+++ b/test/datapipes/transforms/test_set_global_field.py
@@ -24,6 +24,7 @@ from physicsnemo.mesh.primitives.basic import single_triangle_3d
 
 
 def _domain():
+    """Build a small DomainMesh with one boundary and one global field."""
     return DomainMesh(
         interior=Mesh(points=torch.randn(12, 3)),
         boundaries={"wall": single_triangle_3d.load()},
@@ -32,26 +33,38 @@ def _domain():
 
 
 class TestSetGlobalFieldDomainLevel:
+    """SetGlobalField writes both domain-level and sub-mesh global_data."""
+
     def test_domain_level_record_written(self):
+        """The injected field lands in domain-level and sub-mesh global_data."""
         transform = SetGlobalField(fields={"reference_length": [1.0]})
         out = transform.apply_to_domain(_domain())
-        # The domain-level global_data carries the field...
         assert "reference_length" in out.global_data.keys()
         torch.testing.assert_close(
             out.global_data["reference_length"],
             torch.tensor([1.0]),
         )
-        # ...and the sub-mesh broadcast is preserved.
         assert "reference_length" in out.interior.global_data.keys()
         assert "reference_length" in out.boundaries["wall"].global_data.keys()
 
     def test_existing_domain_fields_preserved(self):
+        """Fields already in domain-level global_data survive injection."""
         out = SetGlobalField(fields={"x": [2.0]}).apply_to_domain(_domain())
         torch.testing.assert_close(
             out.global_data["U_inf"], torch.tensor([3.0, 0.0, 4.0])
         )
 
+    def test_existing_domain_field_overwritten(self):
+        """Injecting an existing key overwrites it, as documented."""
+        out = SetGlobalField(fields={"U_inf": [1.0, 0.0, 0.0]}).apply_to_domain(
+            _domain()
+        )
+        torch.testing.assert_close(
+            out.global_data["U_inf"], torch.tensor([1.0, 0.0, 0.0])
+        )
+
     def test_plain_mesh_path_unchanged(self):
+        """The single-Mesh path still injects into the mesh's global_data."""
         mesh = Mesh(points=torch.randn(5, 3))
         out = SetGlobalField(fields={"x": [2.0]})(mesh)
         torch.testing.assert_close(out.global_data["x"], torch.tensor([2.0]))


### PR DESCRIPTION
## What

`SetGlobalField.apply_to_domain` broadcast the injected fields to every sub-mesh's `global_data`, but never wrote them to the `DomainMesh`'s own domain-level `global_data`. Any code reading `DomainMesh.global_data` never saw the injected fields.

- The domain path now writes both records.
- Sub-mesh behavior is unchanged.
- Plain `Mesh` behavior is unchanged.

## Tests

New `test/datapipes/transforms/test_set_global_field.py`:

- domain-level `global_data` receives the field
- the sub-mesh broadcast still happens
- existing domain-level fields are preserved
- injecting an existing key overwrites it, matching the documented contract
- plain `Mesh` path unchanged

Full transforms suite passes; ruff check/format clean.

## Notes

- Found while integrating a DomainMesh-native model into the unified external-aero recipe, which currently carries a local workaround (`SetDomainGlobalField`) that this fix makes unnecessary.
- A companion transform (`ComputeUnitGlobalVector`) that was previously bundled in this PR is now split out into draft PR #1825, since it is new API rather than a bug fix.