### PR TITLE
fix(examples): reject multi-dataset manifest sampling

### DIFF
--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
@@ -34,9 +34,10 @@ The pipeline non-dimensionalizes raw fields to unitless model inputs
 conditions (`U_inf`, `rho_inf`, `p_inf`, ...) live in each file's
 `global_data` and are read by `MeshReaderWithGlobalData`. Because the
 datasets are non-dimensionalized and loaded through the PhysicsNeMo
-datapipes' `MultiDataset` abstraction, you can merge datasets on the fly
-for multi-dataset training; the infrastructure supports it, though we
-haven't extensively tuned it. Non-dimensionalization itself is the
+datapipes' `MultiDataset` abstraction, directory-split datasets can be
+merged on the fly for multi-dataset training. Manifest-split datasets
+currently must be trained one at a time because their sampler indices
+are local to one dataset. Non-dimensionalization itself is the
 `NonDimensionalizeByMetadata` transform in `src/nondim.py`.
 
 ## Quick start
@@ -63,7 +64,7 @@ python src/infer.py model=geotransolver_surface dataset=highlift_surface \
 ```
 
 For the canonical CLI invocations of every named recipe (FA variants,
-GLOBE, multi-dataset Transolver, HiLift, DoMINO), see the
+GLOBE, HiLift, DoMINO), see the
 [Recipe Gallery](#recipe-gallery) section below.
 
 ## Pipeline architecture
@@ -559,10 +560,9 @@ python src/train.py model=transolver_surface dataset=drivaer_ml_surface \
 python src/train.py model=transolver_volume dataset=drivaer_ml_volume \
     training.optimizer.lr=1e-3 training.scheduler.gamma=0.5
 
-# Transolver across DrivAerML + SHIFT SUV (multi-dataset)
-python src/train.py model=transolver_surface dataset=drivaer_ml_surface \
-    'extra_datasets=[shift_suv_estate_surface, shift_suv_fastback_surface]' \
-    training.optimizer.lr=1e-3 training.scheduler.gamma=0.5
+# Multi-dataset training is currently limited to directory-split datasets.
+# DrivAerML and SHIFT SUV use manifests and cannot be combined until their
+# local manifest indices are offset for MultiDataset sampling.
 
 # FLARE
 python src/train.py model=flare_surface dataset=drivaer_ml_surface \
@@ -696,10 +696,11 @@ train_split: train
 val_split: val
 ```
 
-`build_dataloaders` plumbs these into each chosen dataset; manifest-mode
-datasets pick them up via `resolve_manifest_spec`, while directory-mode
-datasets (e.g. SHIFT SUV) ignore them and use the dataset YAML's
-`train_datadir` / `val_datadir`.
+For a single manifest dataset, `build_dataloaders` plumbs these selectors
+into `resolve_manifest_spec`. For directory mode, set both selectors to
+`null` and use the dataset YAML's `train_datadir` / `val_datadir`.
+Manifest and directory modes cannot currently be mixed with
+`extra_datasets` because manifest indices are local to one dataset.
 
 The `ManifestSampler` in `src/datasets.py` resolves manifest entries to
 dataset indices and handles distributed sampling across ranks.

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
@@ -462,7 +462,7 @@ dataset: drivaer_ml_volume
 # Multi-dataset: list of additional datasets to combine via MultiDataset
 extra_datasets: []
 
-# Manifest-mode split selectors (no-op for directory-mode datasets)
+# Non-null selectors request manifest mode; set both to null for directory mode
 train_split: train
 val_split: val
 
@@ -686,9 +686,10 @@ file you need to edit per machine to point at your local data).
 
 ### Manifest-based data splitting
 
-DrivaerML and HiLift datasets use a `manifest.json` next to the data
-directory to define train/val/test splits. Selection is recipe-side via
-the top-level `train_split` / `val_split` keys in `train.yaml`:
+DrivaerML, HiLift, and SHIFT SUV datasets use a `manifest.json` next to
+the data directory to define train/val/test splits. Selection is
+recipe-side via the top-level `train_split` / `val_split` keys in
+`train.yaml`:
 
 ```yaml
 # in conf/train.yaml

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/train.yaml
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/train.yaml
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------------
 # Picks one model template and one dataset, applies the centralized
 # training schedule below, and runs the loop.  Every previously-named
-# recipe (FA variants, GLOBE, multi-dataset Transolver, HiLift) is
+# recipe (FA variants, GLOBE, HiLift) is
 # reproducible from CLI overrides; see the Recipe Gallery in README.md.
 #
 #   Default invocation:
@@ -28,9 +28,8 @@
 #   Pick a different model + dataset:
 #     python src/train.py model=transolver_volume dataset=drivaer_ml_volume
 #
-#   Multi-dataset:
-#     python src/train.py model=transolver_surface dataset=drivaer_ml_surface \
-#         'extra_datasets=[shift_suv_estate_surface, shift_suv_fastback_surface]'
+#   Manifest-split datasets cannot currently be combined with extra_datasets;
+#   multi-dataset training is limited to directory-split datasets.
 ### `_self_` merges before the model template, so model templates may
 ### carry known-good per-model overrides of the schedule below (e.g.
 ### `compile`, `training.optimizer.lr`). CLI overrides still win over both.
@@ -43,9 +42,9 @@ defaults:
 # A string naming a file in datasets/ (without the `.yaml` suffix).
 dataset: drivaer_ml_volume
 
-# Additional datasets to combine via MultiDataset.  Each entry names a
-# file in datasets/.  Empty by default; the Transolver+SHIFT recipe
-# sets this to [shift_suv_estate_surface, shift_suv_fastback_surface].
+# Additional datasets to combine via MultiDataset. Each entry names a
+# file in datasets/. Only directory-split datasets can currently be
+# combined; manifest-split configurations fail loudly at startup.
 extra_datasets: []
 
 # Manifest-mode split selectors.  Setting these requests manifest mode:

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/datasets.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/datasets.py
@@ -581,6 +581,25 @@ def _resolve_manifest_indices_from_spec(
     return train_indices, val_indices
 
 
+def _require_single_manifest_dataset(using_manifests: bool, n_datasets: int) -> None:
+    """Reject manifest sampling against a combined dataset.
+
+    Manifest indices are local to each dataset, but the sampler receives
+    the concatenated dataset. Multiple manifest datasets overwrite the
+    single stored index pair, while a manifest/directory mix either omits
+    the directory dataset or indexes the wrong dataset. Until indices are
+    accumulated with per-dataset offsets, manifest mode requires exactly
+    one dataset.
+    """
+    if using_manifests and n_datasets > 1:
+        raise NotImplementedError(
+            "multi-dataset manifest mode is not implemented: manifest "
+            "train/val indices are local to one dataset but would be applied "
+            "to the combined dataset. Use a single manifest dataset, or "
+            "directory mode for multi-dataset training."
+        )
+
+
 def _build_manifest_val_dataset(
     ds_yaml: DictConfig,
     *,
@@ -750,18 +769,13 @@ def build_dataloaders(
     directory (mirroring directory mode); otherwise it shares the train
     dataset.
 
-    NOTE (limitation): only ONE chosen dataset may carry a manifest
-    today. If both ``cfg.dataset`` and an entry in ``cfg.extra_datasets``
-    are manifest-mode, the later one silently overwrites the earlier's
-    indices and the resulting :class:`ManifestSampler` is indexed
-    against the last reader's local positions rather than the
-    :class:`MultiDataset`'s concatenated positions. The current
-    multi-dataset recipe (Transolver + DrivAerML + SHIFT SUV) sidesteps
-    this because the SHIFT SUV datasets are directory-mode (no
-    manifest). Lifting this limitation requires walking
-    ``(offset, indices)`` pairs and building a single sampler over
-    offset-shifted indices against the :class:`MultiDataset`. Tracked
-    as a follow-up.
+    NOTE (limitation): manifest mode currently supports exactly one
+    chosen dataset. Combining a manifest dataset with any additional
+    dataset, whether manifest- or directory-based, would apply local
+    indices to a :class:`MultiDataset` without the required offsets (and
+    multiple manifest datasets also overwrite the single stored index
+    pair). Lifting this limitation requires accumulating offset-shifted
+    indices for every dataset.
     """
     recipe_root = Path(__file__).resolve().parent.parent
     batch_size = cfg.training.get("batch_size", 1)
@@ -887,9 +901,6 @@ def build_dataloaders(
                 pin_memory=pin_memory,
             )
             train_datasets.append(dataset)
-            ### NOTE: this overwrites any prior manifest dataset's indices
-            ### (and the val dataset below); see the docstring's
-            ### multi-dataset limitation note.
             manifest_train_indices, manifest_val_indices = (
                 _resolve_manifest_indices_from_spec(dataset.reader, manifest_spec)
             )
@@ -929,6 +940,8 @@ def build_dataloaders(
                     pin_memory=pin_memory,
                 )
             )
+
+    _require_single_manifest_dataset(using_manifests, len(train_datasets))
 
     if not train_datasets:
         raise RuntimeError(

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/datasets.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/datasets.py
@@ -581,25 +581,6 @@ def _resolve_manifest_indices_from_spec(
     return train_indices, val_indices
 
 
-def _require_single_manifest_dataset(using_manifests: bool, n_datasets: int) -> None:
-    """Reject manifest sampling against a combined dataset.
-
-    Manifest indices are local to each dataset, but the sampler receives
-    the concatenated dataset. Multiple manifest datasets overwrite the
-    single stored index pair, while a manifest/directory mix either omits
-    the directory dataset or indexes the wrong dataset. Until indices are
-    accumulated with per-dataset offsets, manifest mode requires exactly
-    one dataset.
-    """
-    if using_manifests and n_datasets > 1:
-        raise NotImplementedError(
-            "multi-dataset manifest mode is not implemented: manifest "
-            "train/val indices are local to one dataset but would be applied "
-            "to the combined dataset. Use a single manifest dataset, or "
-            "directory mode for multi-dataset training."
-        )
-
-
 def _build_manifest_val_dataset(
     ds_yaml: DictConfig,
     *,
@@ -941,7 +922,13 @@ def build_dataloaders(
                 )
             )
 
-    _require_single_manifest_dataset(using_manifests, len(train_datasets))
+    if using_manifests and len(train_datasets) > 1:
+        raise NotImplementedError(
+            "multi-dataset manifest mode is not implemented: manifest "
+            "train/val indices are local to one dataset but would be applied "
+            "to the combined dataset. Use a single manifest dataset, or "
+            "directory mode for multi-dataset training."
+        )
 
     if not train_datasets:
         raise RuntimeError(

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_manifest.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_manifest.py
@@ -35,7 +35,6 @@ import pytest
 from datasets import (
     ManifestSampler,
     _build_manifest_val_dataset,
-    _require_single_manifest_dataset,
     build_dataloaders,
     build_dataset,
     load_manifest,
@@ -487,11 +486,6 @@ class TestManifestValDataset:
 class TestMultiDatasetManifestGuard:
     """Manifest indices must never be applied to a combined dataset."""
 
-    def test_single_manifest_or_multiple_directory_datasets_pass(self):
-        """Single-manifest and pure directory configurations remain valid."""
-        _require_single_manifest_dataset(True, 1)
-        _require_single_manifest_dataset(False, 3)
-
     def test_build_dataloaders_rejects_mixed_manifest_and_directory_mode(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -532,6 +526,8 @@ class TestMultiDatasetManifestGuard:
                 "val_split": None,
                 "augment": False,
                 "sampling_resolution": None,
+                "input_type": "mesh",
+                "forward_kwargs": {"domain": ""},
                 "training": {"batch_size": 1, "seed": 0},
                 "dataloader": {"num_workers": 1, "pin_memory": False},
             }

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_manifest.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_manifest.py
@@ -30,19 +30,20 @@ import logging
 from pathlib import Path
 from types import SimpleNamespace
 
+import datasets as datasets_module
 import pytest
-from omegaconf import DictConfig, OmegaConf
-
 from datasets import (
     ManifestSampler,
     _build_manifest_val_dataset,
+    _require_single_manifest_dataset,
+    build_dataloaders,
     build_dataset,
     load_manifest,
     resolve_manifest_indices,
     resolve_manifest_spec,
     validate_dataset_consistency,
 )
-
+from omegaconf import DictConfig, OmegaConf
 
 ### ---------------------------------------------------------------------------
 ### load_manifest
@@ -481,3 +482,60 @@ class TestManifestValDataset:
         assert not any(getattr(t, "stochastic", False) for t in val_ds.transforms)
         ### ...but the deterministic CenterMesh transform is still present.
         assert any(type(t).__name__ == "CenterMesh" for t in val_ds.transforms)
+
+
+class TestMultiDatasetManifestGuard:
+    """Manifest indices must never be applied to a combined dataset."""
+
+    def test_single_manifest_or_multiple_directory_datasets_pass(self):
+        """Single-manifest and pure directory configurations remain valid."""
+        _require_single_manifest_dataset(True, 1)
+        _require_single_manifest_dataset(False, 3)
+
+    def test_build_dataloaders_rejects_mixed_manifest_and_directory_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The assembled loader rejects local indices on a combined dataset."""
+        roots = [tmp_path / name for name in ("manifest", "directory", "directory_val")]
+        for root in roots:
+            root.mkdir()
+            TestManifestValDataset._make_datadir(root)
+        manifest_root, directory_root, directory_val_root = roots
+        train_manifest = tmp_path / "train.txt"
+        train_manifest.write_text("run_0\n")
+        configs = {
+            "drivaer_ml_surface": OmegaConf.merge(
+                TestManifestValDataset._augmented_ds_yaml(manifest_root),
+                {"train_manifest": str(train_manifest)},
+            ),
+            "shift_suv_estate_surface": OmegaConf.merge(
+                TestManifestValDataset._augmented_ds_yaml(directory_root),
+                {"val_datadir": str(directory_val_root)},
+            ),
+        }
+
+        monkeypatch.setattr(
+            datasets_module,
+            "load_dataset_config",
+            lambda path: configs[path.stem],
+        )
+        monkeypatch.setattr(
+            datasets_module,
+            "DistributedManager",
+            lambda: SimpleNamespace(world_size=1, rank=0),
+        )
+        cfg = OmegaConf.create(
+            {
+                "dataset": "drivaer_ml_surface",
+                "extra_datasets": ["shift_suv_estate_surface"],
+                "train_split": None,
+                "val_split": None,
+                "augment": False,
+                "sampling_resolution": None,
+                "training": {"batch_size": 1, "seed": 0},
+                "dataloader": {"num_workers": 1, "pin_memory": False},
+            }
+        )
+
+        with pytest.raises(NotImplementedError, match="multi-dataset manifest mode"):
+            build_dataloaders(cfg)


### PR DESCRIPTION
## Summary

- fail loudly when manifest sampling is combined with any additional dataset
- add an integration regression through `build_dataloaders` for mixed manifest/directory mode
- document the single-dataset manifest limitation and remove the advertised DrivAerML + SHIFT command

## Why

Manifest indices are resolved in each dataset's local coordinate system, but `build_dataloaders` stores only one train/validation index pair and later applies it to the concatenated `MultiDataset`. Multiple manifest datasets overwrite earlier indices; mixing manifest and directory datasets can select the wrong prefix or omit a dataset entirely.

Until the loader accumulates every dataset's indices with the appropriate offsets, rejecting this configuration prevents silent mis-sampling.

## Validation

- `pytest -q examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests` (158 passed)
- `ruff format --check` on the changed Python files
- `ruff check` on the changed Python files
- `git diff --check`
