### PR TITLE
fix: make ShardTensor construction opaque to dynamo to prevent graph …

### DIFF
--- a/physicsnemo/domain_parallel/shard_tensor.py
+++ b/physicsnemo/domain_parallel/shard_tensor.py
@@ -516,6 +516,7 @@ class _FromTorchTensor(torch.autograd.Function):
     """
 
     @staticmethod
+    @torch._dynamo.disable
     def forward(
         ctx: torch.autograd.function.FunctionCtx,
         local_input: torch.Tensor,
@@ -783,6 +784,7 @@ class ShardTensor(torch.Tensor):
         cls._named_function_registry[func_name] = handler
 
     @staticmethod
+    @torch._dynamo.disable
     def __new__(
         cls,
         local_tensor: torch.Tensor,


### PR DESCRIPTION
### Description (#1796)
Fixes `torch.compile` failures that occur when constructing a `ShardTensor` (e.g. via `from_local` and `redistribute`).

**The Bug:**
Dynamo was graph-breaking inside the `ShardTensor` construction path during spec inference (inside `_FromTorchTensor.forward`). When Dynamo attempted to synthesize a resume frame mid-construction (inside `ShardTensor.__new__`), it introspected a half-constructed wrapper subclass. This prematurely triggered `__tensor_flatten__`, which tried to access `self._spec` before it was assigned, causing an `AttributeError`. Additionally, when wrapped in nested helper functions, the graph break produced a resume frame that mis-resolved enclosing-scope names (yielding a `NameError`).

**The Fix:**
Added the `@torch._dynamo.disable` decorator to `_FromTorchTensor.forward` and `ShardTensor.__new__`. 
This explicitly marks the construction path as opaque, instructing Dynamo to graph-break *before* the function, execute the construction eagerly as a black box, and safely resume tracing *after* the `ShardTensor` is returned.

This eliminates the `AttributeError` and nested scope mis-resolutions, closing the eager-mode gap for `ShardTensor` resharding and enabling the removal of manual `@torch._dynamo.disable` wrappers from reshard call sites (like in the HealDA architecture).
