### PR TITLE
Increase unified external aero dataloader defaults

### DIFF
--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
@@ -43,9 +43,9 @@ training:
 
 # -- DataLoader / Dataset Performance Tuning --------------------------------
 dataloader:
-  prefetch_factor: 2
-  num_streams: 1
-  use_streams: false
+  prefetch_factor: 4
+  num_streams: 4
+  use_streams: true
   num_workers: 4
   pin_memory: true
 

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
@@ -43,10 +43,10 @@ training:
 
 # -- DataLoader / Dataset Performance Tuning --------------------------------
 dataloader:
-  prefetch_factor: 1
+  prefetch_factor: 2
   num_streams: 1
   use_streams: false
-  num_workers: 1
+  num_workers: 4
   pin_memory: true
 
 # -- Logging -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Increase the unified external aero recipe's default DataLoader worker count from 1 to 4.
- Increase its default prefetch factor from 1 to 4.
- Increase the CUDA stream count from 1 to 4 and enable streams by default.

## Motivation and impact

The higher defaults give the recipe more CPU-side loading, prefetch, and CUDA-stream capacity, reducing avoidable I/O stalls for mesh workloads. Existing Hydra overrides remain available for systems that need different resource settings.

## Validation

- Parsed `conf/base.yaml` and asserted `num_workers == 4`, `prefetch_factor == 4`, `num_streams == 4`, and `use_streams is true`.
- Ran `git diff --check`.
- Local `pre-commit` executable was unavailable; repository CI will run the configured hooks.
