### PR TITLE
Add non-periodic grid gradient boundary mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds an opt-in ``boundary="one_sided"`` mode to
+  ``rectilinear_grid_gradient`` and ``uniform_grid_gradient``. The default
+  periodic behavior is unchanged, while bounded domains can use one-sided
+  boundary stencils with Torch/Warp forward and autograd parity.
 - Adds dimension-generic volume mesh generation for implicit domains to
   `physicsnemo.mesh.generate`. `mesh_implicit_domain` meshes
   `{x : phi(x) < 0}`, clipped to the bounding box (box faces are honored

--- a/physicsnemo/nn/functional/derivatives/_boundary.py
+++ b/physicsnemo/nn/functional/derivatives/_boundary.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+
+BoundaryMode = Literal["periodic", "one_sided"]
+
+
+def normalize_boundary(boundary: str, *, function_name: str) -> BoundaryMode:
+    """Validate and normalize a grid-gradient boundary mode."""
+    if not isinstance(boundary, str):
+        raise TypeError(f"{function_name} boundary must be a string")
+    if boundary not in ("periodic", "one_sided"):
+        raise ValueError(
+            f'{function_name} boundary must be "periodic" or "one_sided", '
+            f"got {boundary!r}"
+        )
+    return boundary
+
+
+def _finite_difference_weights(
+    nodes: torch.Tensor,
+    evaluation_point: torch.Tensor,
+    derivative_order: int,
+) -> torch.Tensor:
+    """Return finite-difference weights for arbitrary one-dimensional nodes."""
+    offsets = nodes - evaluation_point
+    powers = torch.arange(nodes.numel(), device=nodes.device, dtype=nodes.dtype)
+    factorials = torch.exp(torch.lgamma(powers + 1.0))
+    system = offsets.unsqueeze(0).pow(powers.unsqueeze(1)) / factorials.unsqueeze(1)
+    rhs = torch.zeros_like(nodes)
+    rhs[derivative_order] = 1.0
+    return torch.linalg.solve(system, rhs)
+
+
+def _weighted_boundary_value(
+    field: torch.Tensor,
+    *,
+    axis: int,
+    indices: torch.Tensor,
+    weights: torch.Tensor,
+) -> torch.Tensor:
+    """Evaluate a one-sided stencil and retain the differentiated axis."""
+    values = torch.index_select(field, dim=axis, index=indices)
+    view_shape = [1] * field.ndim
+    view_shape[axis] = weights.numel()
+    return (values * weights.view(view_shape)).sum(dim=axis, keepdim=True)
+
+
+def apply_one_sided_boundaries(
+    output: torch.Tensor,
+    *,
+    field: torch.Tensor,
+    coordinates: tuple[torch.Tensor, ...],
+    derivative_order: int,
+    stencil_size: int,
+    boundary_width: int = 1,
+    function_name: str,
+) -> torch.Tensor:
+    """Replace periodic boundary rows with arbitrary-grid one-sided stencils."""
+    corrected: list[torch.Tensor] = []
+    for axis, coordinates_axis in enumerate(coordinates):
+        axis_size = field.shape[axis]
+        if axis_size < stencil_size:
+            raise ValueError(
+                f"{function_name} boundary='one_sided' requires at least "
+                f"{stencil_size} points along axis {axis}, got {axis_size}"
+            )
+
+        weight_dtype = torch.float64 if field.dtype == torch.float64 else torch.float32
+        nodes = coordinates_axis.to(device=field.device, dtype=weight_dtype)
+        left_indices = torch.arange(stencil_size, device=field.device)
+        right_indices = torch.arange(
+            axis_size - stencil_size, axis_size, device=field.device
+        )
+        left_nodes = torch.index_select(nodes, 0, left_indices)
+        right_nodes = torch.index_select(nodes, 0, right_indices)
+        left_values = []
+        right_values = []
+        for offset in range(boundary_width):
+            left_weights = _finite_difference_weights(
+                left_nodes, nodes[offset], derivative_order
+            ).to(dtype=field.dtype)
+            right_weights = _finite_difference_weights(
+                right_nodes,
+                nodes[axis_size - boundary_width + offset],
+                derivative_order,
+            ).to(dtype=field.dtype)
+            left_values.append(
+                _weighted_boundary_value(
+                    field,
+                    axis=axis,
+                    indices=left_indices,
+                    weights=left_weights,
+                )
+            )
+            right_values.append(
+                _weighted_boundary_value(
+                    field,
+                    axis=axis,
+                    indices=right_indices,
+                    weights=right_weights,
+                )
+            )
+
+        left = torch.cat(left_values, dim=axis)
+        right = torch.cat(right_values, dim=axis)
+        interior_slices = [slice(None)] * field.ndim
+        interior_slices[axis] = slice(boundary_width, -boundary_width)
+        interior = output[axis][tuple(interior_slices)]
+        corrected.append(torch.cat((left, interior, right), dim=axis))
+
+    return torch.stack(corrected, dim=0)
+
+
+def uniform_coordinates(
+    field: torch.Tensor, spacing: tuple[float, ...]
+) -> tuple[torch.Tensor, ...]:
+    """Build per-axis coordinates for uniform-grid boundary stencils."""
+    dtype = torch.float64 if field.dtype == torch.float64 else torch.float32
+    return tuple(
+        torch.arange(size, device=field.device, dtype=dtype) * dx
+        for size, dx in zip(field.shape, spacing, strict=True)
+    )
+
+
+__all__ = [
+    "BoundaryMode",
+    "apply_one_sided_boundaries",
+    "normalize_boundary",
+    "uniform_coordinates",
+]

--- a/physicsnemo/nn/functional/derivatives/rectilinear_grid_gradient/_torch_impl.py
+++ b/physicsnemo/nn/functional/derivatives/rectilinear_grid_gradient/_torch_impl.py
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 
 import torch
 
+from .._boundary import apply_one_sided_boundaries, normalize_boundary
 from .._request_utils import (
     compose_derivative_outputs,
     normalize_derivative_orders,
@@ -41,14 +42,16 @@ def rectilinear_grid_gradient_torch(
     periods: float | Sequence[float] | None = None,
     derivative_order: int = 1,
     include_mixed: bool = False,
+    boundary: str = "periodic",
 ) -> torch.Tensor:
-    """Compute periodic first or pure second derivatives on rectilinear grids."""
+    """Compute first or pure second derivatives on rectilinear grids."""
     ### Validate field and coordinate inputs.
     validate_field(field)
     derivative_order = validate_derivative_request(
         derivative_order=derivative_order,
         include_mixed=include_mixed,
     )
+    boundary = normalize_boundary(boundary, function_name="rectilinear_grid_gradient")
 
     coords_tuple, period_tuple = validate_and_normalize_coordinates(
         field=field,
@@ -86,7 +89,17 @@ def rectilinear_grid_gradient_torch(
         gradients.append(grad_axis)
 
     ### Stack per-axis derivative terms into (dims, *field.shape).
-    return torch.stack(gradients, dim=0)
+    output = torch.stack(gradients, dim=0)
+    if boundary == "one_sided":
+        output = apply_one_sided_boundaries(
+            output,
+            field=field,
+            coordinates=coords_tuple,
+            derivative_order=derivative_order,
+            stencil_size=2 + derivative_order,
+            function_name="rectilinear_grid_gradient",
+        )
+    return output
 
 
 def rectilinear_grid_gradient_torch_multi(
@@ -95,6 +108,7 @@ def rectilinear_grid_gradient_torch_multi(
     periods: float | Sequence[float] | None = None,
     derivative_orders: int | Sequence[int] = 1,
     include_mixed: bool = False,
+    boundary: str = "periodic",
 ) -> torch.Tensor:
     """Compute first/second/mixed derivatives from a unified request."""
     requested_orders = normalize_derivative_orders(
@@ -123,6 +137,7 @@ def rectilinear_grid_gradient_torch_multi(
                 periods=periods,
                 derivative_order=derivative_order,
                 include_mixed=False,
+                boundary=boundary,
             )
         ),
     )

--- a/physicsnemo/nn/functional/derivatives/rectilinear_grid_gradient/_warp_impl/op.py
+++ b/physicsnemo/nn/functional/derivatives/rectilinear_grid_gradient/_warp_impl/op.py
@@ -23,6 +23,7 @@ import warp as wp
 
 from physicsnemo.core.function_spec import FunctionSpec
 
+from ..._boundary import apply_one_sided_boundaries, normalize_boundary
 from ..._request_utils import (
     compose_derivative_outputs,
     normalize_derivative_orders,
@@ -704,8 +705,9 @@ def rectilinear_grid_gradient_warp(
     periods: float | Sequence[float] | None = None,
     derivative_order: int = 1,
     include_mixed: bool = False,
+    boundary: str = "periodic",
 ) -> torch.Tensor:
-    """Compute periodic first or pure second derivatives on rectilinear grids.
+    """Compute first or pure second derivatives on rectilinear grids.
 
     Notes
     -----
@@ -718,6 +720,7 @@ def rectilinear_grid_gradient_warp(
         derivative_order=derivative_order,
         include_mixed=include_mixed,
     )
+    boundary = normalize_boundary(boundary, function_name="rectilinear_grid_gradient")
 
     coords_tuple, period_tuple = validate_and_normalize_coordinates(
         field=field,
@@ -728,15 +731,15 @@ def rectilinear_grid_gradient_warp(
     )
 
     if field.ndim == 1:
-        return rectilinear_grid_gradient_1d_impl(
+        output = rectilinear_grid_gradient_1d_impl(
             field,
             coords_tuple[0],
             float(period_tuple[0]),
             int(derivative_order),
             bool(include_mixed),
         )
-    if field.ndim == 2:
-        return rectilinear_grid_gradient_2d_impl(
+    elif field.ndim == 2:
+        output = rectilinear_grid_gradient_2d_impl(
             field,
             coords_tuple[0],
             coords_tuple[1],
@@ -745,17 +748,29 @@ def rectilinear_grid_gradient_warp(
             int(derivative_order),
             bool(include_mixed),
         )
-    return rectilinear_grid_gradient_3d_impl(
-        field,
-        coords_tuple[0],
-        coords_tuple[1],
-        coords_tuple[2],
-        float(period_tuple[0]),
-        float(period_tuple[1]),
-        float(period_tuple[2]),
-        int(derivative_order),
-        bool(include_mixed),
-    )
+    else:
+        output = rectilinear_grid_gradient_3d_impl(
+            field,
+            coords_tuple[0],
+            coords_tuple[1],
+            coords_tuple[2],
+            float(period_tuple[0]),
+            float(period_tuple[1]),
+            float(period_tuple[2]),
+            int(derivative_order),
+            bool(include_mixed),
+        )
+
+    if boundary == "one_sided":
+        output = apply_one_sided_boundaries(
+            output,
+            field=field,
+            coordinates=coords_tuple,
+            derivative_order=derivative_order,
+            stencil_size=2 + derivative_order,
+            function_name="rectilinear_grid_gradient",
+        )
+    return output
 
 
 def rectilinear_grid_gradient_warp_multi(
@@ -764,6 +779,7 @@ def rectilinear_grid_gradient_warp_multi(
     periods: float | Sequence[float] | None = None,
     derivative_orders: int | Sequence[int] = 1,
     include_mixed: bool = False,
+    boundary: str = "periodic",
 ) -> torch.Tensor:
     """Compute multiple derivative families, fusing first+second when possible.
 
@@ -773,6 +789,7 @@ def rectilinear_grid_gradient_warp_multi(
     ordering and autograd behavior.
     """
     validate_field(field)
+    boundary = normalize_boundary(boundary, function_name="rectilinear_grid_gradient")
     coords_tuple, period_tuple = validate_and_normalize_coordinates(
         field=field,
         coordinates=coordinates,
@@ -796,7 +813,7 @@ def rectilinear_grid_gradient_warp_multi(
     )
 
     ### Fused no-mixed path with custom-op backward for combined first+second.
-    if not mixed_terms and requested_orders == (1, 2):
+    if boundary == "periodic" and not mixed_terms and requested_orders == (1, 2):
         if field.ndim == 1:
             fused = rectilinear_derivatives_1d_fused_no_mixed_impl(
                 field,
@@ -842,6 +859,7 @@ def rectilinear_grid_gradient_warp_multi(
                 periods=period_tuple,
                 derivative_order=derivative_order,
                 include_mixed=False,
+                boundary=boundary,
             )
         ),
     )

--- a/physicsnemo/nn/functional/derivatives/rectilinear_grid_gradient/rectilinear_grid_gradient.py
+++ b/physicsnemo/nn/functional/derivatives/rectilinear_grid_gradient/rectilinear_grid_gradient.py
@@ -29,7 +29,7 @@ from ._warp_impl import (
 
 
 class RectilinearGridGradient(FunctionSpec):
-    r"""Compute periodic gradients on rectilinear grids with nonuniform spacing.
+    r"""Compute gradients on rectilinear grids with nonuniform spacing.
 
     This functional computes first-order and/or second-order
     derivatives of a scalar field on a 1D/2D/3D rectilinear grid where each
@@ -86,6 +86,10 @@ class RectilinearGridGradient(FunctionSpec):
         Include mixed second derivatives when requesting second derivatives.
         Mixed terms are appended in axis-pair order ``(x,y)``, ``(x,z)``,
         ``(y,z)``.
+    boundary : {"periodic", "one_sided"}, optional
+        Boundary treatment. ``"periodic"`` preserves wrap-around behavior.
+        ``"one_sided"`` uses one-sided stencils at the first and last point
+        of each axis while retaining central differences in the interior.
     implementation : {"warp", "torch"} or None
         Explicit backend selection. When ``None``, dispatch selects by rank.
 
@@ -117,6 +121,7 @@ class RectilinearGridGradient(FunctionSpec):
         periods: float | Sequence[float] | None = None,
         derivative_orders: int | Sequence[int] = 1,
         include_mixed: bool = False,
+        boundary: str = "periodic",
     ) -> torch.Tensor:
         """Dispatch rectilinear gradients to the Warp backend."""
         return rectilinear_grid_gradient_warp_multi(
@@ -125,6 +130,7 @@ class RectilinearGridGradient(FunctionSpec):
             periods=periods,
             derivative_orders=derivative_orders,
             include_mixed=include_mixed,
+            boundary=boundary,
         )
 
     @FunctionSpec.register(name="torch", rank=1, baseline=True)
@@ -134,6 +140,7 @@ class RectilinearGridGradient(FunctionSpec):
         periods: float | Sequence[float] | None = None,
         derivative_orders: int | Sequence[int] = 1,
         include_mixed: bool = False,
+        boundary: str = "periodic",
     ) -> torch.Tensor:
         """Dispatch rectilinear gradients to eager PyTorch."""
         return rectilinear_grid_gradient_torch_multi(
@@ -142,6 +149,7 @@ class RectilinearGridGradient(FunctionSpec):
             periods=periods,
             derivative_orders=derivative_orders,
             include_mixed=include_mixed,
+            boundary=boundary,
         )
 
     @classmethod

--- a/physicsnemo/nn/functional/derivatives/uniform_grid_gradient/_torch_impl.py
+++ b/physicsnemo/nn/functional/derivatives/uniform_grid_gradient/_torch_impl.py
@@ -20,6 +20,11 @@ from collections.abc import Sequence
 
 import torch
 
+from .._boundary import (
+    apply_one_sided_boundaries,
+    normalize_boundary,
+    uniform_coordinates,
+)
 from .._request_utils import (
     compose_derivative_outputs,
     normalize_derivative_orders,
@@ -148,8 +153,9 @@ def uniform_grid_gradient_torch(
     order: int = 2,
     derivative_order: int = 1,
     include_mixed: bool = False,
+    boundary: str = "periodic",
 ) -> torch.Tensor:
-    """Compute periodic first or pure second derivatives on a uniform grid."""
+    """Compute first or pure second derivatives on a uniform grid."""
     ### Validate field shape and dtype.
     if field.ndim < 1 or field.ndim > 3:
         raise ValueError(
@@ -159,6 +165,7 @@ def uniform_grid_gradient_torch(
         raise TypeError("field must be a floating-point tensor")
     order = _validate_order(order)
     derivative_order = _validate_derivative_order(derivative_order)
+    boundary = normalize_boundary(boundary, function_name="uniform_grid_gradient")
     _validate_include_mixed(
         derivative_order=derivative_order,
         include_mixed=include_mixed,
@@ -178,7 +185,18 @@ def uniform_grid_gradient_torch(
         gradients.append(grad_axis)
 
     ### Stack per-axis derivative terms into (dims, *field.shape).
-    return torch.stack(gradients, dim=0)
+    output = torch.stack(gradients, dim=0)
+    if boundary == "one_sided":
+        output = apply_one_sided_boundaries(
+            output,
+            field=field,
+            coordinates=uniform_coordinates(field, spacing_tuple),
+            derivative_order=derivative_order,
+            stencil_size=order + derivative_order,
+            boundary_width=order // 2,
+            function_name="uniform_grid_gradient",
+        )
+    return output
 
 
 def uniform_grid_gradient_torch_multi(
@@ -187,6 +205,7 @@ def uniform_grid_gradient_torch_multi(
     order: int = 2,
     derivative_orders: int | Sequence[int] = 1,
     include_mixed: bool = False,
+    boundary: str = "periodic",
 ) -> torch.Tensor:
     """Compute first/second/mixed derivatives from a unified request."""
     requested_orders = normalize_derivative_orders(
@@ -215,6 +234,7 @@ def uniform_grid_gradient_torch_multi(
                 order=order,
                 derivative_order=derivative_order,
                 include_mixed=False,
+                boundary=boundary,
             )
         ),
     )

--- a/physicsnemo/nn/functional/derivatives/uniform_grid_gradient/_warp_impl/op.py
+++ b/physicsnemo/nn/functional/derivatives/uniform_grid_gradient/_warp_impl/op.py
@@ -22,6 +22,11 @@ import torch
 
 from physicsnemo.core.function_spec import FunctionSpec
 
+from ..._boundary import (
+    apply_one_sided_boundaries,
+    normalize_boundary,
+    uniform_coordinates,
+)
 from ..._request_utils import (
     compose_derivative_outputs,
     normalize_derivative_orders,
@@ -311,8 +316,9 @@ def uniform_grid_gradient_warp(
     order: int = 2,
     derivative_order: int = 1,
     include_mixed: bool = False,
+    boundary: str = "periodic",
 ) -> torch.Tensor:
-    """Compute periodic first or pure second derivatives on a uniform grid.
+    """Compute first or pure second derivatives on a uniform grid.
 
     Notes
     -----
@@ -324,18 +330,30 @@ def uniform_grid_gradient_warp(
     _validate_positive_spacing(spacing_tuple)
     order = _validate_order(order)
     derivative_order = _validate_derivative_order(derivative_order)
+    boundary = normalize_boundary(boundary, function_name="uniform_grid_gradient")
     _validate_include_mixed(
         derivative_order=derivative_order,
         include_mixed=include_mixed,
     )
     spacing_meta = torch.tensor(spacing_tuple, dtype=torch.float32, device="cpu")
-    return uniform_grid_gradient_impl(
+    output = uniform_grid_gradient_impl(
         field,
         spacing_meta,
         int(order),
         int(derivative_order),
         bool(include_mixed),
     )
+    if boundary == "one_sided":
+        output = apply_one_sided_boundaries(
+            output,
+            field=field,
+            coordinates=uniform_coordinates(field, spacing_tuple),
+            derivative_order=derivative_order,
+            stencil_size=order + derivative_order,
+            boundary_width=order // 2,
+            function_name="uniform_grid_gradient",
+        )
+    return output
 
 
 def uniform_grid_gradient_warp_multi(
@@ -344,6 +362,7 @@ def uniform_grid_gradient_warp_multi(
     order: int,
     derivative_orders: int | Sequence[int] = 1,
     include_mixed: bool = False,
+    boundary: str = "periodic",
 ) -> torch.Tensor:
     """Compute multiple derivative families, fusing Warp launches when possible.
 
@@ -352,6 +371,7 @@ def uniform_grid_gradient_warp_multi(
     derivatives. ``order=4`` requests continue to compose single-order Warp calls.
     """
     _validate_field(field)
+    boundary = normalize_boundary(boundary, function_name="uniform_grid_gradient")
     spacing_tuple = _normalize_spacing(spacing, field.ndim)
     _validate_positive_spacing(spacing_tuple)
     order = _validate_order(order)
@@ -373,7 +393,11 @@ def uniform_grid_gradient_warp_multi(
     spacing_meta = torch.tensor(spacing_tuple, dtype=torch.float32, device="cpu")
 
     ### Use fused order-2 path whenever multiple derivative families are requested.
-    if order == 2 and (len(requested_orders) > 1 or mixed_terms):
+    if (
+        boundary == "periodic"
+        and order == 2
+        and (len(requested_orders) > 1 or mixed_terms)
+    ):
         fused = uniform_grid_derivatives_order2_fused_impl(
             field, spacing_meta, mixed_terms
         )
@@ -400,6 +424,7 @@ def uniform_grid_gradient_warp_multi(
                 order=order,
                 derivative_order=derivative_order,
                 include_mixed=False,
+                boundary=boundary,
             )
         ),
     )

--- a/physicsnemo/nn/functional/derivatives/uniform_grid_gradient/uniform_grid_gradient.py
+++ b/physicsnemo/nn/functional/derivatives/uniform_grid_gradient/uniform_grid_gradient.py
@@ -27,7 +27,7 @@ from ._warp_impl import uniform_grid_gradient_warp_multi
 
 
 class UniformGridGradient(FunctionSpec):
-    r"""Compute periodic central-difference gradients on a uniform grid.
+    r"""Compute finite-difference gradients on a uniform grid.
 
     This functional computes first-order and/or second-order
     derivatives of a scalar field defined on a 1D/2D/3D uniform Cartesian
@@ -66,6 +66,11 @@ class UniformGridGradient(FunctionSpec):
         Include mixed second derivatives when requesting second derivatives.
         Mixed terms are appended in axis-pair order ``(x,y)``, ``(x,z)``,
         ``(y,z)``.
+    boundary : {"periodic", "one_sided"}, optional
+        Boundary treatment. ``"periodic"`` preserves wrap-around behavior.
+        ``"one_sided"`` uses one-sided stencils matching ``order`` across the
+        boundary region of each axis while retaining central differences in
+        the interior.
     implementation : {"warp", "torch"} or None
         Explicit backend selection. When ``None``, rank-based backend dispatch
         is used.
@@ -98,6 +103,7 @@ class UniformGridGradient(FunctionSpec):
         order: int = 2,
         derivative_orders: int | Sequence[int] = 1,
         include_mixed: bool = False,
+        boundary: str = "periodic",
     ) -> torch.Tensor:
         """Dispatch uniform-grid gradients to the Warp backend."""
         return uniform_grid_gradient_warp_multi(
@@ -106,6 +112,7 @@ class UniformGridGradient(FunctionSpec):
             order=order,
             derivative_orders=derivative_orders,
             include_mixed=include_mixed,
+            boundary=boundary,
         )
 
     @FunctionSpec.register(name="torch", rank=2, baseline=True)
@@ -115,6 +122,7 @@ class UniformGridGradient(FunctionSpec):
         order: int = 2,
         derivative_orders: int | Sequence[int] = 1,
         include_mixed: bool = False,
+        boundary: str = "periodic",
     ) -> torch.Tensor:
         """Dispatch uniform-grid gradients to eager PyTorch."""
         return uniform_grid_gradient_torch_multi(
@@ -123,6 +131,7 @@ class UniformGridGradient(FunctionSpec):
             order=order,
             derivative_orders=derivative_orders,
             include_mixed=include_mixed,
+            boundary=boundary,
         )
 
     @classmethod

--- a/test/nn/functional/derivatives/test_rectilinear_grid_gradient.py
+++ b/test/nn/functional/derivatives/test_rectilinear_grid_gradient.py
@@ -17,7 +17,7 @@
 import pytest
 import torch
 
-from physicsnemo.nn.functional import rectilinear_grid_gradient
+from physicsnemo.nn.functional import rectilinear_grid_gradient, uniform_grid_gradient
 from physicsnemo.nn.functional.derivatives import RectilinearGridGradient
 from test.conftest import requires_module
 from test.nn.functional._parity_utils import clone_case
@@ -106,6 +106,75 @@ def test_rectilinear_grid_gradient_torch(device: str, dims: int, derivative_orde
     )
     atol, rtol = (6e-1, 1e-1) if derivative_order == 2 and dims == 1 else (3e-2, 3e-2)
     torch.testing.assert_close(output, expected, atol=atol, rtol=rtol)
+
+
+# Validate one-sided boundaries on nonuniform coordinates and uniform-grid parity.
+@pytest.mark.parametrize("derivative_order", [1, 2])
+def test_rectilinear_grid_gradient_one_sided_analytic(
+    device: str, derivative_order: int
+):
+    x = torch.tensor(
+        [-1.0, -0.82, -0.55, -0.1, 0.35, 0.7, 1.0],
+        device=device,
+        dtype=torch.float32,
+    )
+    field = x.square()
+    expected = 2.0 * x if derivative_order == 1 else torch.full_like(x, 2.0)
+    output = RectilinearGridGradient.dispatch(
+        field,
+        (x,),
+        derivative_orders=derivative_order,
+        boundary="one_sided",
+        implementation="torch",
+    )
+    torch.testing.assert_close(output[0], expected, atol=2e-5, rtol=2e-5)
+
+    uniform_x = torch.linspace(-1.0, 1.0, 9, device=device)
+    uniform_field = uniform_x.square()
+    rect_output = rectilinear_grid_gradient(
+        uniform_field,
+        (uniform_x,),
+        derivative_orders=derivative_order,
+        boundary="one_sided",
+        implementation="torch",
+    )
+    uniform_output = uniform_grid_gradient(
+        uniform_field,
+        spacing=float(uniform_x[1] - uniform_x[0]),
+        derivative_orders=derivative_order,
+        boundary="one_sided",
+        implementation="torch",
+    )
+    torch.testing.assert_close(rect_output, uniform_output, atol=2e-5, rtol=2e-5)
+
+
+# Validate one-sided Warp forward and backward paths against torch.
+@requires_module("warp")
+def test_rectilinear_grid_gradient_one_sided_backend_parity(device: str):
+    x = torch.tensor(
+        [0.0, 0.12, 0.31, 0.57, 0.76, 1.0], device=device, dtype=torch.float32
+    )
+    y = torch.tensor([-0.5, -0.2, 0.15, 0.6, 1.1], device=device, dtype=torch.float32)
+    field_torch = torch.randn(6, 5, device=device, requires_grad=True)
+    field_warp = field_torch.detach().clone().requires_grad_(True)
+    kwargs = {
+        "coordinates": (x, y),
+        "derivative_orders": (1, 2),
+        "boundary": "one_sided",
+    }
+
+    out_torch = RectilinearGridGradient.dispatch(
+        field_torch, implementation="torch", **kwargs
+    )
+    out_warp = RectilinearGridGradient.dispatch(
+        field_warp, implementation="warp", **kwargs
+    )
+    torch.testing.assert_close(out_warp, out_torch, atol=1e-4, rtol=1e-4)
+
+    grad_seed = torch.randn_like(out_torch)
+    grad_torch = torch.autograd.grad(out_torch, field_torch, grad_seed)[0]
+    grad_warp = torch.autograd.grad(out_warp, field_warp, grad_seed)[0]
+    torch.testing.assert_close(grad_warp, grad_torch, atol=1e-4, rtol=1e-4)
 
 
 # Validate unified derivative-order requests concatenate outputs deterministically.
@@ -398,6 +467,15 @@ def test_rectilinear_grid_gradient_error_handling(device: str):
 
     output = rectilinear_grid_gradient(field, (x.to(torch.float32),), periods=1.0)
     assert output.shape == (1, 16)
+
+    with pytest.raises(ValueError, match="boundary must be"):
+        RectilinearGridGradient.dispatch(
+            field,
+            (x.to(torch.float32),),
+            periods=1.0,
+            boundary="reflect",
+            implementation="torch",
+        )
 
     with pytest.raises(ValueError, match="supports 1D-3D fields"):
         RectilinearGridGradient.dispatch(

--- a/test/nn/functional/derivatives/test_uniform_grid_gradient.py
+++ b/test/nn/functional/derivatives/test_uniform_grid_gradient.py
@@ -97,6 +97,52 @@ def test_uniform_grid_gradient_torch(
     torch.testing.assert_close(output, expected, atol=5e-2, rtol=5e-2)
 
 
+# Validate one-sided boundaries against an analytic polynomial.
+@pytest.mark.parametrize("order", [2, 4])
+@pytest.mark.parametrize("derivative_order", [1, 2])
+def test_uniform_grid_gradient_one_sided_analytic(
+    device: str, order: int, derivative_order: int
+):
+    x = torch.linspace(-1.0, 1.0, 17, device=device, dtype=torch.float32)
+    field = x.square()
+    expected = 2.0 * x if derivative_order == 1 else torch.full_like(x, 2.0)
+
+    output = UniformGridGradient.dispatch(
+        field,
+        spacing=float(x[1] - x[0]),
+        order=order,
+        derivative_orders=derivative_order,
+        boundary="one_sided",
+        implementation="torch",
+    )
+
+    torch.testing.assert_close(output[0], expected, atol=2e-4, rtol=2e-4)
+
+
+# Validate one-sided Warp forward and backward paths against torch.
+@requires_module("warp")
+def test_uniform_grid_gradient_one_sided_backend_parity(device: str):
+    field_torch = torch.randn(9, 8, device=device, requires_grad=True)
+    field_warp = field_torch.detach().clone().requires_grad_(True)
+    kwargs = {
+        "spacing": (0.2, 0.3),
+        "order": 2,
+        "derivative_orders": (1, 2),
+        "boundary": "one_sided",
+    }
+
+    out_torch = UniformGridGradient.dispatch(
+        field_torch, implementation="torch", **kwargs
+    )
+    out_warp = UniformGridGradient.dispatch(field_warp, implementation="warp", **kwargs)
+    torch.testing.assert_close(out_warp, out_torch, atol=1e-5, rtol=1e-5)
+
+    grad_seed = torch.randn_like(out_torch)
+    grad_torch = torch.autograd.grad(out_torch, field_torch, grad_seed)[0]
+    grad_warp = torch.autograd.grad(out_warp, field_warp, grad_seed)[0]
+    torch.testing.assert_close(grad_warp, grad_torch, atol=1e-5, rtol=1e-5)
+
+
 # Validate unified derivative-order requests concatenate outputs deterministically.
 @pytest.mark.parametrize("dims", [1, 2, 3])
 def test_uniform_grid_gradient_torch_combined_orders(device: str, dims: int):
@@ -445,6 +491,22 @@ def test_uniform_grid_gradient_error_handling(device: str):
             torch.randn(8, 8, device=device, dtype=torch.float32),
             derivative_orders=2,
             include_mixed=1,  # type: ignore[arg-type]
+            implementation="torch",
+        )
+
+    with pytest.raises(ValueError, match="boundary must be"):
+        UniformGridGradient.dispatch(
+            field,
+            boundary="reflect",
+            implementation="torch",
+        )
+
+    with pytest.raises(ValueError, match="requires at least 6 points"):
+        UniformGridGradient.dispatch(
+            torch.randn(5, device=device),
+            order=4,
+            derivative_orders=2,
+            boundary="one_sided",
             implementation="torch",
         )
 


### PR DESCRIPTION
## What changed

- adds `boundary="one_sided"` to `rectilinear_grid_gradient` and `uniform_grid_gradient`
- preserves `boundary="periodic"` as the default with the existing periodic code path unchanged
- computes arbitrary-grid one-sided finite-difference weights for first and second derivatives
- applies corrections across the full stencil radius, including the two edge points required by fourth-order uniform stencils
- supports torch and Warp forward paths and autograd; Warp retains its existing kernels for interior points and composes differentiable boundary corrections
- documents the new API and updates the changelog

## Why

Periodic wrapping mixes values from opposite edges on bounded, non-periodic domains and corrupts boundary derivatives. Callers currently need to mask or replace those values themselves.

The explicit boundary mode is backward-compatible and leaves room for additional boundary treatments in the future.

## Validation

- `uv run --group dev python -m pytest -q test/nn/functional/derivatives`
  - 202 passed
- `uv run ruff check <changed Python files>`
- `uv run ruff format --check <changed Python files>`
- verified public generated signatures include `boundary: str = "periodic"`

Tests cover analytic boundary derivatives, uniform/rectilinear equivalence, torch/Warp forward parity, torch/Warp backward parity, fourth-order stencil radius handling, invalid modes, and insufficient axis lengths.

Closes #1852.
