### PR TITLE
Mesh: make FEM regularization scale-free and avoid linalg synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   norms, but a custom `norm` that relies on unobserved entries being zeroed
   before the call may differ. The integer `norm` selector (e.g. `norm=2`) is
   unaffected.
+- `Mesh.transform` and `compute_cotan_weights_fem` now use the non-checking
+  `torch.linalg.inv_ex` / `solve_ex` solvers, and build their index tensors on
+  device. The checked solvers read a status code back to the host on every call,
+  which synchronizes on CUDA; removing that and the index-tensor uploads takes
+  `Mesh.transform` on a cached codimension-one mesh from three host
+  synchronizations to one, and `compute_cotan_weights_fem` from six to three. As
+  a consequence,
+  `Mesh.transform(..., assume_invertible=True)` no longer raises when the matrix
+  is in fact singular: it propagates NaN caches instead, as its docstring now
+  documents. The default `assume_invertible=None` still tests the determinant
+  and is unaffected.
 
 ### Deprecated
 
@@ -311,6 +322,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `compute_cotan_weights_fem`, and the calculus, curvature, and smoothing
+  routines built on it such as `Mesh.laplacian`, no longer fail on degenerate
+  cells in float32. The Gram-matrix regularization is now scale-free, so it also
+  covers cells with no extent — including the null cells that `Mesh.pad` and
+  `Mesh.pad_to_next_power` insert — and flat cells at large coordinate values,
+  both of which previously raised a singular-matrix `_LinAlgError` from
+  `torch.linalg.inv`. Weights for non-degenerate cells are unchanged bit for bit.
 - Multinomial index sampling now uses one shared `weighted_multinomial`
   functional across datapipes, DoMINO, and remeshing. Its core API follows
   `torch.multinomial`, adds allocation-free integer input for uniform

--- a/physicsnemo/mesh/geometry/dual_meshes.py
+++ b/physicsnemo/mesh/geometry/dual_meshes.py
@@ -562,8 +562,6 @@ def compute_cotan_weights_fem(
     >>> weights, edges = compute_cotan_weights_fem(mesh)
     >>> # weights[i] is the cotangent weight for edges[i]
     """
-    from itertools import combinations
-
     from physicsnemo.mesh.utilities._topology import extract_unique_edges
 
     device = mesh.points.device
@@ -593,26 +591,40 @@ def compute_cotan_weights_fem(
     # G: (n_cells, n_manifold_dims, n_manifold_dims)
     G = E @ E.transpose(-1, -2)
 
-    ### Handle degenerate cells by regularizing singular Gram matrices
-    # Degenerate cells (collinear/coplanar vertices) have det(G) ~ 0.
-    # We regularize these so that torch.linalg.inv doesn't produce NaN,
-    # then zero out their contributions via the cell volume (which is also ~0).
-    det_G = torch.linalg.det(G)  # (n_cells,)
-    # Scale-aware degeneracy threshold: compare det against typical edge length
-    # raised to the 2n power (since det(G) has units of length^{2n})
-    edge_length_scale = E.norm(dim=-1).mean(dim=-1).clamp(min=1e-30)  # (n_cells,)
-    det_threshold = (edge_length_scale ** (2 * n_manifold_dims)) * 1e-12
-    is_degenerate = det_G.abs() < det_threshold  # (n_cells,)
+    ### Handle degenerate cells by substituting an isotropic Gram matrix
+    # Degenerate cells (collinear/coplanar vertices) have det(G) ~ 0, so inverting
+    # G as-is would fail. Their contribution is meant to vanish anyway, because
+    # their cell volume is ~0, so we swap in an isotropic Gram matrix of the same
+    # magnitude: strictly positive and diagonal, hence exactly invertible, and
+    # scaled so that the volume suppresses the contribution at any coordinate
+    # scale. (Adding a bare identity instead would be a no-op once the entries of
+    # G exceed the dtype's unit-in-last-place, leaving G singular.)
 
-    # Add identity to degenerate Gram matrices to make them invertible.
-    # The contribution from these cells will be zeroed by cell_volumes ~ 0.
+    # A cell's mean edge length is its natural scale. Floor it where squaring
+    # would underflow, so g_scale -- the magnitude of an entry of G -- is always a
+    # normal positive number and G / g_scale is a dimensionless O(1) matrix.
+    edge_length_scale = E.norm(dim=-1).mean(dim=-1)  # (n_cells,)
+    has_extent = edge_length_scale > torch.finfo(dtype).tiny ** 0.5  # (n_cells,)
+    g_scale = torch.where(has_extent, edge_length_scale, 1.0).square()  # (n_cells,)
+
+    # det(G) == det(G / g_scale) * g_scale**n, so thresholding the dimensionless
+    # determinant applies exactly the same criterion as a scale-aware threshold on
+    # det(G), without the under/overflow that the g_scale**n factor would suffer.
+    # Cells with no usable extent carry no direction at all, so are always degenerate.
     # Written branchlessly so torch.compile can trace through without graph breaks.
+    is_degenerate = ~has_extent | (
+        torch.linalg.det(G / g_scale[:, None, None]).abs() < 1e-12
+    )  # (n_cells,)
     eye = torch.eye(n_manifold_dims, dtype=dtype, device=device)
-    G = G + is_degenerate.float().unsqueeze(-1).unsqueeze(-1) * eye
+    G = torch.where(is_degenerate[:, None, None], g_scale[:, None, None] * eye, G)
 
     ### Invert Gram matrix
     # G_inv: (n_cells, n_manifold_dims, n_manifold_dims)
-    G_inv = torch.linalg.inv(G)
+    # Every G is now invertible by construction: degenerate cells hold a positive
+    # diagonal matrix, and the rest satisfy |det(G / g_scale)| >= 1e-12. So the
+    # non-checking ``inv_ex`` variant is safe here, and it spares CUDA callers a
+    # device-to-host synchronization made solely for error reporting.
+    G_inv = torch.linalg.inv_ex(G, check_errors=False).inverse
 
     ### Build the gradient dot product matrix C = H @ G_inv @ H^T
     # H: (n_verts_per_cell, n_manifold_dims) = [[-1,...,-1]; I_n]
@@ -626,10 +638,12 @@ def compute_cotan_weights_fem(
     C = H.unsqueeze(0) @ G_inv @ H.T.unsqueeze(0)
 
     ### Extract gradient dot products for each local edge pair
-    # Local edge pairs in combinations order (matches extract_candidate_facets)
-    local_pairs = list(combinations(range(n_verts_per_cell), 2))
-    pair_i = torch.as_tensor([p[0] for p in local_pairs], device=device)
-    pair_j = torch.as_tensor([p[1] for p in local_pairs], device=device)
+    # Upper-triangle order is itertools.combinations order, which is the local edge
+    # order that extract_candidate_facets produces. Building the indices on-device
+    # avoids the host-to-device copy (and its synchronization) a Python list needs.
+    pair_i, pair_j = torch.triu_indices(
+        n_verts_per_cell, n_verts_per_cell, offset=1, device=device
+    )
 
     # grad_dots: (n_cells, n_pairs) - one value per cell per local edge
     grad_dots = C[:, pair_i, pair_j]

--- a/physicsnemo/mesh/transformations/geometric.py
+++ b/physicsnemo/mesh/transformations/geometric.py
@@ -461,9 +461,20 @@ def transform(
     assume_invertible : bool or None
         Controls cache propagation for square matrices:
 
-        - True: Assume matrix is invertible, propagate caches (compile-safe)
-        - False: Assume matrix is singular, skip cache propagation (compile-safe)
-        - None: Check determinant at runtime (may cause graph breaks under torch.compile)
+        - ``True``: assume ``matrix`` is invertible and propagate caches
+          (compile-safe). This is a promise, not a check. If ``matrix`` is in
+          fact singular, the inverse-transpose step silently yields non-finite
+          values instead of raising, so the propagated ``normals`` and ``areas``
+          caches -- and anything derived from them, such as the sum of
+          ``cell_areas`` -- come back as NaN. Use ``False`` or ``None`` unless
+          you know the matrix is non-singular.
+        - ``False``: assume ``matrix`` is singular and skip cache propagation
+          (compile-safe). Caches are dropped and recomputed lazily on demand,
+          which is always correct, just slower.
+        - ``None`` (default): test ``abs(det(matrix)) > 1e-10`` at runtime and
+          take one of the branches above. Safe for singular input, but the test
+          reads a device scalar back to the host, which synchronizes on CUDA and
+          may cause graph breaks under ``torch.compile``.
 
     Returns
     -------
@@ -526,7 +537,9 @@ def transform(
             elif mesh.codimension == 1:
                 ### Cell (face) normals: the inverse-transpose law is exact per face.
                 if (v := mesh._cache.get(("cell", "normals"), None)) is not None:
-                    transformed = torch.linalg.solve(matrix.T, v.T).T
+                    transformed = torch.linalg.solve_ex(
+                        matrix.T, v.T, check_errors=False
+                    ).result.T
                     norm_scale = transformed.norm(dim=-1)
                     if (areas := mesh._cache.get(("cell", "areas"), None)) is not None:
                         new_cache["cell", "areas"] = areas * det_abs * norm_scale
@@ -552,7 +565,9 @@ def transform(
                         and _is_similarity_transform(matrix)
                     )
                 ):
-                    transformed = torch.linalg.solve(matrix.T, v.T).T
+                    transformed = torch.linalg.solve_ex(
+                        matrix.T, v.T, check_errors=False
+                    ).result.T
                     new_cache["point", "normals"] = det_sign * F.normalize(
                         transformed, dim=-1
                     )

--- a/test/mesh/geometry/test_dual_meshes.py
+++ b/test/mesh/geometry/test_dual_meshes.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Robustness of the FEM cotangent weights against degenerate cells.
+
+``compute_cotan_weights_fem`` inverts a per-cell Gram matrix. Degenerate cells make
+that matrix singular, so it substitutes an isotropic one for them. These tests pin
+the two ways that substitution has to stay scale-free: it must handle cells with no
+extent at all, and cells that are flat but live at large coordinate values.
+"""
+
+import pytest
+import torch
+
+from physicsnemo.mesh import Mesh
+from physicsnemo.mesh.geometry.dual_meshes import compute_cotan_weights_fem
+from physicsnemo.mesh.primitives import surfaces
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_padding_leaves_cotan_weights_unchanged(device, dtype) -> None:
+    """``Mesh.pad`` promises null cells that don't affect computations.
+
+    Padding cells put every vertex on the same point, so their edge matrix is
+    exactly zero and their Gram matrix is exactly singular. Regularizing by adding
+    a bare identity used to leave that untouched in float32, because the degeneracy
+    threshold underflowed, so the inverse raised and ``laplacian`` died on any
+    padded float32 mesh.
+    """
+    base = surfaces.sphere_uv.load(theta_resolution=8, phi_resolution=8)
+    mesh = Mesh(
+        points=base.points.to(dtype=dtype, device=device),
+        cells=base.cells.to(device=device),
+    )
+    padded = mesh.pad_to_next_power()
+    assert padded.n_cells > mesh.n_cells, "test needs padding to actually happen"
+
+    weights, edges = compute_cotan_weights_fem(mesh)
+    padded_weights, padded_edges = compute_cotan_weights_fem(padded)
+
+    n_real = len(edges)
+    torch.testing.assert_close(padded_edges[:n_real], edges)
+    torch.testing.assert_close(padded_weights[:n_real], weights)
+    # Edges that exist only because of the padding must carry no weight at all.
+    assert bool((padded_weights[n_real:] == 0).all())
+
+    # The public entry point that the singular inverse used to break.
+    values = torch.ones(padded.n_points, dtype=dtype, device=device)
+    assert bool(torch.isfinite(padded.laplacian(values)).all())
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_degenerate_cell_weights_are_finite_and_scale_invariant(device, dtype) -> None:
+    """A flat cell must be neutralised at any coordinate scale.
+
+    Cotangent weights on a 2-manifold are dimensionless, so scaling the mesh must
+    not move them. Adding a bare identity to the Gram matrix broke that: it is a
+    no-op once the entries of G exceed the dtype's unit-in-last-place, which for
+    float32 happens around coordinates of 1e4 -- a car body measured in
+    millimetres. Such a cell stayed exactly singular and the inverse raised.
+    """
+    # Cell 0 is collinear (degenerate); cell 1 is a healthy right triangle. They
+    # share an edge, so a mishandled cell 0 would also corrupt cell 1's weights.
+    unit_points = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        dtype=dtype,
+        device=device,
+    )
+    cells = torch.tensor([[0, 1, 2], [0, 1, 3]], dtype=torch.long, device=device)
+
+    reference = None
+    for scale in (1.0, 1e2, 1e4, 1e6):
+        mesh = Mesh(points=unit_points * scale, cells=cells)
+        weights, _ = compute_cotan_weights_fem(mesh)
+
+        assert bool(torch.isfinite(weights).all()), f"non-finite weights at {scale=}"
+        if reference is None:
+            reference = weights
+        else:
+            torch.testing.assert_close(
+                weights, reference, msg=f"weights changed at {scale=}"
+            )

--- a/test/mesh/misc/test_sync_free_linalg.py
+++ b/test/mesh/misc/test_sync_free_linalg.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for synchronization-free mesh linear algebra.
+
+``torch.linalg.inv`` and ``torch.linalg.solve`` read a LAPACK/cuSOLVER status code
+back to the host purely so they can raise on singular input, which costs a
+device-to-host synchronization on every call. The mesh hot paths use the ``_ex``
+variants with ``check_errors=False`` instead. These tests pin both halves of that
+trade: that the synchronization is really gone, and what the lost error check now
+means for callers who feed in a singular matrix anyway.
+"""
+
+import pytest
+import torch
+
+from physicsnemo.mesh import Mesh
+from physicsnemo.mesh.geometry.dual_meshes import compute_cotan_weights_fem
+from physicsnemo.mesh.transformations.geometric import transform
+
+_CUDA = torch.cuda.is_available()
+
+
+def _curve_mesh(device: torch.device | str) -> Mesh:
+    """Return a non-axis-aligned 1-manifold with all normal caches populated."""
+    mesh = Mesh(
+        points=torch.tensor(
+            [[0.0, 0.0], [1.0, 0.25], [1.5, 1.5]],
+            dtype=torch.float64,
+            device=device,
+        ),
+        cells=torch.tensor([[0, 1], [1, 2]], dtype=torch.long, device=device),
+    )
+    _ = mesh.cell_areas
+    _ = mesh.cell_normals
+    _ = mesh.point_normals
+    return mesh
+
+
+def _triangle_mesh(device: torch.device | str) -> Mesh:
+    return Mesh(
+        points=torch.tensor(
+            [[0.0, 0.0], [1.25, 0.1], [0.2, 1.1]],
+            dtype=torch.float64,
+            device=device,
+        ),
+        cells=torch.tensor([[0, 1, 2]], dtype=torch.long, device=device),
+    )
+
+
+def test_singular_matrix_with_assume_invertible_poisons_caches(device) -> None:
+    """``assume_invertible=True`` is a promise, and breaking it is now silent.
+
+    Without the error check there is nothing left to detect a singular matrix, so
+    the inverse-transpose step yields non-finite values and they reach the caller
+    through the ordinary accessors rather than through an exception. This is the
+    documented contract for ``assume_invertible=True``; the point of pinning it is
+    that ``assume_invertible=None`` must remain the safe default.
+    """
+    mesh = _curve_mesh(device)
+    # Rank-1 projection onto the x-axis: singular, and a plausible user input.
+    singular = torch.tensor(
+        [[1.0, 0.0], [0.0, 0.0]], dtype=mesh.points.dtype, device=device
+    )
+
+    promised = transform(mesh, singular, assume_invertible=True)
+    assert not bool(torch.isfinite(promised.cell_normals).any())
+    assert not bool(torch.isfinite(promised.cell_areas).any())
+    assert not bool(torch.isfinite(promised.point_normals).any())
+
+    # The escape hatches must still be safe: both drop the caches and recompute.
+    for kwargs in ({}, {"assume_invertible": False}):
+        checked = transform(mesh, singular, **kwargs)
+        assert ("cell", "normals") not in checked._cache.keys(include_nested=True)
+        assert bool(torch.isfinite(checked.cell_areas).all())
+
+
+@pytest.mark.skipif(not _CUDA, reason="CUDA required to detect host synchronizations")
+def test_cotan_weight_inverse_is_sync_free(monkeypatch) -> None:
+    """FEM Gram-matrix inversion must not synchronize CUDA for error checks."""
+    device = torch.device("cuda")
+    mesh = _triangle_mesh(device)
+    _ = mesh.cell_areas
+
+    # Topology extraction has independently data-dependent output. Replace it
+    # with the known topology so this test isolates the fixed-size inversion.
+    edges = torch.tensor([[0, 1], [0, 2], [1, 2]], device=device)
+    inverse = torch.arange(3, device=device)
+    from physicsnemo.mesh.utilities import _topology
+
+    monkeypatch.setattr(_topology, "extract_unique_edges", lambda _: (edges, inverse))
+
+    # Warm lazy CUDA-library initialization and allocator growth outside the guard.
+    compute_cotan_weights_fem(mesh)
+    torch.cuda.synchronize()
+
+    # The surrounding topology path contains separate data-dependent indexing,
+    # so guard the inversion call itself. The called assertion also makes this a
+    # regression test against reverting to the synchronizing ``linalg.inv``.
+    original_inv_ex = torch.linalg.inv_ex
+    called = False
+
+    def checked_inv_ex(*args, **kwargs):
+        nonlocal called
+        called = True
+        previous_mode = torch.cuda.get_sync_debug_mode()
+        torch.cuda.set_sync_debug_mode("error")
+        try:
+            return original_inv_ex(*args, **kwargs)
+        finally:
+            torch.cuda.set_sync_debug_mode(previous_mode)
+
+    monkeypatch.setattr(torch.linalg, "inv_ex", checked_inv_ex)
+    compute_cotan_weights_fem(mesh)
+    torch.cuda.synchronize()
+    assert called
+
+
+@pytest.mark.skipif(not _CUDA, reason="CUDA required to detect host synchronizations")
+def test_cached_normal_transformation_is_sync_free() -> None:
+    """Inverse-transpose cache propagation must not synchronize CUDA.
+
+    A 1-manifold with ``assume_invertible=True`` is the configuration in which
+    ``transform`` has no other reason to synchronize: it skips both the runtime
+    determinant test and the similarity test, which are host reads of a device
+    scalar. Keep it that way when editing this test -- ``set_sync_debug_mode`` is a
+    prototype feature, and a ``bool(cuda_tensor)`` under it has been observed to
+    abort the interpreter rather than raise, which would take the whole session
+    down instead of failing one test.
+    """
+    device = torch.device("cuda")
+    mesh = _curve_mesh(device)
+    matrix = torch.tensor(
+        [[1.75, 0.3], [-0.2, 1.25]], dtype=mesh.points.dtype, device=device
+    )
+
+    transform(mesh, matrix, assume_invertible=True)
+    torch.cuda.synchronize()
+
+    previous_mode = torch.cuda.get_sync_debug_mode()
+    torch.cuda.set_sync_debug_mode("error")
+    try:
+        transform(mesh, matrix, assume_invertible=True)
+    finally:
+        torch.cuda.set_sync_debug_mode(previous_mode)
+    torch.cuda.synchronize()


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

FEM cotangent weights regularize singular Gram matrices by adding an unscaled identity. That addition can underflow or fall below one ULP at realistic coordinate scales, leaving padded or degenerate cells singular. Checked `torch.linalg.inv` and `solve` also synchronize CUDA solely to inspect solver status at call sites where invertibility is already established or explicitly promised.

This PR:

- Detects degeneracy with a dimensionless determinant and substitutes a scale-matched positive diagonal Gram matrix for degenerate cells.
- Uses `inv_ex` and `solve_ex` without status checks where invertibility is guaranteed by construction or by `assume_invertible=True`.
- Builds local edge indices directly on-device instead of uploading Python lists.
- Documents the `assume_invertible` contract and adds regression coverage for padded, collapsed, and large-scale degenerate cells.

## Verification

- `pytest test/mesh`: 2347 passed, 708 skipped.
- Cotangent weights for non-degenerate cells are bit-identical to `main` across float dtypes, manifold dimensions 1-3, and coordinate scales from `1e-6` to `1e6`.
- Measured CUDA host synchronizations: cotangent FEM 6 to 3, `transform(assume_invertible=True)` 3 to 1, and default `transform()` 4 to 2.
- `ruff check` and `ruff format --check` pass for all changed files.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [x] Model implementation standards are not applicable; no model code is changed.

## Dependencies

None.

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score. This score reflects the AI's assessment of merge readiness and is **not** a qualitative judgment of the work or an indication that the PR will be accepted or rejected.

AI-generated feedback should be reviewed critically for usefulness. You are not required to respond to every AI comment, but they are intended to help both authors and reviewers. Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.