### PR TITLE
Mesh: preserve empty tensors in memmap serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   broke the `test_get_checkpoint_dir` CI test on Windows. The function now
   always joins with `/`, working uniformly for local paths and `fsspec`
   URIs (`msc://`, etc.) across operating systems.
+- Fixed two `Mesh.save`/`Mesh.load` (memmap) defects. First, zero-element
+  tensors were silently lost: TensorDict records their shape and dtype in
+  `meta.json` but writes no backing file, and its loader skips any key whose
+  file is absent. A `cells` of shape `(0, 3)` came back as `(0, 1)` with a
+  different dtype (silently changing `n_manifold_dims`), zero-width
+  `point_data` / `cell_data` / `global_data` fields disappeared, and a mesh
+  with no points, or with an `Adjacency` cached over a point cloud, failed to
+  load at all. `Mesh`, `DomainMesh`, `Adjacency`, `BVH`, `ClusterTree`,
+  `DualInteractionPlan`, and `SourceAggregates` now rebuild those tensors from
+  metadata on load. Second, and independently of empty tensors, loading any
+  mesh with a populated topology cache in a process that had not otherwise
+  imported the adjacency API raised
+  `RuntimeError: Could not find name ...Adjacency` — the offline-preprocess /
+  dataloader-worker pattern. Importing `Mesh` now registers `Adjacency` with
+  TensorDict. Both fixes are read-side only: the on-disk format is unchanged
+  and files remain byte-identical and compatible in both directions.
 
 ### Security
 

--- a/physicsnemo/mesh/domain_mesh.py
+++ b/physicsnemo/mesh/domain_mesh.py
@@ -27,6 +27,9 @@ from tensordict import TensorDict, tensorclass
 
 from physicsnemo.mesh.mesh import Mesh, _requested_float_dtype
 from physicsnemo.mesh.transformations.deform.ffd import _FFDBasis
+from physicsnemo.mesh.utilities._serialization import (
+    _load_memmap_with_empty_tensors,
+)
 from physicsnemo.mesh.utilities.mesh_repr import format_mesh_repr
 
 if TYPE_CHECKING:
@@ -1684,3 +1687,10 @@ def _domain_mesh_to(self, *args: Any, **kwargs: Any) -> "DomainMesh":
 
 _tensorclass_domain_to = DomainMesh.to  # the generated tensorclass ``to``
 DomainMesh.to = _domain_mesh_to  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+
+
+# Preserve zero-element domain-level fields and delegate nested Mesh loading to
+# Mesh's corresponding format-compatible memmap loader.
+DomainMesh._load_memmap = classmethod(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    _load_memmap_with_empty_tensors
+)

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -48,6 +48,13 @@ from physicsnemo.mesh.calculus import (
 )
 from physicsnemo.mesh.geometry._cell_areas import compute_cell_areas
 from physicsnemo.mesh.geometry._cell_normals import compute_cell_normals
+
+# Imported at runtime, not merely for typing: a saved Mesh's topology cache can
+# hold `Adjacency` entries, and TensorDict can only reconstruct a tensorclass it
+# has already seen registered. Without this, loading such a mesh in a process
+# that has not otherwise touched the adjacency API fails with
+# `RuntimeError: Could not find name ...Adjacency`.
+from physicsnemo.mesh.neighbors._adjacency import Adjacency
 from physicsnemo.mesh.transformations.deform import (
     displace,
     free_form_deform,
@@ -62,13 +69,12 @@ from physicsnemo.mesh.transformations.geometric import (
 )
 from physicsnemo.mesh.utilities._padding import _pad_by_tiling_last, _pad_with_value
 from physicsnemo.mesh.utilities._scatter_ops import scatter_aggregate
+from physicsnemo.mesh.utilities._serialization import (
+    _load_memmap_with_empty_tensors,
+)
 from physicsnemo.mesh.utilities.mesh_repr import format_mesh_repr
 from physicsnemo.mesh.validation import validate
 from physicsnemo.mesh.visualization.draw_mesh import draw
-
-if TYPE_CHECKING:
-    from physicsnemo.mesh.neighbors._adjacency import Adjacency
-
 
 # A field on a `Mesh` is "associated with" either points (e.g. a per-vertex
 # temperature), cells (e.g. a per-element pressure), or the mesh-as-a-whole
@@ -3137,3 +3143,10 @@ def _mesh_to(self, *args: Any, **kwargs: Any) -> "Mesh":
 
 _tensorclass_mesh_to = Mesh.to  # the generated tensorclass ``to``
 Mesh.to = _mesh_to  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+
+
+# Preserve zero-element tensors -- notably a point cloud's `cells` -- which
+# TensorDict's memmap writer records in metadata but never writes to disk.
+Mesh._load_memmap = classmethod(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    _load_memmap_with_empty_tensors
+)

--- a/physicsnemo/mesh/neighbors/_adjacency.py
+++ b/physicsnemo/mesh/neighbors/_adjacency.py
@@ -24,6 +24,10 @@ import torch
 from jaxtyping import Int
 from tensordict import tensorclass
 
+from physicsnemo.mesh.utilities._serialization import (
+    _load_memmap_with_empty_tensors,
+)
+
 
 @tensorclass
 class Adjacency:
@@ -359,3 +363,11 @@ def build_adjacency_from_pairs(
         offsets=offsets,
         indices=sorted_targets,
     )
+
+
+# TensorDict's memmap writer records zero-length ``indices`` in metadata but
+# omits the backing file. Use the mesh-specific loader so an adjacency with no
+# neighbors still round-trips when stored in a Mesh topology cache.
+Adjacency._load_memmap = classmethod(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    _load_memmap_with_empty_tensors
+)

--- a/physicsnemo/mesh/spatial/bvh.py
+++ b/physicsnemo/mesh/spatial/bvh.py
@@ -34,6 +34,9 @@ from tensordict import tensorclass
 from physicsnemo.mesh.neighbors._adjacency import Adjacency, build_adjacency_from_pairs
 from physicsnemo.mesh.spatial._lbvh import build_lbvh_topology
 from physicsnemo.mesh.spatial._ragged import _ragged_arange
+from physicsnemo.mesh.utilities._serialization import (
+    _load_memmap_with_empty_tensors,
+)
 
 if TYPE_CHECKING:
     from physicsnemo.mesh.mesh import Mesh
@@ -658,3 +661,10 @@ class BVH:
             n_targets=len(self.sorted_cell_order),
         )
         return adjacency.truncate_per_source(max_candidates_per_point)
+
+
+# A BVH over a mesh with no cells has zero-length node and leaf arrays, which
+# TensorDict's memmap writer records in metadata but never writes to disk.
+BVH._load_memmap = classmethod(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    _load_memmap_with_empty_tensors
+)

--- a/physicsnemo/mesh/spatial/cluster_tree.py
+++ b/physicsnemo/mesh/spatial/cluster_tree.py
@@ -54,6 +54,9 @@ from torch.profiler import record_function
 from physicsnemo.mesh.spatial._lbvh import build_lbvh_topology
 from physicsnemo.mesh.spatial._ragged import _ragged_arange
 from physicsnemo.mesh.spatial.bvh import _compute_morton_codes
+from physicsnemo.mesh.utilities._serialization import (
+    _load_memmap_with_empty_tensors,
+)
 
 logger = logging.getLogger("mesh.spatial.cluster_tree")
 
@@ -1374,3 +1377,17 @@ def _fill_leaf_aggregates(
     aabb_min_buf[leaf_nids] = seg_min
     aabb_max_buf[leaf_nids] = seg_max
     total_area_buf[leaf_nids] = leaf_areas
+
+
+# Interaction plans routinely leave whole categories empty (a small point set
+# may have no far-field pairs at all), and TensorDict's memmap writer records
+# zero-length tensors in metadata without writing them to disk.
+ClusterTree._load_memmap = classmethod(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    _load_memmap_with_empty_tensors
+)
+DualInteractionPlan._load_memmap = classmethod(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    _load_memmap_with_empty_tensors
+)
+SourceAggregates._load_memmap = classmethod(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    _load_memmap_with_empty_tensors
+)

--- a/physicsnemo/mesh/utilities/_serialization.py
+++ b/physicsnemo/mesh/utilities/_serialization.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serialization helpers for mesh tensorclasses.
+
+TensorDict's memmap writer records every tensor's shape and dtype in
+``meta.json``, but it allocates storage with ``torch.from_file(..., size=0)``,
+which creates no file at all for a tensor with zero elements. Its loader then
+skips any key whose ``.memmap`` file is absent, so zero-element tensors are lost
+on load: a mesh's ``cells`` of shape :math:`(0, 3)` comes back as ``None`` (and
+is silently replaced with a :math:`(0, 1)` point-cloud sentinel), empty
+``point_data`` fields vanish, and an
+:class:`~physicsnemo.mesh.neighbors.Adjacency` with no neighbors raises during
+reconstruction.
+
+:func:`_load_memmap_with_empty_tensors` closes that gap purely on the read side,
+rebuilding the missing tensors from metadata that is already on disk. Nothing
+about the written format changes, so files stay byte-identical and remain
+readable by PhysicsNeMo releases that predate this module.
+
+Tensorclasses opt in by overriding their generated ``_load_memmap``::
+
+    Adjacency._load_memmap = classmethod(_load_memmap_with_empty_tensors)
+"""
+
+import json
+import math
+import pickle
+from pathlib import Path
+from typing import Any
+
+import torch
+from tensordict import TensorDict, TensorDictBase
+
+### Upstream provenance
+# ``_load_memmap_with_empty_tensors`` is a fork of the private
+# ``tensordict.tensorclass._load_memmap``, mirrored from tensordict 0.12.4.
+# Re-check it against upstream on every tensordict bump: divergence shows up as
+# tensorclass fields that quietly fail to load, not as an import error.
+#
+# The fork is necessary only because the repair has to happen *between*
+# ``TensorDict.load_memmap`` and ``cls._from_tensordict`` -- the latter runs
+# ``__post_init__``, which is exactly where a missing tensor turns into
+# corruption. There is no upstream hook in that gap.
+#
+# The durable fix belongs in ``TensorDict._load_memmap`` (``tensordict/_td.py``,
+# at the ``if not memmap_file.exists(): continue`` guard), which already holds
+# both the shape and the dtype and could allocate the empty tensor there. If
+# that lands upstream, this whole module can be deleted.
+
+
+def _restore_empty_tensors(tensordict: TensorDictBase) -> None:
+    """Rebuild the zero-element tensors that TensorDict's memmap writer omitted.
+
+    Walks ``tensordict`` and its sub-collections in place, consulting the
+    ``meta.json`` written alongside each one. Any entry the metadata declares
+    but the loader skipped is recreated with its recorded shape and dtype.
+
+    Parameters
+    ----------
+    tensordict : TensorDictBase
+        A collection freshly returned by ``load_memmap``, whose
+        ``_memmap_prefix`` still points at the directory it was read from.
+        Collections that were never memory-mapped are left untouched.
+
+    Returns
+    -------
+    None
+        ``tensordict`` is modified in place.
+
+    Notes
+    -----
+    Nested (jagged) tensors are deliberately skipped. Their recorded ``shape``
+    is the shape *of the shape tensor*, whose values live in a separate
+    ``.shape.memmap`` file, so a jagged tensor cannot be rebuilt from
+    ``meta.json`` alone. An empty jagged tensor therefore still round-trips as a
+    missing key -- a known limitation, not an oversight.
+
+    Sub-collections stored as tensorclasses, rather than as plain
+    ``TensorDict`` instances, are skipped here because each dispatches to its
+    own ``_load_memmap``. They are repaired only if that class also opts in to
+    :func:`_load_memmap_with_empty_tensors`.
+    """
+    prefix = tensordict._memmap_prefix
+    if prefix is None:
+        return
+
+    with (prefix / "meta.json").open(encoding="utf-8") as metadata_file:
+        metadata = json.load(metadata_file)
+
+    ### Rebuild this level's storage-free leaves.
+    empty_tensors: dict[str, torch.Tensor] = {}
+    for key, entry in metadata.items():
+        # Non-dict values are collection-level metadata ("shape", "device",
+        # "_type"); a "type" key marks a sub-collection, handled by recursion.
+        if not isinstance(entry, dict) or entry.get("type") is not None:
+            continue
+
+        shape, dtype_name = entry.get("shape"), entry.get("dtype")
+        if (
+            shape is None
+            or dtype_name is None
+            or entry.get("is_nested", False)  # unrecoverable; see Notes
+            or math.prod(shape) != 0  # non-empty, so it has a file and loaded
+            or key in tensordict  # already present; never clobber
+        ):
+            continue
+
+        empty_tensors[key] = torch.empty(
+            shape,
+            dtype=getattr(torch, dtype_name.removeprefix("torch.")),
+            device=tensordict.device,
+        )
+
+    if empty_tensors:
+        with tensordict.unlock_():
+            tensordict.update(empty_tensors)
+
+    ### Descend. Each sub-collection carries the prefix it was read from, which
+    # is the only reliable way to locate it on disk: the directory name is a
+    # filesystem-encoded form of the key, not the key itself.
+    for value in tensordict.values():
+        if isinstance(value, TensorDictBase):
+            _restore_empty_tensors(value)
+
+
+def _load_memmap_with_empty_tensors(
+    cls,
+    prefix: Path,
+    metadata: dict[str, Any],
+    *,
+    robust_key: bool | None,
+    **kwargs: Any,
+):
+    """Load a memory-mapped tensorclass, keeping its zero-element tensors.
+
+    Drop-in replacement for the ``_load_memmap`` classmethod that
+    ``@tensorclass`` generates. See the module docstring for why the override
+    exists and the provenance note above for its relationship to upstream.
+
+    Parameters
+    ----------
+    cls : type
+        The tensorclass being reconstructed.
+    prefix : Path
+        Directory holding the tensorclass's ``meta.json``, its ``_tensordict``
+        subdirectory, and optionally an ``other.pickle`` sidecar.
+    metadata : dict[str, Any]
+        Already-parsed contents of ``prefix / "meta.json"``.
+    robust_key : bool or None
+        Filesystem key-encoding scheme the data was written with; forwarded to
+        ``TensorDict.load_memmap`` unchanged.
+    **kwargs : Any
+        Remaining ``load_memmap`` options (``device``, ``out``), forwarded
+        unchanged.
+
+    Returns
+    -------
+    cls
+        The reconstructed tensorclass instance.
+
+    Raises
+    ------
+    ValueError
+        If ``prefix`` has no ``_tensordict`` subdirectory, which means the saved
+        directory is incomplete.
+    """
+    ### Non-tensor fields come from meta.json plus the optional pickle sidecar.
+    non_tensordict = dict(metadata)
+    non_tensordict.pop("_type", None)
+
+    other_metadata_path = prefix / "other.pickle"
+    if other_metadata_path.exists():
+        with other_metadata_path.open("rb") as other_metadata_file:
+            non_tensordict.update(pickle.load(other_metadata_file))  # noqa: S301
+
+    tensordict_prefix = prefix / "_tensordict"
+    if not tensordict_prefix.exists():
+        # Upstream tolerates this only for NonTensorData subclasses, which never
+        # route through here, so for a mesh tensorclass it is always corruption.
+        raise ValueError(
+            f"The _tensordict directory seems to be missing: {str(tensordict_prefix)!r}."
+        )
+
+    tensordict = TensorDict.load_memmap(
+        tensordict_prefix,
+        **kwargs,
+        non_blocking=False,
+        robust_key=robust_key,
+    )
+    # Must run before ``_from_tensordict``, which invokes ``__post_init__``:
+    # that is where a missing ``cells`` or ``indices`` becomes corruption.
+    _restore_empty_tensors(tensordict)
+    return cls._from_tensordict(tensordict, non_tensordict)
+
+
+__all__ = ["_load_memmap_with_empty_tensors", "_restore_empty_tensors"]

--- a/test/mesh/mesh/test_serialization.py
+++ b/test/mesh/mesh/test_serialization.py
@@ -16,14 +16,21 @@
 
 """Tests for Mesh serialization round-trips (memmap and pickle).
 
-The tensordict memmap format does not serialize tensors with 0 elements. This means
-that point clouds (where cells has shape (0, 1)) lose their cells tensor on save/load,
-causing downstream failures in n_manifold_dims, repr, and any method that accesses cells.
-These tests verify that __post_init__ correctly restores empty cells tensors.
+TensorDict records zero-element tensors in memmap metadata but does not write a
+backing file for them. These tests verify that mesh serialization reconstructs
+those tensors with their original shape and dtype.
 """
 
-import torch
+import os
+import shutil
+import subprocess
+import sys
 
+import pytest
+import torch
+from tensordict import TensorDict
+
+from physicsnemo.mesh.domain_mesh import DomainMesh
 from physicsnemo.mesh.mesh import Mesh
 from physicsnemo.mesh.primitives.basic import two_triangles_2d
 
@@ -164,6 +171,233 @@ class TestMemmapRoundTrip:
         assert loaded.n_spatial_dims == mesh.n_spatial_dims
         assert loaded.n_points == mesh.n_points
         assert loaded.n_cells == mesh.n_cells
+
+    @pytest.mark.parametrize("vertices_per_cell", [1, 2, 3, 4])
+    def test_empty_cells_preserve_shape_and_dtype(self, tmp_path, vertices_per_cell):
+        """Empty connectivity retains its manifold dimension and dtype."""
+        mesh = Mesh(
+            points=torch.randn(5, 4),
+            cells=torch.empty((0, vertices_per_cell), dtype=torch.int32),
+        )
+
+        mesh.save(tmp_path / "mesh.pt")
+        loaded = Mesh.load(tmp_path / "mesh.pt")
+
+        assert loaded.cells.shape == (0, vertices_per_cell)
+        assert loaded.cells.dtype == torch.int32
+        assert loaded.n_manifold_dims == vertices_per_cell - 1
+
+    def test_fully_empty_geometry_preserves_shape_and_dtype(self, tmp_path):
+        """A mesh with no points or cells can be loaded without losing metadata."""
+        mesh = Mesh(
+            points=torch.empty((0, 4), dtype=torch.float64),
+            cells=torch.empty((0, 3), dtype=torch.int32),
+        )
+
+        mesh.save(tmp_path / "mesh.pt")
+        loaded = Mesh.load(tmp_path / "mesh.pt")
+
+        assert loaded.points.shape == (0, 4)
+        assert loaded.points.dtype == torch.float64
+        assert loaded.cells.shape == (0, 3)
+        assert loaded.cells.dtype == torch.int32
+        assert loaded.n_spatial_dims == 4
+        assert loaded.n_manifold_dims == 2
+
+    def test_zero_element_data_preserves_nested_shapes_and_dtypes(self, tmp_path):
+        """Zero-width user fields survive at every association and nesting level."""
+        point_data = TensorDict(
+            {
+                "embedding": torch.empty((3, 0), dtype=torch.float16),
+                "nested": TensorDict(
+                    {"features": torch.empty((3, 2, 0), dtype=torch.float64)},
+                    batch_size=[3],
+                ),
+            },
+            batch_size=[3],
+        )
+        mesh = Mesh(
+            points=torch.randn(3, 3),
+            cells=torch.tensor([[0, 1, 2]], dtype=torch.int64),
+            point_data=point_data,
+            cell_data={"embedding": torch.empty((1, 0), dtype=torch.int16)},
+            global_data={"embedding": torch.empty((2, 0), dtype=torch.float64)},
+        )
+
+        mesh.save(tmp_path / "mesh.pt")
+        loaded = Mesh.load(tmp_path / "mesh.pt")
+
+        assert loaded.point_data["embedding"].shape == (3, 0)
+        assert loaded.point_data["embedding"].dtype == torch.float16
+        assert loaded.point_data["nested", "features"].shape == (3, 2, 0)
+        assert loaded.point_data["nested", "features"].dtype == torch.float64
+        assert loaded.cell_data["embedding"].shape == (1, 0)
+        assert loaded.cell_data["embedding"].dtype == torch.int16
+        assert loaded.global_data["embedding"].shape == (2, 0)
+        assert loaded.global_data["embedding"].dtype == torch.float64
+
+    def test_empty_cached_adjacency_round_trip(self, tmp_path):
+        """A cached adjacency with no indices remains loadable and empty."""
+        mesh = Mesh(points=torch.randn(4, 3))
+        expected = mesh.get_point_to_points_adjacency().to_list()
+
+        mesh.save(tmp_path / "mesh.pt")
+        loaded = Mesh.load(tmp_path / "mesh.pt")
+        adjacency = loaded.get_point_to_points_adjacency()
+
+        assert adjacency.to_list() == expected
+        assert adjacency.indices.shape == (0,)
+        assert adjacency.indices.dtype == torch.int64
+
+    def test_domain_mesh_preserves_nested_empty_tensors(self, tmp_path):
+        """Domain, interior, and boundary empties all survive one round-trip."""
+        interior = Mesh(
+            points=torch.randn(4, 3),
+            cells=torch.empty((0, 4), dtype=torch.int32),
+        )
+        boundary = Mesh(
+            points=torch.empty((0, 3), dtype=torch.float64),
+            cells=torch.empty((0, 3), dtype=torch.int32),
+            point_data={"embedding": torch.empty((0, 2), dtype=torch.float16)},
+        )
+        domain = DomainMesh(
+            interior=interior,
+            boundaries={"empty": boundary},
+            global_data={"embedding": torch.empty((2, 0), dtype=torch.float64)},
+        )
+
+        domain.save(tmp_path / "domain.pt")
+        loaded = DomainMesh.load(tmp_path / "domain.pt")
+
+        assert loaded.interior.cells.shape == (0, 4)
+        assert loaded.interior.cells.dtype == torch.int32
+        assert loaded.boundaries["empty"].points.shape == (0, 3)
+        assert loaded.boundaries["empty"].points.dtype == torch.float64
+        assert loaded.boundaries["empty"].cells.shape == (0, 3)
+        assert loaded.boundaries["empty"].cells.dtype == torch.int32
+        assert loaded.boundaries["empty"].point_data["embedding"].shape == (0, 2)
+        assert loaded.boundaries["empty"].point_data["embedding"].dtype == torch.float16
+        assert loaded.global_data["embedding"].shape == (2, 0)
+        assert loaded.global_data["embedding"].dtype == torch.float64
+
+    def test_restored_empties_share_the_device_of_loaded_tensors(
+        self, tmp_path, device
+    ):
+        """Rebuilt empties land on the same device as the tensors read from disk.
+
+        ``Mesh.__post_init__`` rejects a mesh whose ``points`` and ``cells``
+        disagree on device, so a rebuilt tensor placed on the wrong device
+        breaks the load outright rather than degrading quietly.
+        """
+        mesh = Mesh(
+            points=torch.randn(4, 3, device=device),
+            cells=torch.empty((0, 3), dtype=torch.int32, device=device),
+            point_data={"embedding": torch.empty((4, 0), device=device)},
+        )
+
+        mesh.save(tmp_path / "mesh.pt")
+        loaded = Mesh.load(tmp_path / "mesh.pt")
+
+        assert loaded.cells.device == loaded.points.device
+        assert loaded.point_data["embedding"].device == loaded.points.device
+
+    def test_missing_tensordict_directory_raises_clear_error(self, tmp_path):
+        """An incomplete save directory reports what is missing, not a raw OSError."""
+        mesh = two_triangles_2d.load()
+        mesh.save(tmp_path / "mesh.pt")
+        shutil.rmtree(tmp_path / "mesh.pt" / "_tensordict")
+
+        with pytest.raises(
+            ValueError, match="_tensordict directory seems to be missing"
+        ):
+            Mesh.load(tmp_path / "mesh.pt")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="A jagged tensor's recorded shape is the shape of its shape "
+        "tensor, which lives in a separate file, so an empty one cannot be "
+        "rebuilt from meta.json alone. Documented in _serialization.py; if this "
+        "starts passing, update those Notes.",
+    )
+    def test_empty_jagged_tensor_round_trip(self, tmp_path):
+        """Known limitation: empty nested (jagged) tensors are still dropped."""
+        mesh = Mesh(
+            points=torch.randn(2, 3),
+            cells=torch.empty((0, 3), dtype=torch.int64),
+        )
+        mesh.global_data["jagged"] = torch.nested.nested_tensor(
+            [torch.empty((0, 2)), torch.empty((0, 2))]
+        )
+
+        mesh.save(tmp_path / "mesh.pt")
+        loaded = Mesh.load(tmp_path / "mesh.pt")
+
+        assert "jagged" in loaded.global_data
+
+
+### Fresh-Process Load Tests ###
+
+# Deliberately imports nothing but ``Mesh``: reaching for an adjacency helper
+# here would register ``Adjacency`` by hand and mask the bug under test.
+_LOAD_MESH_WITH_CACHED_ADJACENCY = """
+import sys
+
+from physicsnemo.mesh.mesh import Mesh
+
+mesh = Mesh.load(sys.argv[1])
+adjacency = mesh._cache["topology", "point_to_points"]
+print(f"{type(adjacency).__name__} {tuple(adjacency.indices.shape)}")
+"""
+
+
+class TestFreshProcessLoad:
+    """Loading must work in a process that has only ever imported ``Mesh``.
+
+    This is the offline-preprocessing / dataloader-worker pattern: one process
+    writes meshes to disk, an unrelated one reads them back.
+    """
+
+    def test_cached_adjacency_loads_in_a_fresh_process(self, tmp_path):
+        """A saved topology cache reconstructs without touching the adjacency API.
+
+        ``TensorDict.load_memmap`` resolves the ``Adjacency`` held in
+        ``_cache["topology"]`` by looking its class up in tensordict's registry,
+        which is only populated as an import side effect. If nothing imports
+        ``physicsnemo.mesh.neighbors``, the load dies with
+        ``RuntimeError: Could not find name ...Adjacency`` -- and note this
+        happens for a perfectly ordinary non-empty adjacency, independent of the
+        zero-element handling the rest of this module covers.
+
+        Runs out-of-process because any in-process test would already have the
+        class registered by an earlier import.
+        """
+        mesh = two_triangles_2d.load()
+        adjacency = mesh.get_point_to_points_adjacency()
+        assert adjacency.indices.numel() > 0, "want a populated cache here"
+        mesh.save(tmp_path / "mesh.pt")
+
+        # Hand the child our own sys.path so it imports the same physicsnemo we
+        # are testing (matters in a git worktree, where the installed
+        # distribution resolves elsewhere).
+        env = {**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
+        result = subprocess.run(  # noqa: S603 - interpreter and snippet are test constants
+            [
+                sys.executable,
+                "-c",
+                _LOAD_MESH_WITH_CACHED_ADJACENCY,
+                str(tmp_path / "mesh.pt"),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=600,
+            check=False,
+        )
+
+        assert result.returncode == 0, (
+            f"fresh-process load failed:\n{result.stdout}\n{result.stderr}"
+        )
+        assert result.stdout.strip() == f"Adjacency {tuple(adjacency.indices.shape)}"
 
 
 ### Pickle (torch.save / torch.load) Round-Trip Tests ###

--- a/test/mesh/spatial/test_bvh.py
+++ b/test/mesh/spatial/test_bvh.py
@@ -761,3 +761,33 @@ class TestBVHParametrized:
         query = torch.tensor([[0.3, 0.3, 0.3]], device=device)
         candidates = bvh.find_candidate_cells(query)
         assert candidates.n_sources == 1
+
+
+class TestBVHSerialization:
+    """Memmap round-trips, including the degenerate all-empty BVH."""
+
+    def test_bvh_over_zero_cell_mesh_survives_round_trip(self, tmp_path, device):
+        """Every node and leaf array of an all-empty BVH is restored.
+
+        A mesh with no cells yields a BVH whose arrays are all zero-length.
+        TensorDict's memmap writer records their shapes in metadata but writes
+        no backing files, so without the empty-tensor loader in
+        `physicsnemo.mesh.utilities._serialization` every field returns `None`.
+        """
+        mesh = Mesh(
+            points=torch.randn(3, 3, device=device),
+            cells=torch.empty((0, 3), dtype=torch.int64, device=device),
+        )
+        bvh = BVH.from_mesh(mesh)
+        assert all(
+            getattr(bvh, field).numel() == 0 for field in BVH.__dataclass_fields__
+        ), "expected an entirely empty BVH"
+
+        bvh.save(tmp_path / "bvh.pt")
+        loaded = BVH.load(tmp_path / "bvh.pt")
+
+        for field in BVH.__dataclass_fields__:
+            original, restored = getattr(bvh, field), getattr(loaded, field)
+            assert restored is not None, f"{field!r} was dropped on load"
+            assert restored.shape == original.shape
+            assert restored.dtype == original.dtype

--- a/test/mesh/spatial/test_cluster_tree.py
+++ b/test/mesh/spatial/test_cluster_tree.py
@@ -41,7 +41,7 @@ import pytest
 import torch
 from tensordict import TensorDict
 
-from physicsnemo.mesh.spatial import ClusterTree
+from physicsnemo.mesh.spatial import ClusterTree, DualInteractionPlan, SourceAggregates
 from physicsnemo.mesh.spatial._ragged import _ragged_arange
 
 # ---------------------------------------------------------------------------
@@ -596,3 +596,70 @@ def test_validate_rejects_corrupted_plan(device):
     plan.fn_broadcast_counts[-1] = 1
     with pytest.raises(ValueError, match="out of bounds"):
         plan.validate()
+
+
+# ---------------------------------------------------------------------------
+# Memmap round-trips: zero-length tensors have no backing file on disk, so
+# every tensorclass here opts into the empty-tensor loader in
+# physicsnemo.mesh.utilities._serialization. Without it these come back `None`.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_cluster_tree_round_trip(tmp_path):
+    """A tree built over no points restores all of its zero-length arrays."""
+    tree = ClusterTree.from_points(torch.empty((0, 3)))
+    empty_fields = [
+        field
+        for field in ClusterTree.__dataclass_fields__
+        if torch.is_tensor(getattr(tree, field)) and getattr(tree, field).numel() == 0
+    ]
+    assert empty_fields, "expected zero-length arrays to exercise the loader"
+
+    tree.save(tmp_path / "tree.pt")
+    loaded = ClusterTree.load(tmp_path / "tree.pt")
+
+    for field in empty_fields:
+        restored = getattr(loaded, field)
+        assert restored is not None, f"{field!r} was dropped on load"
+        assert restored.shape == getattr(tree, field).shape
+        assert restored.dtype == getattr(tree, field).dtype
+
+
+def test_interaction_plan_with_empty_buckets_round_trip(tmp_path, device):
+    """A real traversal that leaves whole categories empty survives save/load.
+
+    Well-separated clouds produce a plan with no near-field and no broadcast
+    survivors, so several of its eleven index tensors are zero-length.
+    """
+    target_points, source_points = _zero_survivor_clouds(device)
+    target_tree = ClusterTree.from_points(target_points, leaf_size=8)
+    source_tree = ClusterTree.from_points(source_points, leaf_size=8)
+    plan = source_tree.find_dual_interaction_pairs(target_tree, theta=1.0)
+    assert plan.fn_broadcast_targets.numel() == 0, "expected an empty bucket"
+
+    plan.save(tmp_path / "plan.pt")
+    loaded = DualInteractionPlan.load(tmp_path / "plan.pt")
+
+    for field in DualInteractionPlan.__dataclass_fields__:
+        original, restored = getattr(plan, field), getattr(loaded, field)
+        assert restored is not None, f"{field!r} was dropped on load"
+        assert restored.shape == original.shape
+        assert restored.dtype == original.dtype
+    loaded.validate()
+
+
+def test_empty_source_aggregates_round_trip(tmp_path):
+    """Aggregates over an empty node set keep their shapes and dtypes."""
+    aggregates = SourceAggregates(
+        node_centroid=torch.empty((0, 3), dtype=torch.float64),
+        node_source_data=torch.empty((0, 2), dtype=torch.float16),
+        batch_size=[],
+    )
+
+    aggregates.save(tmp_path / "aggregates.pt")
+    loaded = SourceAggregates.load(tmp_path / "aggregates.pt")
+
+    assert loaded.node_centroid.shape == (0, 3)
+    assert loaded.node_centroid.dtype == torch.float64
+    assert loaded.node_source_data.shape == (0, 2)
+    assert loaded.node_source_data.dtype == torch.float16


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

TensorDict records zero-element tensors in memmap metadata but writes no backing file, so loading silently drops them. This can change empty connectivity from `(0, 3)` to the `(0, 1)` point-cloud sentinel, remove empty data fields, or crash while restoring empty adjacency and spatial structures. Loading a cached `Adjacency` in a fresh process can also fail because its tensorclass has not been registered.

This PR:

- Rebuilds missing zero-element tensors from existing metadata before tensorclass `__post_init__` can replace or dereference them.
- Applies the loader to `Mesh`, `DomainMesh`, `Adjacency`, `BVH`, `ClusterTree`, and interaction-plan tensorclasses.
- Registers `Adjacency` when `Mesh` is imported so fresh-process cache loading succeeds.
- Leaves writing and the on-disk format unchanged; files remain byte-identical and backward compatible.

Empty jagged tensors remain a documented, strict-xfail limitation because their shapes cannot be reconstructed from `meta.json` alone.

## Verification

- `pytest test/mesh`: 2357 passed, 704 skipped, 1 xfailed.
- Every new regression test fails without its corresponding fix.
- Saved-file SHA-256 digests are unchanged for empty `Mesh`, `DomainMesh`, and `BVH` cases.
- `ruff check`, `ruff format --check`, and docstring coverage checks pass.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [x] Model implementation standards are not applicable; no model code is changed.

## Dependencies

None.

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score. This score reflects the AI's assessment of merge readiness and is **not** a qualitative judgment of the work or an indication that the PR will be accepted or rejected.

AI-generated feedback should be reviewed critically for usefulness. You are not required to respond to every AI comment, but they are intended to help both authors and reviewers. Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.