### PR TITLE
Unified Aero Recipe: fix direction-blind aggregate vector metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,12 +276,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_mae`) were computed on per-point vector magnitudes, so direction errors
   were invisible — a prediction with the correct magnitude but wrong direction
   at every point scored 0. The bare-name aggregate is now computed over all
-  components jointly (whole-field relative norms, Frobenius for `l2`), and the
-  direction-blind magnitude comparison moved to an explicit
-  `<field>_mag_<metric>` key. Per-component metrics (`wss_x_l2`, ...) were
-  always direction-sensitive and are unchanged, and training/checkpoints are
-  unaffected (the training objective goes through `LossCalculator`, not this
-  metric path) — only reported aggregate vector metrics were misleading.
+  components jointly (whole-field relative norms, Frobenius for `l2`). The
+  broken magnitude-only aggregate is not retained under a separate key.
+  Per-component metrics (`wss_x_l2`, ...) were always direction-sensitive and
+  are unchanged, and training/checkpoints are unaffected (the training
+  objective goes through `LossCalculator`, not this metric path) — only
+  reported aggregate vector metrics were misleading.
 - Unified external aerodynamics recipe: model templates can now carry
   known-good training overrides (`train.yaml`'s `_self_` merges before the
   model template; all existing templates resolve identically). The GLOBE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unified external aerodynamics recipe: the aggregate metrics reported for
+  vector fields under the bare field name (e.g. `wss_l2`, likewise `_l1` /
+  `_mae`) were computed on per-point vector magnitudes, so direction errors
+  were invisible — a prediction with the correct magnitude but wrong direction
+  at every point scored 0. The bare-name aggregate is now computed over all
+  components jointly (whole-field relative norms, Frobenius for `l2`), and the
+  direction-blind magnitude comparison moved to an explicit
+  `<field>_mag_<metric>` key. Per-component metrics (`wss_x_l2`, ...) were
+  always direction-sensitive and are unchanged, and training/checkpoints are
+  unaffected (the training objective goes through `LossCalculator`, not this
+  metric path) — only reported aggregate vector metrics were misleading.
 - Unified external aerodynamics recipe: model templates can now carry
   known-good training overrides (`train.yaml`'s `_self_` merges before the
   model template; all existing templates resolve identically). The GLOBE

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/metrics.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/metrics.py
@@ -22,8 +22,9 @@ named target field declared in ``target_config`` produces:
 - For ``"scalar"`` types: per-metric values (``l1``, ``l2``, ``mae`` by
   default), keyed ``"<prefix>/<name>_<metric>"``.
 - For ``"vector"`` types: per-component values
-  (``"<prefix>/<name>_x_<metric>"`` etc.) plus aggregate magnitude values
-  (``"<prefix>/<name>_<metric>"``).
+  (``"<prefix>/<name>_x_<metric>"`` etc.), aggregate values over all
+  components jointly (``"<prefix>/<name>_<metric>"``), and
+  direction-blind magnitude values (``"<prefix>/<name>_mag_<metric>"``).
 
 Metrics are reported unweighted -- per-field weighting belongs in the
 loss, not in diagnostic summaries.
@@ -189,8 +190,9 @@ class MetricCalculator:
     def expected_keys(self) -> list[str]:
         """The exact key set :meth:`__call__` produces, derivable without data.
 
-        Vector fields contribute one key per spatial component plus the
-        aggregate-magnitude key; scalars contribute one key per metric.
+        Vector fields contribute keys per spatial component, the bare-name
+        aggregate keys, and the ``mag`` (magnitude-comparison) keys;
+        scalars contribute one key per metric.
         Lets callers pre-size accumulators identically on every rank --
         e.g. ``infer.py`` zero-fills its running sums with these keys so
         the cross-rank all-reduce packs the same tensor length even on a
@@ -207,6 +209,8 @@ class MetricCalculator:
                         self._make_key(name, comp, m) for m in self.metric_names
                     )
             keys.extend(self._make_key(name, m) for m in self.metric_names)
+            if field_type == "vector":
+                keys.extend(self._make_key(name, "mag", m) for m in self.metric_names)
         return keys
 
     def _metrics_for_tensor(
@@ -232,8 +236,10 @@ class MetricCalculator:
             0-D ``TensorDict`` (``batch_size=[]``) keyed by
             ``"<prefix>/<name>_<metric>"`` for scalar fields and by
             ``"<prefix>/<name>_<comp>_<metric>"`` plus
-            ``"<prefix>/<name>_<metric>"`` (aggregate magnitude) for
-            vector fields. Slash-containing keys are stored verbatim;
+            ``"<prefix>/<name>_<metric>"`` (aggregate over all components
+            jointly) and ``"<prefix>/<name>_mag_<metric>"``
+            (direction-blind magnitude comparison) for vector fields.
+            Slash-containing keys are stored verbatim;
             TensorDict only treats ``/`` as nested when the caller
             explicitly invokes ``flatten_keys("/")``.
         """
@@ -262,10 +268,20 @@ class MetricCalculator:
                         out.update(
                             self._metrics_for_tensor(p[..., i], t[..., i], (name, comp))
                         )
-                    ### Aggregate magnitude metric.
+                    ### Aggregate vector metric under the bare field name:
+                    ### all components jointly, flattened so the relative
+                    ### norms reduce over the whole field (Frobenius for
+                    ### l2) and direction errors count.
+                    out.update(
+                        self._metrics_for_tensor(p.flatten(-2), t.flatten(-2), (name,))
+                    )
+                    ### Magnitude comparison under an explicit "mag" key.
+                    ### Direction-blind by construction -- a prediction with
+                    ### correct magnitude but arbitrary direction scores 0
+                    ### here -- so it must never be the headline aggregate.
                     p_mag = torch.linalg.vector_norm(p, dim=-1)
                     t_mag = torch.linalg.vector_norm(t, dim=-1)
-                    out.update(self._metrics_for_tensor(p_mag, t_mag, (name,)))
+                    out.update(self._metrics_for_tensor(p_mag, t_mag, (name, "mag")))
 
         return TensorDict(out)
 

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/metrics.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/metrics.py
@@ -22,9 +22,8 @@ named target field declared in ``target_config`` produces:
 - For ``"scalar"`` types: per-metric values (``l1``, ``l2``, ``mae`` by
   default), keyed ``"<prefix>/<name>_<metric>"``.
 - For ``"vector"`` types: per-component values
-  (``"<prefix>/<name>_x_<metric>"`` etc.), aggregate values over all
-  components jointly (``"<prefix>/<name>_<metric>"``), and
-  direction-blind magnitude values (``"<prefix>/<name>_mag_<metric>"``).
+  (``"<prefix>/<name>_x_<metric>"`` etc.) plus aggregate values over all
+  components jointly (``"<prefix>/<name>_<metric>"``).
 
 Metrics are reported unweighted -- per-field weighting belongs in the
 loss, not in diagnostic summaries.
@@ -190,9 +189,8 @@ class MetricCalculator:
     def expected_keys(self) -> list[str]:
         """The exact key set :meth:`__call__` produces, derivable without data.
 
-        Vector fields contribute keys per spatial component, the bare-name
-        aggregate keys, and the ``mag`` (magnitude-comparison) keys;
-        scalars contribute one key per metric.
+        Vector fields contribute keys per spatial component plus the bare-name
+        aggregate keys; scalars contribute one key per metric.
         Lets callers pre-size accumulators identically on every rank --
         e.g. ``infer.py`` zero-fills its running sums with these keys so
         the cross-rank all-reduce packs the same tensor length even on a
@@ -209,8 +207,6 @@ class MetricCalculator:
                         self._make_key(name, comp, m) for m in self.metric_names
                     )
             keys.extend(self._make_key(name, m) for m in self.metric_names)
-            if field_type == "vector":
-                keys.extend(self._make_key(name, "mag", m) for m in self.metric_names)
         return keys
 
     def _metrics_for_tensor(
@@ -237,8 +233,7 @@ class MetricCalculator:
             ``"<prefix>/<name>_<metric>"`` for scalar fields and by
             ``"<prefix>/<name>_<comp>_<metric>"`` plus
             ``"<prefix>/<name>_<metric>"`` (aggregate over all components
-            jointly) and ``"<prefix>/<name>_mag_<metric>"``
-            (direction-blind magnitude comparison) for vector fields.
+            jointly) for vector fields.
             Slash-containing keys are stored verbatim;
             TensorDict only treats ``/`` as nested when the caller
             explicitly invokes ``flatten_keys("/")``.
@@ -275,13 +270,6 @@ class MetricCalculator:
                     out.update(
                         self._metrics_for_tensor(p.flatten(-2), t.flatten(-2), (name,))
                     )
-                    ### Magnitude comparison under an explicit "mag" key.
-                    ### Direction-blind by construction -- a prediction with
-                    ### correct magnitude but arbitrary direction scores 0
-                    ### here -- so it must never be the headline aggregate.
-                    p_mag = torch.linalg.vector_norm(p, dim=-1)
-                    t_mag = torch.linalg.vector_norm(t, dim=-1)
-                    out.update(self._metrics_for_tensor(p_mag, t_mag, (name, "mag")))
 
         return TensorDict(out)
 

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_utils.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_utils.py
@@ -148,11 +148,11 @@ def test_vector_aggregate_metric_is_direction_sensitive():
 
     Adversarial case: ``pred = -target`` has the correct magnitude at
     every point but maximally wrong direction. The aggregate ``wss_*``
-    metrics must say so (relative l1/l2 of a sign flip is exactly 2),
-    while the explicitly direction-blind ``wss_mag_*`` metrics score it
-    as perfect. Before 2026-07 the bare-name aggregate *was* the
-    magnitude comparison, so this prediction scored 0 -- the headline
-    vector metric could not see direction errors at all.
+    metrics must say so (relative l1/l2 of a sign flip is exactly 2).
+    Before 2026-07 the bare-name aggregate was a magnitude comparison,
+    so this prediction scored 0 -- the headline vector metric could not
+    see direction errors at all. That broken behavior is not retained
+    under a separate metric key.
     """
     t = torch.randn(64, 3)
     calc = MetricCalculator({"wss": "vector"})
@@ -165,9 +165,7 @@ def test_vector_aggregate_metric_is_direction_sensitive():
     assert out["wss_mae"].item() == pytest.approx(
         (2 * torch.mean(torch.abs(t.flatten()))).item(), rel=1e-5
     )
-    assert out["wss_mag_l1"].item() == pytest.approx(0.0, abs=1e-6)
-    assert out["wss_mag_l2"].item() == pytest.approx(0.0, abs=1e-6)
-    assert out["wss_mag_mae"].item() == pytest.approx(0.0, abs=1e-6)
+    assert not any("_mag_" in key for key in out.keys())
 
 
 def test_vector_aggregate_l2_is_frobenius():

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_utils.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_utils.py
@@ -162,7 +162,9 @@ def test_vector_aggregate_metric_is_direction_sensitive():
     )
     assert out["wss_l1"].item() == pytest.approx(2.0, rel=1e-5)
     assert out["wss_l2"].item() == pytest.approx(2.0, rel=1e-5)
-    assert out["wss_mae"].item() > 0.5
+    assert out["wss_mae"].item() == pytest.approx(
+        (2 * torch.mean(torch.abs(t.flatten()))).item(), rel=1e-5
+    )
     assert out["wss_mag_l1"].item() == pytest.approx(0.0, abs=1e-6)
     assert out["wss_mag_l2"].item() == pytest.approx(0.0, abs=1e-6)
     assert out["wss_mag_mae"].item() == pytest.approx(0.0, abs=1e-6)

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_utils.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_utils.py
@@ -143,6 +143,51 @@ def test_metric_calculator_expected_keys_match_call():
     assert set(calc.expected_keys()) == computed
 
 
+def test_vector_aggregate_metric_is_direction_sensitive():
+    """The bare-name vector aggregate must penalize direction errors.
+
+    Adversarial case: ``pred = -target`` has the correct magnitude at
+    every point but maximally wrong direction. The aggregate ``wss_*``
+    metrics must say so (relative l1/l2 of a sign flip is exactly 2),
+    while the explicitly direction-blind ``wss_mag_*`` metrics score it
+    as perfect. Before 2026-07 the bare-name aggregate *was* the
+    magnitude comparison, so this prediction scored 0 -- the headline
+    vector metric could not see direction errors at all.
+    """
+    t = torch.randn(64, 3)
+    calc = MetricCalculator({"wss": "vector"})
+    out = calc(
+        TensorDict({"wss": -t}, batch_size=[]),
+        TensorDict({"wss": t}, batch_size=[]),
+    )
+    assert out["wss_l1"].item() == pytest.approx(2.0, rel=1e-5)
+    assert out["wss_l2"].item() == pytest.approx(2.0, rel=1e-5)
+    assert out["wss_mae"].item() > 0.5
+    assert out["wss_mag_l1"].item() == pytest.approx(0.0, abs=1e-6)
+    assert out["wss_mag_l2"].item() == pytest.approx(0.0, abs=1e-6)
+    assert out["wss_mag_mae"].item() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_vector_aggregate_l2_is_frobenius():
+    """The bare-name l2 aggregate is the whole-field relative norm.
+
+    Pins the reduction axes: the field is flattened before the relative
+    norm, so the result is ``||pred - target||_F / ||target||_F`` --
+    not a mean of per-point ratios, which would blow up wherever the
+    target magnitude is near zero (e.g. WSS at stagnation points).
+    """
+    torch.manual_seed(0)
+    t = torch.randn(128, 3)
+    p = t + 0.1 * torch.randn(128, 3)
+    calc = MetricCalculator({"wss": "vector"}, metrics=["l2"])
+    out = calc(
+        TensorDict({"wss": p}, batch_size=[]),
+        TensorDict({"wss": t}, batch_size=[]),
+    )
+    expected = (torch.linalg.norm(p - t) / torch.linalg.norm(t)).item()
+    assert out["wss_l2"].item() == pytest.approx(expected, rel=1e-5)
+
+
 ### ---------------------------------------------------------------------------
 ### Autocast precision contract
 ### ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes a direction-blindness defect in the unified external aero recipe's shared metric path (`src/metrics.py`, `MetricCalculator`), which affects every model and dataset evaluated through the recipe.

**Defect.** For vector fields, the aggregate metrics reported under the bare field name (e.g. `wss_l2`, likewise `_l1` / `_mae`) were computed on per-point vector *magnitudes*, so direction errors were invisible: a prediction with the correct magnitude but wrong direction at every point scored 0 ("perfect") on the headline aggregate. Per-component metrics (`wss_x_l2`, ...) were always computed componentwise and are direction-sensitive, so tables reporting components alongside the aggregate contain honest columns — the misleading number is specifically the bare-field-name aggregate.

**Fix.**

- The bare-name aggregate now computes each metric over all components jointly, flattened so the relative norms reduce over the whole field (Frobenius for `l2`), making direction errors count.
- The broken magnitude-only aggregate is removed rather than retained under a separate metric key.
- Existing metric key names are preserved, but their vector aggregate semantics are corrected.

**Tests.** An adversarial regression uses `pred = -target` (correct magnitude, maximally wrong direction everywhere): the bare-name relative l1/l2 metrics must equal 2, and no magnitude-only keys may be emitted. A second test pins aggregate `l2` to the whole-field Frobenius ratio — not a mean of per-point ratios, which explodes wherever the target magnitude is near zero (e.g. WSS at stagnation points).

**Scope of impact.** Any vector field evaluated through the recipe's metric path — training/validation metric tables and `infer.py` summaries alike — for surface (wall shear stress) and volume (velocity/momentum-type) fields, across all model configs run through the recipe. Training and checkpoints are unaffected: the training/validation objective goes through `LossCalculator`, not this metric path. Only reported aggregate vector metrics flattered direction errors.

Existing historical bare-name vector metrics are not directly comparable with metrics produced after this fix because the meaning of the existing key has intentionally changed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

None.
