### PR TITLE
Unified Aero Recipe: offset manifest indices into the combined MultiDataset

### DIFF
--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
@@ -34,10 +34,10 @@ The pipeline non-dimensionalizes raw fields to unitless model inputs
 conditions (`U_inf`, `rho_inf`, `p_inf`, ...) live in each file's
 `global_data` and are read by `MeshReaderWithGlobalData`. Because the
 datasets are non-dimensionalized and loaded through the PhysicsNeMo
-datapipes' `MultiDataset` abstraction, directory-split datasets can be
-merged on the fly for multi-dataset training. Manifest-split datasets
-currently must be trained one at a time because their sampler indices
-are local to one dataset. Non-dimensionalization itself is the
+datapipes' `MultiDataset` abstraction, you can merge directory- and
+manifest-split datasets on the fly for multi-dataset training. Manifest
+indices are resolved within each dataset and shifted into the combined
+index space before sampling. Non-dimensionalization itself is the
 `NonDimensionalizeByMetadata` transform in `src/nondim.py`.
 
 ## Quick start
@@ -64,7 +64,7 @@ python src/infer.py model=geotransolver_surface dataset=highlift_surface \
 ```
 
 For the canonical CLI invocations of every named recipe (FA variants,
-GLOBE, HiLift, DoMINO), see the
+GLOBE, multi-dataset Transolver, HiLift, DoMINO), see the
 [Recipe Gallery](#recipe-gallery) section below.
 
 ## Pipeline architecture
@@ -462,7 +462,7 @@ dataset: drivaer_ml_volume
 # Multi-dataset: list of additional datasets to combine via MultiDataset
 extra_datasets: []
 
-# Non-null selectors request manifest mode; set both to null for directory mode
+# Split selectors applied independently to every chosen manifest dataset
 train_split: train
 val_split: val
 
@@ -560,9 +560,10 @@ python src/train.py model=transolver_surface dataset=drivaer_ml_surface \
 python src/train.py model=transolver_volume dataset=drivaer_ml_volume \
     training.optimizer.lr=1e-3 training.scheduler.gamma=0.5
 
-# Multi-dataset training is currently limited to directory-split datasets.
-# DrivAerML and SHIFT SUV use manifests and cannot be combined until their
-# local manifest indices are offset for MultiDataset sampling.
+# Transolver across DrivAerML + SHIFT SUV (multi-dataset)
+python src/train.py model=transolver_surface dataset=drivaer_ml_surface \
+    'extra_datasets=[shift_suv_estate_surface, shift_suv_fastback_surface]' \
+    training.optimizer.lr=1e-3 training.scheduler.gamma=0.5
 
 # FLARE
 python src/train.py model=flare_surface dataset=drivaer_ml_surface \
@@ -697,11 +698,21 @@ train_split: train
 val_split: val
 ```
 
-For a single manifest dataset, `build_dataloaders` plumbs these selectors
-into `resolve_manifest_spec`. For directory mode, set both selectors to
-`null` and use the dataset YAML's `train_datadir` / `val_datadir`.
-Manifest and directory modes cannot currently be mixed with
-`extra_datasets` because manifest indices are local to one dataset.
+`build_dataloaders` resolves the selected split independently for every
+chosen manifest dataset. It then shifts each dataset's local indices by
+that dataset's cumulative `MultiDataset` offset before constructing the
+train and validation samplers. Directory-mode datasets can participate in
+the same run and contribute their complete local ranges. Because non-null
+top-level split selectors request manifest mode for every chosen dataset,
+a manifest/directory mix should set them to `null` and provide explicit
+`train_manifest` / `val_manifest` paths on the manifest dataset YAML.
+
+Do not skip that second step. With the selectors cleared and no explicit
+`train_manifest`, a dataset that *has* a `manifest.json` falls back to
+directory mode and sweeps every run under `train_datadir` — including the
+manifest's held-out val/test entries — into training. `resolve_manifest_spec`
+logs a warning when it sees that combination; treat it as an error in your
+config.
 
 The `ManifestSampler` in `src/datasets.py` resolves manifest entries to
 dataset indices and handles distributed sampling across ranks.

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/train.yaml
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/train.yaml
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------------
 # Picks one model template and one dataset, applies the centralized
 # training schedule below, and runs the loop.  Every previously-named
-# recipe (FA variants, GLOBE, HiLift) is
+# recipe (FA variants, GLOBE, multi-dataset Transolver, HiLift) is
 # reproducible from CLI overrides; see the Recipe Gallery in README.md.
 #
 #   Default invocation:
@@ -28,8 +28,9 @@
 #   Pick a different model + dataset:
 #     python src/train.py model=transolver_volume dataset=drivaer_ml_volume
 #
-#   Manifest-split datasets cannot currently be combined with extra_datasets;
-#   multi-dataset training is limited to directory-split datasets.
+#   Multi-dataset:
+#     python src/train.py model=transolver_surface dataset=drivaer_ml_surface \
+#         'extra_datasets=[shift_suv_estate_surface, shift_suv_fastback_surface]'
 ### `_self_` merges before the model template, so model templates may
 ### carry known-good per-model overrides of the schedule below (e.g.
 ### `compile`, `training.optimizer.lr`). CLI overrides still win over both.
@@ -43,8 +44,8 @@ defaults:
 dataset: drivaer_ml_volume
 
 # Additional datasets to combine via MultiDataset. Each entry names a
-# file in datasets/. Only directory-split datasets can currently be
-# combined; manifest-split configurations fail loudly at startup.
+# file in datasets/. Manifest selections are offset into the combined
+# index space independently for every chosen dataset.
 extra_datasets: []
 
 # Manifest-mode split selectors.  Setting these requests manifest mode:

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/datasets.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/datasets.py
@@ -230,6 +230,11 @@ def resolve_manifest_spec(ds_yaml: DictConfig, ds_cfg_block: DictConfig) -> dict
     prevents the silent fallback to directory mode, which - combined with
     a dataset YAML that has no ``val_datadir`` - would otherwise leave the
     val loader iterating the train data.
+
+    Warns (but still returns ``None``) when directory mode is selected for
+    a dataset that nonetheless has a sibling ``manifest.json``: that
+    combination silently sweeps the manifest's held-out val / test entries
+    into the training set.
     """
     train_manifest = ds_cfg_block.get("train_manifest", None)
     val_manifest = ds_cfg_block.get("val_manifest", None)
@@ -237,12 +242,16 @@ def resolve_manifest_spec(ds_yaml: DictConfig, ds_cfg_block: DictConfig) -> dict
     train_split = ds_cfg_block.get("train_split", None)
     val_split = ds_cfg_block.get("val_split", None)
 
+    train_datadir = OmegaConf.select(ds_yaml, "train_datadir", default=None)
+    sibling_manifest: Path | None = (
+        Path(str(train_datadir)) / "manifest.json" if train_datadir else None
+    )
+
     ### Auto-derive manifest path from `train_datadir/manifest.json` when
     ### the user gave a split key but no explicit manifest path.
-    train_datadir = OmegaConf.select(ds_yaml, "train_datadir", default=None)
     derived_path: Path | None = None
-    if manifest is None and train_split is not None and train_datadir:
-        derived_path = Path(str(train_datadir)) / "manifest.json"
+    if manifest is None and train_split is not None and sibling_manifest is not None:
+        derived_path = sibling_manifest
         if derived_path.exists():
             manifest = str(derived_path)
 
@@ -261,13 +270,9 @@ def resolve_manifest_spec(ds_yaml: DictConfig, ds_cfg_block: DictConfig) -> dict
         )
         if user_intended_manifest:
             looked_for = (
-                str(derived_path)
-                if derived_path is not None
-                else (
-                    f"{Path(str(train_datadir)) / 'manifest.json'}"
-                    if train_datadir
-                    else "<no train_datadir set in dataset YAML>"
-                )
+                str(sibling_manifest)
+                if sibling_manifest is not None
+                else "<no train_datadir set in dataset YAML>"
             )
             raise ValueError(
                 f"Manifest mode was requested but no usable manifest could be "
@@ -278,6 +283,23 @@ def resolve_manifest_spec(ds_yaml: DictConfig, ds_cfg_block: DictConfig) -> dict
                 f"Either set 'manifest:' (or 'train_manifest:' / "
                 f"'val_manifest:') explicitly in the data block, or place a "
                 f"manifest.json next to the dataset's train_datadir."
+            )
+        ### Genuine directory mode, but a manifest sits right next to the
+        ### data. Almost always a misconfiguration: left silent, every run
+        ### under train_datadir -- including the manifest's held-out val /
+        ### test entries -- is swept into training. This is easy to hit now
+        ### that mixing manifest- and directory-mode datasets requires
+        ### clearing the top-level split selectors, so warn loudly.
+        if sibling_manifest is not None and sibling_manifest.exists():
+            _LOGGER.warning(
+                "Directory mode selected for a dataset that has a manifest "
+                "at %s, so the manifest's splits are ignored: every run "
+                "under %s (including its held-out val/test entries) will be "
+                "used for training. Set 'train_split' / 'val_split', or set "
+                "'train_manifest' / 'val_manifest' on the dataset YAML, to "
+                "honor the manifest.",
+                str(sibling_manifest),
+                str(train_datadir),
             )
         return None
     return {
@@ -678,12 +700,12 @@ def _build_directory_samplers(
 
 def _build_manifest_samplers(
     train_indices: list[int],
-    val_indices: list[int] | None,
+    val_indices: list[int],
     *,
     dist_manager: DistributedManager,
     sampler_seed: int,
 ) -> tuple[ManifestSampler, ManifestSampler]:
-    """ManifestSamplers (with distributed sharding when world_size > 1)."""
+    """ManifestSamplers over global dataset indices, with optional sharding."""
     use_distributed = dist_manager.world_size > 1
     rank = dist_manager.rank if use_distributed else 0
     world_size = dist_manager.world_size if use_distributed else 1
@@ -696,21 +718,6 @@ def _build_manifest_samplers(
         world_size=world_size,
         drop_last=True,
     )
-    ### When no explicit val split is configured, fall back to the train
-    ### indices but build a separate non-shuffled, no-drop sampler so val
-    ### iteration is deterministic and covers every sample. This used to
-    ### happen silently; warn loudly so the duplication shows up in the
-    ### run log instead of producing a "val == train" loss curve that
-    ### looks correct.
-    if val_indices is None:
-        _LOGGER.warning(
-            "Manifest mode: no val_split / val_manifest configured; "
-            "validation will iterate the train split (%d samples). "
-            "Set 'val_split:' or 'val_manifest:' on the data block to "
-            "use a real holdout.",
-            len(train_indices),
-        )
-        val_indices = train_indices
     val_sampler = ManifestSampler(
         val_indices,
         shuffle=False,
@@ -750,13 +757,11 @@ def build_dataloaders(
     directory (mirroring directory mode); otherwise it shares the train
     dataset.
 
-    NOTE (limitation): manifest mode currently supports exactly one
-    chosen dataset. Combining a manifest dataset with any additional
-    dataset, whether manifest- or directory-based, would apply local
-    indices to a :class:`MultiDataset` without the required offsets (and
-    multiple manifest datasets also overwrite the single stored index
-    pair). Lifting this limitation requires accumulating offset-shifted
-    indices for every dataset.
+    Multiple datasets may use either split strategy. Each dataset's local
+    train and validation indices are shifted by its cumulative offset in
+    the corresponding :class:`MultiDataset` before the samplers are built.
+    Directory-mode datasets contribute their full local index ranges when
+    combined with manifest-mode datasets.
     """
     recipe_root = Path(__file__).resolve().parent.parent
     batch_size = cfg.training.get("batch_size", 1)
@@ -793,11 +798,12 @@ def build_dataloaders(
     extras: list[str] = list(cfg.get("extra_datasets", []) or [])
     dataset_names: list[str] = [primary_name, *extras]
 
-    train_datasets: list = []
-    val_datasets: list = []
-    manifest_train_indices: list[int] | None = None
-    manifest_val_indices: list[int] | None = None
-    manifest_val_dataset: MeshDataset | None = None
+    train_datasets: list[MeshDataset] = []
+    val_datasets: list[MeshDataset] = []
+    combined_train_indices: list[int] = []
+    combined_val_indices: list[int] = []
+    train_offset = 0
+    val_offset = 0
     using_manifests = False
     first_targets: dict[str, str] | None = None
     first_metrics: list[str] | None = None
@@ -872,24 +878,45 @@ def build_dataloaders(
             }
         )
         manifest_spec = resolve_manifest_spec(ds_yaml, ds_cfg_block)
+        dataset = build_dataset(
+            ds_yaml,
+            augment=augment,
+            device=device,
+            num_workers=num_workers,
+            pin_memory=pin_memory,
+        )
+        train_datasets.append(dataset)
+
         if manifest_spec is not None:
             using_manifests = True
-            dataset = build_dataset(
-                ds_yaml,
-                augment=augment,
-                device=device,
-                num_workers=num_workers,
-                pin_memory=pin_memory,
-            )
-            train_datasets.append(dataset)
-            manifest_train_indices, manifest_val_indices = (
+            local_train_indices, local_val_indices = (
                 _resolve_manifest_indices_from_spec(dataset.reader, manifest_spec)
             )
+            combined_train_indices.extend(
+                train_offset + index for index in local_train_indices
+            )
+            train_offset += len(dataset)
+
+            ### A missing validation split falls back per dataset, before
+            ### offsets are applied. This keeps that dataset's training
+            ### selection in validation without accidentally pulling in
+            ### another dataset's indices.
+            if local_val_indices is None:
+                _LOGGER.warning(
+                    "Manifest mode for dataset %r: no val_split / "
+                    "val_manifest configured; validation will iterate "
+                    "that dataset's train split (%d samples). Set "
+                    "'val_split:' or 'val_manifest:' to use a real holdout.",
+                    ds_name,
+                    len(local_train_indices),
+                )
+                local_val_indices = local_train_indices
+
             ### Augmentations are training-only: when enabled, give
             ### validation its own un-augmented dataset over the same
-            ### directory so eval is never augmented (matching directory
-            ### mode). Stays None when augment is off, so val shares the
-            ### train dataset.
+            ### directory so eval is never augmented. Otherwise this entry
+            ### shares its training dataset, preserving the same local index
+            ### space without constructing another reader.
             manifest_val_dataset = _build_manifest_val_dataset(
                 ds_yaml,
                 augment=augment,
@@ -897,38 +924,34 @@ def build_dataloaders(
                 num_workers=num_workers,
                 pin_memory=pin_memory,
             )
+            val_dataset = (
+                manifest_val_dataset if manifest_val_dataset is not None else dataset
+            )
+            val_datasets.append(val_dataset)
+            combined_val_indices.extend(
+                val_offset + index for index in local_val_indices
+            )
+            val_offset += len(val_dataset)
             continue
 
         ### Directory mode: separate readers / datasets per split.
-        train_datasets.append(
-            build_dataset(
-                ds_yaml,
-                augment=augment,
+        combined_train_indices.extend(range(train_offset, train_offset + len(dataset)))
+        train_offset += len(dataset)
+        val_datadir = OmegaConf.select(ds_yaml, "val_datadir", default=None)
+        if val_datadir and Path(val_datadir).exists():
+            val_yaml = OmegaConf.merge(ds_yaml, {"train_datadir": val_datadir})
+            val_dataset = build_dataset(
+                val_yaml,
+                augment=False,
                 device=device,
                 num_workers=num_workers,
                 pin_memory=pin_memory,
             )
-        )
-        val_datadir = OmegaConf.select(ds_yaml, "val_datadir", default=None)
-        if val_datadir and Path(val_datadir).exists():
-            val_yaml = OmegaConf.merge(ds_yaml, {"train_datadir": val_datadir})
-            val_datasets.append(
-                build_dataset(
-                    val_yaml,
-                    augment=False,
-                    device=device,
-                    num_workers=num_workers,
-                    pin_memory=pin_memory,
-                )
+            val_datasets.append(val_dataset)
+            combined_val_indices.extend(
+                range(val_offset, val_offset + len(val_dataset))
             )
-
-    if using_manifests and len(train_datasets) > 1:
-        raise NotImplementedError(
-            "multi-dataset manifest mode is not implemented: manifest "
-            "train/val indices are local to one dataset but would be applied "
-            "to the combined dataset. Use a single manifest dataset, or "
-            "directory mode for multi-dataset training."
-        )
+            val_offset += len(val_dataset)
 
     if not train_datasets:
         raise RuntimeError(
@@ -952,18 +975,13 @@ def build_dataloaders(
     train_dataset = _combine_datasets(train_datasets)
 
     if using_manifests:
-        ### Manifest mode: train and val share one underlying reader; the
-        ### samplers carve out the per-split index sets. When augmentations
-        ### are enabled, validation uses a dedicated un-augmented dataset
-        ### (built in the loop above) so eval is never augmented -- matching
-        ### directory mode; otherwise the chains are identical and val
-        ### shares the train dataset.
-        val_dataset = (
-            manifest_val_dataset if manifest_val_dataset is not None else train_dataset
-        )
+        ### At least one manifest selection requires explicit samplers for
+        ### the whole concatenation. The accumulated indices already include
+        ### full directory-mode ranges and independent train/val offsets.
+        val_dataset = _combine_datasets(val_datasets)
         train_sampler, val_sampler = _build_manifest_samplers(
-            manifest_train_indices,
-            manifest_val_indices,
+            combined_train_indices,
+            combined_val_indices,
             dist_manager=dist_manager,
             sampler_seed=sampler_seed,
         )

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_manifest.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_manifest.py
@@ -313,6 +313,33 @@ class TestResolveManifestSpec:
         ds_block = OmegaConf.create({})
         assert resolve_manifest_spec(ds_yaml, ds_block) is None
 
+    def test_directory_mode_with_sibling_manifest_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """A manifest next to the data that is about to be ignored is loud.
+
+        Clearing the top-level split selectors is how a manifest/directory
+        mix is configured, so this misconfiguration is easy to reach: it
+        would silently sweep the manifest's held-out val/test runs into
+        training.
+        """
+        (tmp_path / "manifest.json").write_text(
+            json.dumps({"train": ["run_1"], "val": ["run_0"]})
+        )
+        ds_yaml = OmegaConf.create({"train_datadir": str(tmp_path)})
+        with caplog.at_level(logging.WARNING, logger="training.datasets"):
+            assert resolve_manifest_spec(ds_yaml, OmegaConf.create({})) is None
+        assert any("manifest's splits are ignored" in r.message for r in caplog.records)
+
+    def test_directory_mode_without_sibling_manifest_is_silent(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Genuine directory mode must not nag."""
+        ds_yaml = OmegaConf.create({"train_datadir": str(tmp_path)})
+        with caplog.at_level(logging.WARNING, logger="training.datasets"):
+            assert resolve_manifest_spec(ds_yaml, OmegaConf.create({})) is None
+        assert not caplog.records
+
     def test_style_a_separate_files(self, tmp_path: Path):
         """``train_manifest`` / ``val_manifest`` (style A)."""
         train_path = tmp_path / "train.txt"
@@ -418,10 +445,11 @@ class TestManifestValDataset:
         """
         return OmegaConf.create(
             {
+                "train_datadir": str(datadir),
                 "pipeline": {
                     "reader": {
                         "_target_": "${dp:DomainMeshReader}",
-                        "path": str(datadir),
+                        "path": "${train_datadir}",
                         "pattern": "run_*/domain_*.pdmsh",
                     },
                     "augmentations": [
@@ -437,9 +465,9 @@ class TestManifestValDataset:
         )
 
     @staticmethod
-    def _make_datadir(tmp_path: Path) -> Path:
+    def _make_datadir(tmp_path: Path, n_samples: int = 2) -> Path:
         """Create placeholder runs the reader can glob (it never opens them)."""
-        for i in range(2):
+        for i in range(n_samples):
             run = tmp_path / f"run_{i}"
             run.mkdir()
             (run / f"domain_{i}.pdmsh").write_bytes(b"")
@@ -483,31 +511,20 @@ class TestManifestValDataset:
         assert any(type(t).__name__ == "CenterMesh" for t in val_ds.transforms)
 
 
-class TestMultiDatasetManifestGuard:
-    """Manifest indices must never be applied to a combined dataset."""
+class TestMultiDatasetManifestOffsets:
+    """Local split indices map correctly into concatenated datasets."""
 
-    def test_build_dataloaders_rejects_mixed_manifest_and_directory_mode(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        """The assembled loader rejects local indices on a combined dataset."""
-        roots = [tmp_path / name for name in ("manifest", "directory", "directory_val")]
-        for root in roots:
-            root.mkdir()
-            TestManifestValDataset._make_datadir(root)
-        manifest_root, directory_root, directory_val_root = roots
-        train_manifest = tmp_path / "train.txt"
-        train_manifest.write_text("run_0\n")
-        configs = {
-            "drivaer_ml_surface": OmegaConf.merge(
-                TestManifestValDataset._augmented_ds_yaml(manifest_root),
-                {"train_manifest": str(train_manifest)},
-            ),
-            "shift_suv_estate_surface": OmegaConf.merge(
-                TestManifestValDataset._augmented_ds_yaml(directory_root),
-                {"val_datadir": str(directory_val_root)},
-            ),
-        }
+    _augmented_ds_yaml = staticmethod(TestManifestValDataset._augmented_ds_yaml)
+    _make_datadir = staticmethod(TestManifestValDataset._make_datadir)
 
+    @staticmethod
+    def _patch_configs(
+        monkeypatch: pytest.MonkeyPatch,
+        configs: dict,
+        *,
+        world_size: int = 1,
+        rank: int = 0,
+    ) -> None:
         monkeypatch.setattr(
             datasets_module,
             "load_dataset_config",
@@ -516,22 +533,299 @@ class TestMultiDatasetManifestGuard:
         monkeypatch.setattr(
             datasets_module,
             "DistributedManager",
-            lambda: SimpleNamespace(world_size=1, rank=0),
+            lambda: SimpleNamespace(world_size=world_size, rank=rank),
         )
-        cfg = OmegaConf.create(
+
+    @staticmethod
+    def _loader_cfg(
+        primary: str,
+        extras: list[str],
+        *,
+        train_split: str | None,
+        val_split: str | None,
+        augment: bool = False,
+    ) -> DictConfig:
+        return OmegaConf.create(
             {
-                "dataset": "drivaer_ml_surface",
-                "extra_datasets": ["shift_suv_estate_surface"],
-                "train_split": None,
-                "val_split": None,
-                "augment": False,
+                "dataset": primary,
+                "extra_datasets": extras,
+                "train_split": train_split,
+                "val_split": val_split,
+                "augment": augment,
                 "sampling_resolution": None,
                 "input_type": "mesh",
                 "forward_kwargs": {"domain": ""},
                 "training": {"batch_size": 1, "seed": 0},
-                "dataloader": {"num_workers": 1, "pin_memory": False},
+                "dataloader": {
+                    "num_workers": 1,
+                    "pin_memory": False,
+                    "prefetch_factor": 0,
+                },
             }
         )
 
-        with pytest.raises(NotImplementedError, match="multi-dataset manifest mode"):
-            build_dataloaders(cfg)
+    def test_multiple_manifest_datasets_use_global_offsets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Every manifest contributes offset train and val selections."""
+        first_root = tmp_path / "first"
+        second_root = tmp_path / "second"
+        first_root.mkdir()
+        second_root.mkdir()
+        self._make_datadir(first_root, n_samples=4)
+        self._make_datadir(second_root, n_samples=3)
+        (first_root / "manifest.json").write_text(
+            json.dumps({"train": ["run_1", "run_3"], "val": ["run_0"]})
+        )
+        (second_root / "manifest.json").write_text(
+            json.dumps({"train": ["run_0", "run_2"], "val": ["run_1"]})
+        )
+        configs = {
+            "drivaer_ml_surface": self._augmented_ds_yaml(first_root),
+            "shift_suv_estate_surface": self._augmented_ds_yaml(second_root),
+        }
+        self._patch_configs(monkeypatch, configs)
+
+        train_loader, val_loader, _, _ = build_dataloaders(
+            self._loader_cfg(
+                "drivaer_ml_surface",
+                ["shift_suv_estate_surface"],
+                train_split="train",
+                val_split="val",
+                augment=True,
+            )
+        )
+
+        ### The second dataset begins at global index 4 in both combined
+        ### datasets: local train [0, 2] -> [4, 6], local val [1] -> [5].
+        assert sorted(train_loader.sampler) == [1, 3, 4, 6]
+        assert list(val_loader.sampler) == [0, 5]
+        assert len(train_loader.dataset) == len(val_loader.dataset) == 7
+        assert all(
+            any(getattr(transform, "stochastic", False) for transform in ds.transforms)
+            for ds in train_loader.dataset._datasets
+        )
+        assert all(
+            not any(
+                getattr(transform, "stochastic", False) for transform in ds.transforms
+            )
+            for ds in val_loader.dataset._datasets
+        )
+
+    def test_offsets_resolve_to_the_intended_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The offset indices address the runs the manifests actually name.
+
+        Asserting index *numbers* only checks the arithmetic against
+        itself. This walks ``MultiDataset``'s own global -> (dataset,
+        local) mapping back to reader paths, which is the property that
+        actually matters: mis-offset indices silently train on another
+        dataset's samples.
+        """
+        roots = []
+        for name, n_samples, manifest in (
+            ("first", 4, {"train": ["run_2", "run_3"], "val": ["run_0", "run_1"]}),
+            ("second", 3, {"train": ["run_0"], "val": ["run_1"]}),
+            ("third", 2, {"train": ["run_1"], "val": ["run_0"]}),
+        ):
+            root = tmp_path / name
+            root.mkdir()
+            self._make_datadir(root, n_samples=n_samples)
+            (root / "manifest.json").write_text(json.dumps(manifest))
+            roots.append(root)
+        names = [
+            "drivaer_ml_surface",
+            "shift_suv_estate_surface",
+            "shift_suv_fastback_surface",
+        ]
+        self._patch_configs(
+            monkeypatch,
+            {name: self._augmented_ds_yaml(root) for name, root in zip(names, roots)},
+        )
+
+        train_loader, val_loader, _, _ = build_dataloaders(
+            self._loader_cfg(names[0], names[1:], train_split="train", val_split="val")
+        )
+
+        def resolved(dataset, global_index: int) -> str:
+            ds_idx, local = dataset._index_to_dataset_and_local(global_index)
+            path = dataset._datasets[ds_idx].reader._paths[local]
+            return str(path.relative_to(tmp_path))
+
+        train_files = {resolved(train_loader.dataset, i) for i in train_loader.sampler}
+        val_files = {resolved(val_loader.dataset, i) for i in val_loader.sampler}
+        assert train_files == {
+            "first/run_2/domain_2.pdmsh",
+            "first/run_3/domain_3.pdmsh",
+            "second/run_0/domain_0.pdmsh",
+            "third/run_1/domain_1.pdmsh",
+        }
+        assert val_files == {
+            "first/run_0/domain_0.pdmsh",
+            "first/run_1/domain_1.pdmsh",
+            "second/run_1/domain_1.pdmsh",
+            "third/run_0/domain_0.pdmsh",
+        }
+        ### The pre-offset bug trained on the first dataset's held-out runs.
+        assert train_files.isdisjoint(val_files)
+
+    def test_distributed_ranks_shard_the_combined_indices(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Sharding partitions the concatenated selection, not one dataset's."""
+        first_root = tmp_path / "first"
+        second_root = tmp_path / "second"
+        first_root.mkdir()
+        second_root.mkdir()
+        self._make_datadir(first_root, n_samples=4)
+        self._make_datadir(second_root, n_samples=3)
+        (first_root / "manifest.json").write_text(
+            json.dumps({"train": ["run_1", "run_3"], "val": ["run_0"]})
+        )
+        (second_root / "manifest.json").write_text(
+            json.dumps({"train": ["run_0", "run_2"], "val": ["run_1"]})
+        )
+        configs = {
+            "drivaer_ml_surface": self._augmented_ds_yaml(first_root),
+            "shift_suv_estate_surface": self._augmented_ds_yaml(second_root),
+        }
+
+        per_rank_train, per_rank_val = [], []
+        for rank in range(2):
+            with monkeypatch.context() as ctx:
+                self._patch_configs(ctx, configs, world_size=2, rank=rank)
+                train_loader, val_loader, _, _ = build_dataloaders(
+                    self._loader_cfg(
+                        "drivaer_ml_surface",
+                        ["shift_suv_estate_surface"],
+                        train_split="train",
+                        val_split="val",
+                    )
+                )
+                per_rank_train.append(list(train_loader.sampler))
+                per_rank_val.append(list(val_loader.sampler))
+
+        ### 4 train indices over 2 ranks divides evenly, so drop_last keeps
+        ### all of them; each rank sees half, and no sample is duplicated.
+        assert [len(shard) for shard in per_rank_train] == [2, 2]
+        assert sorted(per_rank_train[0] + per_rank_train[1]) == [1, 3, 4, 6]
+        assert set(per_rank_train[0]).isdisjoint(per_rank_train[1])
+        ### Validation spans both datasets rather than one rank's slice.
+        assert sorted(per_rank_val[0] + per_rank_val[1]) == [0, 5]
+
+    @pytest.mark.parametrize("manifest_first", [True, False])
+    def test_mixed_manifest_and_directory_offsets_are_split_specific(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        manifest_first: bool,
+    ):
+        """Directory ranges and manifest selections share each split's index space."""
+        manifest_root = tmp_path / "manifest"
+        directory_root = tmp_path / "directory"
+        directory_val_root = tmp_path / "directory_val"
+        for root, n_samples in (
+            (manifest_root, 3),
+            (directory_root, 4),
+            (directory_val_root, 2),
+        ):
+            root.mkdir()
+            self._make_datadir(root, n_samples=n_samples)
+        train_manifest = tmp_path / "train.txt"
+        val_manifest = tmp_path / "val.txt"
+        train_manifest.write_text("run_2\n")
+        val_manifest.write_text("run_0\n")
+        manifest_name = "drivaer_ml_surface"
+        directory_name = "shift_suv_estate_surface"
+        configs = {
+            manifest_name: OmegaConf.merge(
+                self._augmented_ds_yaml(manifest_root),
+                {
+                    "train_manifest": str(train_manifest),
+                    "val_manifest": str(val_manifest),
+                },
+            ),
+            directory_name: OmegaConf.merge(
+                self._augmented_ds_yaml(directory_root),
+                {"val_datadir": str(directory_val_root)},
+            ),
+        }
+        self._patch_configs(monkeypatch, configs)
+        ordered_names = (
+            [manifest_name, directory_name]
+            if manifest_first
+            else [directory_name, manifest_name]
+        )
+
+        train_loader, val_loader, _, _ = build_dataloaders(
+            self._loader_cfg(
+                ordered_names[0],
+                ordered_names[1:],
+                train_split=None,
+                val_split=None,
+            )
+        )
+
+        if manifest_first:
+            ### Train offsets: manifest len=3; val offsets: manifest len=3.
+            expected_train = [2, 3, 4, 5, 6]
+            expected_val = [0, 3, 4]
+        else:
+            ### Train offsets: directory len=4; val offsets: directory val len=2.
+            expected_train = [0, 1, 2, 3, 6]
+            expected_val = [0, 1, 2]
+        assert sorted(train_loader.sampler) == expected_train
+        assert list(val_loader.sampler) == expected_val
+        assert len(train_loader.dataset) == 7
+        assert len(val_loader.dataset) == 5
+
+    def test_missing_val_manifest_falls_back_before_offsetting(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A per-dataset train fallback cannot capture another dataset's indices."""
+        first_root = tmp_path / "first"
+        second_root = tmp_path / "second"
+        first_root.mkdir()
+        second_root.mkdir()
+        self._make_datadir(first_root, n_samples=3)
+        self._make_datadir(second_root, n_samples=2)
+        first_train = tmp_path / "first_train.txt"
+        second_train = tmp_path / "second_train.txt"
+        second_val = tmp_path / "second_val.txt"
+        first_train.write_text("run_1\n")
+        second_train.write_text("run_0\n")
+        second_val.write_text("run_1\n")
+        configs = {
+            "drivaer_ml_surface": OmegaConf.merge(
+                self._augmented_ds_yaml(first_root),
+                {"train_manifest": str(first_train)},
+            ),
+            "shift_suv_estate_surface": OmegaConf.merge(
+                self._augmented_ds_yaml(second_root),
+                {
+                    "train_manifest": str(second_train),
+                    "val_manifest": str(second_val),
+                },
+            ),
+        }
+        self._patch_configs(monkeypatch, configs)
+
+        with caplog.at_level(logging.WARNING, logger="training.datasets"):
+            train_loader, val_loader, _, _ = build_dataloaders(
+                self._loader_cfg(
+                    "drivaer_ml_surface",
+                    ["shift_suv_estate_surface"],
+                    train_split=None,
+                    val_split=None,
+                )
+            )
+
+        ### First local train/val [1]; second starts at 3 and contributes
+        ### local train [0] / val [1].
+        assert sorted(train_loader.sampler) == [1, 3]
+        assert list(val_loader.sampler) == [1, 4]
+        assert any("drivaer_ml_surface" in record.message for record in caplog.records)


### PR DESCRIPTION
## What

Follow-up to #1859. Implements the offset-shifted manifest indices that
#1859 deliberately deferred, and removes the `NotImplementedError` guard
it added.

## Why

Manifest split indices are local to a single reader, but the sampler
addresses the concatenated `MultiDataset`. Before #1859, choosing more
than one manifest dataset meant the last one's indices overwrote the
others and were applied to the whole concatenation — so training ran on
the wrong samples, silently.

I reproduced this on the pre-#1859 tree. Two manifest datasets, `a` (4
runs, val = `run_0`/`run_1`) and `b` (2 runs):

```
train: ['a/run_0/domain_0.pdmsh']    <-- a's held-out val run
val:   ['a/run_1/domain_1.pdmsh']
```

Training on a validation run, `b` never sampled at all, and no error.

#1859 correctly converted that into a loud failure. But every dataset
YAML in this recipe is manifest-mode — none defines a `val_datadir` —
so the guard also blocks the multi-dataset recipe the README documents
(Transolver across DrivAerML + SHIFT SUV), leaving `extra_datasets`
unusable for any combination. #1859's docstring assumed the SHIFT SUV
datasets were directory-mode; they auto-discover a `manifest.json` next
to `train_datadir`.

## How

Accumulate offset-shifted indices per dataset. Each dataset's local
train/val indices are shifted by its cumulative offset in the
corresponding `MultiDataset`. Train and val offsets are tracked
separately, because the two concatenations diverge whenever a dataset
contributes to one split but not the other (a directory dataset with no
`val_datadir`, or an `augment=True` run that builds a second
un-augmented reader for validation).

Directory-mode datasets contribute their full local ranges, so the two
modes can be combined in one run. The missing-val-split fallback moves
into the per-dataset loop, ahead of offsetting, so it can no longer
capture a neighbouring dataset's indices.

Same scenario on this branch:

```
train: ['a/run_2', 'a/run_3', 'b/run_0']
val:   ['a/run_0', 'a/run_1', 'b/run_1']
```

## Also

`resolve_manifest_spec` now warns when a dataset falls back to directory
mode while a `manifest.json` sits next to its `train_datadir`. Clearing
the top-level split selectors is how a manifest/directory mix is
configured, so this is easy to reach — and left silent it sweeps the
manifest's held-out val/test runs into training.

## Testing

`examples/.../unified_external_aero_recipe/tests/`: 165 passed (161 + 4).
New coverage: multi-manifest offsets, mixed manifest/directory ordering
in both orders, the per-dataset val fallback, distributed sharding over
the combined index space, and — the property that actually matters —
that indices resolve back through `MultiDataset`'s own global → (dataset,
local) mapping to the runs the manifests name.

Mutation-checked: swapping `val_offset` for `train_offset` fails 6 tests,
including all the new ones.
