### PR TITLE
Docs: fix mesh image paths

### DIFF
--- a/docs/api/mesh/remeshing.rst
+++ b/docs/api/mesh/remeshing.rst
@@ -64,7 +64,7 @@ unused vertices. Small targets use farthest-point initialization for mesh
 quality. Large targets use a linearithmic spatially stratified initializer to
 avoid quadratic setup cost.
 
-.. image:: /img/mesh/remeshing_comparison.png
+.. image:: ../../img/mesh/remeshing_comparison.png
    :alt: Dense Stanford bunny beside its Warp-remeshed result
    :align: center
    :width: 72%
@@ -94,7 +94,7 @@ Server Edition MIG 1g.24GB partition using Warp 1.14.0. Absolute timings depend
 on hardware and software versions. Use the ASV benchmark above for measurements
 in another environment.
 
-.. image:: /img/mesh/remeshing_performance.png
+.. image:: ../../img/mesh/remeshing_performance.png
    :alt: GPU remeshing runtime plot across increasing input sizes
    :align: center
    :width: 65%

--- a/docs/api/mesh/transformations.rst
+++ b/docs/api/mesh/transformations.rst
@@ -152,7 +152,7 @@ multiple-control examples above. Green markers identify the displaced handle
 locations, while arrows and labels show the prescribed displacement directions
 and magnitudes.
 
-.. figure:: /img/mesh/sphere_morphing.png
+.. figure:: ../../img/mesh/sphere_morphing.png
    :alt: Original sphere and single-control and multiple-control sphere morphing
    :width: 100%
 
@@ -214,7 +214,7 @@ Bernstein lattice tapers the whole sphere because every node acts globally,
 while three independently displaced regions in a finer cubic B-spline lattice
 produce two local bulges and a local indentation.
 
-.. figure:: /img/mesh/sphere_ffd.png
+.. figure:: ../../img/mesh/sphere_ffd.png
    :alt: Sphere with control lattice, Bernstein taper, and local B-spline sculpt
    :width: 100%
 


### PR DESCRIPTION
## Summary

- use document-relative paths for four images in the mesh API documentation
- fix image rendering in GitHub's RST preview
- preserve the existing Sphinx image locations and output

## Root cause

The mesh documentation used source-root paths such as `/img/mesh/sphere_ffd.png`.
Sphinx resolves those paths from the `docs` source root, but GitHub's RST preview
does not. Resolving the paths relative to each RST file works in both renderers.

## Validation

- ran the repository pre-commit hooks on both changed RST files
- built the documentation with `sphinx-build -b html`
- confirmed all four images were copied and referenced in the generated HTML
- confirmed no source-root image directives remain under `docs/api/mesh`
