### PR TITLE
Fix AeroJEPA manual grad all-reduce: skip unreached params + guard fp16 multi-GPU

### DIFF
--- a/examples/cfd/external_aerodynamics/aerojepa/train.py
+++ b/examples/cfd/external_aerodynamics/aerojepa/train.py
@@ -505,9 +505,7 @@ def _all_reduce_grads(model: torch.nn.Module, world_size: int) -> None:
     # multi-GPU runs only — a single-vs-multi-GPU divergence. Skipping them
     # keeps the optimizer's per-parameter behavior identical to single-GPU.
     grads = [
-        p.grad
-        for p in model.parameters()
-        if p.requires_grad and p.grad is not None
+        p.grad for p in model.parameters() if p.requires_grad and p.grad is not None
     ]
     if not grads:
         return

--- a/examples/cfd/external_aerodynamics/aerojepa/train.py
+++ b/examples/cfd/external_aerodynamics/aerojepa/train.py
@@ -493,15 +493,22 @@ def _all_reduce_grads(model: torch.nn.Module, world_size: int) -> None:
     ``optimizer.step()``. Every rank starts from identical weights and applies
     identical averaged gradients, so the models stay in lockstep.
     """
-    grads = []
-    for p in model.parameters():
-        if not p.requires_grad:
-            continue
-        if p.grad is None:
-            # Materialize a zero grad so the collective stays balanced across
-            # ranks (the frozen/trainable split is deterministic per phase).
-            p.grad = torch.zeros_like(p)
-        grads.append(p.grad)
+    # SAFETY: reduce only parameters that actually received a gradient, and do
+    # NOT materialize zero grads for the ones that didn't. Every rank runs the
+    # identical forward/backward graph on the same trainable parameter set, so
+    # the reached (grad-is-not-None) set is identical across ranks and the
+    # coalesced buffers line up element-for-element. Materializing zeros for
+    # unreached params (the previous approach) is not only unnecessary for the
+    # collective but actively harmful: AdamW's decoupled weight decay applies
+    # ``p *= 1 - lr*wd`` to every parameter whose ``.grad`` is not None, so a
+    # forced zero grad silently decays otherwise-untouched parameters on
+    # multi-GPU runs only — a single-vs-multi-GPU divergence. Skipping them
+    # keeps the optimizer's per-parameter behavior identical to single-GPU.
+    grads = [
+        p.grad
+        for p in model.parameters()
+        if p.requires_grad and p.grad is not None
+    ]
     if not grads:
         return
     # Coalesce every gradient into one contiguous buffer and all-reduce ONCE,
@@ -834,6 +841,16 @@ def main(cfg: DictConfig) -> None:
     dm = DistributedManager()
     world_size = dm.world_size
     is_main = dm.rank == 0
+
+    # fp16 + multi-GPU is unsupported: the manual gradient all-reduce averages
+    # unscaled grads directly, with no cross-rank GradScaler coordination, so a
+    # per-rank scaler could diverge (one rank skipping a step on inf/nan while
+    # others step). bf16 needs no scaler and is the supported multi-GPU path.
+    if world_size > 1 and str(cfg.training.precision).lower() == "fp16":
+        raise ValueError(
+            "fp16 + multi-GPU (world_size>1) is unsupported by the manual "
+            "gradient all-reduce; use precision=bf16."
+        )
 
     # Same seed on every rank -> identical model initialization, which manual
     # gradient averaging then keeps in lockstep. (Dataset subsampling uses its


### PR DESCRIPTION
Stop zero-materializing None grads in _all_reduce_grads; that made AdamW's decoupled weight decay silently decay unreached params on multi-GPU only, diverging from single-GPU. Reduce only grad-is-not-None params (identical reached set across ranks). Also reject fp16 + world_size>1, which the manual all-reduce cannot coordinate a GradScaler across.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
