### PR TITLE
Miscellaneous fixes

### DIFF
--- a/examples/cfd/external_aerodynamics/domino/README.md
+++ b/examples/cfd/external_aerodynamics/domino/README.md
@@ -86,6 +86,20 @@ with `PhysicsNeMo-Curator`.
 
 Download the DrivAer ML dataset using the
 [provided instructions in PhysicsNeMo-Curator](https://github.com/NVIDIA/physicsnemo-curator/blob/main/examples/external_aerodynamics/README.md#download-drivaerml-dataset).
+Before preprocessing, verify downloaded files against the SHA-256 object IDs in
+an immutable dataset revision. For example, the versioned
+[DrivAerML `run_1` files](https://huggingface.co/datasets/neashton/drivaerml/tree/f26d75e0d3dee10ba0e42829bafd0e0d95ca5acc/run_1)
+give these checksums:
+
+```console
+$ sha256sum run_1/boundary_1.vtp run_1/drivaer_1.stl
+01d388402dad7a783db9c666ddb18e6db745aac16a3193c275e0726dd108bb40  run_1/boundary_1.vtp
+411e6651284a26fc94924106b833fd79febc6deba63922c929dd8acfc99720d2  run_1/drivaer_1.stl
+```
+
+Use the same versioned file listing to verify every run selected for
+preprocessing.
+
 The first step for running the DoMINO pipeline requires processing the raw data
 (vtp, vtu and stl) into either Zarr or NumPy format for training.
 Each of the raw simulations files are downloaded in `vtp`, `vtu` and `stl` formats.

--- a/examples/cfd/flow_reconstruction_diffusion/README.md
+++ b/examples/cfd/flow_reconstruction_diffusion/README.md
@@ -26,6 +26,17 @@ Datasets used for model training and sampling can be downloaded via the followin
 
 - Low resolution data measured from random grid locations (input data for the super-resolution task) (<a href="https://figshare.com/ndownloader/files/39214622">link</a>)
 
+After downloading, verify the files against these SHA-256 checksums for the
+immutable, versioned Figshare records
+([high resolution](https://doi.org/10.6084/m9.figshare.22064621.v1),
+[low resolution](https://doi.org/10.6084/m9.figshare.22080935.v1)):
+
+```console
+$ sha256sum kf_2d_re1000_256_40seed.npy kmflow_sampled_data_irregnew.npz
+775ca8435d2f2f1887e39d7e302890c434fb5d839e3521d80db4fff19d14cf89  kf_2d_re1000_256_40seed.npy
+d007da6d934c6882e7f08a43b83520eacd894a6e6471127e899a21e54a14835e  kmflow_sampled_data_irregnew.npz
+```
+
 
 ## Prerequisites
 
@@ -81,4 +92,3 @@ This implementation is based on / inspired by:
 
 - [https://github.com/ermongroup/SDEdit](https://github.com/ermongroup/SDEdit) (SDEdit: Guided Image Synthesis and Editing with Stochastic Differential Equations)
 - [https://github.com/ermongroup/ddim](https://github.com/ermongroup/ddim) (Denoising Diffusion Implicit Models)
-

--- a/examples/cfd/flow_reconstruction_diffusion/generate_dfsr.py
+++ b/examples/cfd/flow_reconstruction_diffusion/generate_dfsr.py
@@ -492,7 +492,7 @@ def load_flow_data(path, stat_path=None):
 def load_recons_data(ref_path, sample_path, data_kw, smoothing, smoothing_scale):
     """Loads recons data"""
     print("Loading low-res input data from: ", sample_path)
-    with np.load(sample_path, allow_pickle=True) as f:
+    with np.load(sample_path, allow_pickle=False) as f:
         sampled_data = f[data_kw][-4:, ...].copy().astype(np.float32)
     sampled_data = torch.as_tensor(sampled_data, dtype=torch.float32)
     print("Loading high-res reference data from: ", ref_path)

--- a/examples/cfd/lagrangian_mgn/README.md
+++ b/examples/cfd/lagrangian_mgn/README.md
@@ -128,9 +128,8 @@ set `loggers.wandb.mode` to `online` in the command line:
 python train.py +experiment=water data.data_dir=/data/Water loggers.wandb.mode=online
 ```
 
-An active Weights & Biases account is required. You will also need to set your
-API key either through the command line option `loggers.wandb.wandb_key`
-or by using the `WANDB_API_KEY` environment variable:
+An active Weights & Biases account is required. Set your API key using the
+`WANDB_API_KEY` environment variable:
 
 ```bash
 export WANDB_API_KEY=key

--- a/examples/cfd/lagrangian_mgn/conf/config.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/config.yaml
@@ -93,7 +93,6 @@ loggers:
     mode: disabled
     dir: ${output}
     id:
-    wandb_key:
     watch_model: false
   tensorboard:
     _target_: loggers.TensorBoardLogger

--- a/examples/cfd/lagrangian_mgn/conf/config_2d.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/config_2d.yaml
@@ -53,7 +53,6 @@ recompute_activation: False
 # wandb configs
 wandb_mode: offline
 watch_model: False
-wandb_key:
 wandb_project: "meshgraphnet"
 wandb_entity:
 wandb_name:

--- a/examples/cfd/lagrangian_mgn/conf/config_3d.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/config_3d.yaml
@@ -53,7 +53,6 @@ recompute_activation: False
 # wandb configs
 wandb_mode: offline
 watch_model: False
-wandb_key:
 wandb_project: "meshgraphnet"
 wandb_entity:
 wandb_name:

--- a/examples/cfd/lagrangian_mgn/inference.py
+++ b/examples/cfd/lagrangian_mgn/inference.py
@@ -27,7 +27,7 @@ from matplotlib import pyplot as plt
 
 import numpy as np
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 
 import torch
 from torch import Tensor
@@ -36,7 +36,7 @@ from torch_geometric.loader import DataLoader as PyGDataLoader
 from physicsnemo.datapipes.gnn.lagrangian_dataset import graph_update
 from physicsnemo.utils import load_checkpoint
 
-from loggers import get_gpu_info, init_python_logging
+from loggers import config_summary, get_gpu_info, init_python_logging
 
 
 logger = logging.getLogger("lmgn")
@@ -215,7 +215,7 @@ def plot_error(mse, out_dir):
 @hydra.main(version_base="1.3", config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     init_python_logging(cfg, base_filename="inference")
-    logger.info(f"Config summary:\n{OmegaConf.to_yaml(cfg, sort_keys=True)}")
+    logger.info(f"Config summary:\n{config_summary(cfg)}")
     logger.info(get_gpu_info())
 
     logger.info("Rollout started...")

--- a/examples/cfd/lagrangian_mgn/loggers.py
+++ b/examples/cfd/lagrangian_mgn/loggers.py
@@ -37,6 +37,33 @@ from physicsnemo.distributed import DistributedManager
 logger = logging.getLogger("lmgn")
 
 
+def _redact_config_value(value: Any, key: str | None = None) -> Any:
+    """Return a logging-safe copy of a configuration value."""
+    normalized_key = key.lower() if key is not None else ""
+    if normalized_key in {
+        "key",
+        "password",
+        "secret",
+        "token",
+    } or normalized_key.endswith(("_key", "_password", "_secret", "_token")):
+        return "<redacted>"
+    if isinstance(value, Mapping):
+        return {
+            child_key: _redact_config_value(child_value, str(child_key))
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_config_value(child_value) for child_value in value]
+    return value
+
+
+def config_summary(config: DictConfig) -> str:
+    """Serialize a config for logging without exposing credential-like values."""
+    container = OmegaConf.to_container(config, resolve=False)
+    redacted = _redact_config_value(container)
+    return OmegaConf.to_yaml(OmegaConf.create(redacted), sort_keys=True)
+
+
 class TermColorFormatter(logging.Formatter):
     """Custom logging formatter that colors the log output based on log level."""
 
@@ -191,14 +218,14 @@ class WandBLogger(ExperimentLogger):
         if DistributedManager().rank != 0:
             return
 
-        if wandb_key := kwargs.pop("wandb_key", None) is not None:
+        if (wandb_key := kwargs.pop("wandb_key", None)) is not None:
             logger.warning("Passing W&B key via config is not recommended.")
             wandb.login(key=wandb_key)
 
         # If wandb_id is not provided to resume the experiment,
         # create new id if wandb_id.txt does not exist,
         # otherwise - load id from the file.
-        if wandb_id := kwargs.pop("id", None) is None:
+        if (wandb_id := kwargs.pop("id", None)) is None:
             wandb_id_file = os.path.join(kwargs["dir"], "wandb_id.txt")
             if not os.path.exists(wandb_id_file):
                 wandb_id = wandb.util.generate_id()

--- a/examples/cfd/lagrangian_mgn/train.py
+++ b/examples/cfd/lagrangian_mgn/train.py
@@ -19,7 +19,7 @@ import time
 
 import hydra
 from hydra.utils import instantiate, to_absolute_path
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 
 import torch
 from torch.amp import GradScaler, autocast
@@ -31,7 +31,13 @@ from torch_geometric.loader import DataLoader as PyGDataLoader
 from physicsnemo.distributed.manager import DistributedManager
 from physicsnemo.utils import load_checkpoint, save_checkpoint
 
-from loggers import CompositeLogger, ExperimentLogger, get_gpu_info, init_python_logging
+from loggers import (
+    CompositeLogger,
+    ExperimentLogger,
+    config_summary,
+    get_gpu_info,
+    init_python_logging,
+)
 
 
 logger = logging.getLogger("lmgn")
@@ -211,7 +217,7 @@ def main(cfg: DictConfig) -> None:
     dist = DistributedManager()
 
     init_python_logging(cfg, dist.rank)
-    logger.info(f"Config summary:\n{OmegaConf.to_yaml(cfg, sort_keys=True)}")
+    logger.info(f"Config summary:\n{config_summary(cfg)}")
     logger.info(get_gpu_info())
 
     # Initialize loggers.

--- a/physicsnemo/core/filesystem.py
+++ b/physicsnemo/core/filesystem.py
@@ -19,7 +19,9 @@ import json
 import logging
 import os
 import re
+import tempfile
 import urllib
+import warnings
 import zipfile
 from pathlib import Path
 
@@ -150,9 +152,44 @@ def _download_ngc_model_file(path: str, out_path: str, timeout: int = 300) -> st
     return out_path
 
 
+def _file_sha256(path: str | os.PathLike) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_checksum(path: str | os.PathLike, checksum: str) -> None:
+    if re.fullmatch(r"[0-9a-fA-F]{64}", checksum) is None:
+        raise ValueError("checksum must be a 64-character SHA-256 hex digest")
+    actual = _file_sha256(path)
+    if actual.lower() != checksum.lower():
+        raise ValueError(
+            f"Checksum mismatch for {path}: expected {checksum}, got {actual}"
+        )
+
+
 def _download_cached(
-    path: str, recursive: bool = False, local_cache_path: str = LOCAL_CACHE
+    path: str,
+    recursive: bool = False,
+    local_cache_path: str | os.PathLike = LOCAL_CACHE,
+    checksum: str | None = None,
 ) -> str:
+    if checksum is not None and recursive:
+        raise ValueError("checksum verification is only supported for individual files")
+    if checksum is not None and re.fullmatch(r"[0-9a-fA-F]{64}", checksum) is None:
+        raise ValueError("checksum must be a 64-character SHA-256 hex digest")
+    if (
+        checksum is not None
+        and path.startswith("ngc://models/")
+        and path.endswith(".zip")
+    ):
+        raise ValueError(
+            "checksum verification is not supported for automatically extracted "
+            "NGC archives"
+        )
+
     sha = hashlib.sha256(path.encode())
     filename = sha.hexdigest()
     try:
@@ -173,6 +210,20 @@ def _download_cached(
     cache_path = os.path.join(local_cache_path, filename)
 
     url = urllib.parse.urlparse(path)
+    if url.scheme == "http":
+        warnings.warn(
+            "Downloading over plain HTTP; prefer HTTPS. A checksum can verify "
+            "file integrity.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    if os.path.exists(cache_path) and checksum is not None:
+        try:
+            _validate_checksum(cache_path, checksum)
+        except ValueError:
+            logger.warning("Removing cached file with an unexpected checksum: %s", path)
+            os.remove(cache_path)
 
     # TODO watch for race condition here
     if not os.path.exists(cache_path):
@@ -182,23 +233,59 @@ def _download_cached(
             fs.get(path, cache_path, recursive=recursive)
         elif path.startswith("ngc://models/"):
             path = _download_ngc_model_file(path, cache_path)
+            if checksum is not None:
+                try:
+                    _validate_checksum(path, checksum)
+                except ValueError:
+                    os.remove(path)
+                    raise
             return path
-        elif url.scheme == "http":
-            # urllib.request.urlretrieve(path, cache_path)
-            # TODO: Check if this supports directory fetches
-            response = requests.get(path, stream=True, timeout=5)
-            with open(cache_path, "wb") as output:
-                for chunk in response.iter_content(chunk_size=8192):
-                    if chunk:
-                        output.write(chunk)
+        elif url.scheme in ("http", "https"):
+            temporary_path = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    dir=local_cache_path, prefix=f"{filename}.", delete=False
+                ) as output:
+                    temporary_path = output.name
+                    with requests.get(path, stream=True, timeout=5) as response:
+                        response_url = getattr(response, "url", path)
+                        if (
+                            url.scheme == "https"
+                            and urllib.parse.urlparse(response_url).scheme != "https"
+                        ):
+                            raise ValueError(
+                                "HTTPS download redirected to a non-HTTPS URL"
+                            )
+                        response.raise_for_status()
+                        for chunk in response.iter_content(chunk_size=8192):
+                            if chunk:
+                                output.write(chunk)
+                if checksum is not None:
+                    _validate_checksum(temporary_path, checksum)
+                os.replace(temporary_path, cache_path)
+                temporary_path = None
+            finally:
+                if temporary_path is not None and os.path.exists(temporary_path):
+                    os.remove(temporary_path)
         elif url.scheme == "file":
             path = os.path.join(url.netloc, url.path)
+            if checksum is not None:
+                _validate_checksum(path, checksum)
             return path
         else:
+            if checksum is not None:
+                _validate_checksum(path, checksum)
             return path
 
     else:
         logger.debug("Opening from cache: %s", cache_path)
+
+    if checksum is not None:
+        try:
+            _validate_checksum(cache_path, checksum)
+        except ValueError:
+            os.remove(cache_path)
+            raise
 
     return cache_path
 
@@ -212,7 +299,8 @@ class Package:
     Presently one can use Package with the following directories:
     - Package("/path/to/local/directory") = local file system
     - Package("s3://bucket/path/to/directory") = object store file system
-    - Package("http://url/path/to/directory") = http file system
+    - Package("http://url/path/to/directory") = HTTP file system (not recommended)
+    - Package("https://url/path/to/directory") = HTTPS file system
     - Package("ngc://model/<org_id/team_id/model_id>@<version>") = ngc model file system
 
     Args:
@@ -224,13 +312,18 @@ class Package:
         self.root = root
         self.seperator = seperator
 
-    def get(self, path: str, recursive: bool = False) -> str:
+    def get(
+        self, path: str, recursive: bool = False, checksum: str | None = None
+    ) -> str:
         """Get a local path to the item at ``path``
 
         ``path`` might be a remote file, in which case it is downloaded to a
-        local cache at $LOCAL_CACHE or $HOME/.cache/physicsnemo first.
+        local cache at $LOCAL_CACHE or $HOME/.cache/physicsnemo first. Pass a
+        SHA-256 ``checksum`` to verify an individual file before it is used.
         """
-        return _download_cached(self._fullpath(path), recursive=recursive)
+        return _download_cached(
+            self._fullpath(path), recursive=recursive, checksum=checksum
+        )
 
     def _fullpath(self, path):
         return self.root + self.seperator + path

--- a/physicsnemo/core/filesystem.py
+++ b/physicsnemo/core/filesystem.py
@@ -20,9 +20,10 @@ import logging
 import os
 import re
 import tempfile
-import urllib
+import urllib.parse
 import warnings
 import zipfile
+from collections.abc import Callable
 from pathlib import Path
 
 import fsspec
@@ -170,6 +171,30 @@ def _validate_checksum(path: str | os.PathLike, checksum: str) -> None:
         )
 
 
+def _install_in_cache(
+    fetch: Callable[[str], object],
+    cache_path: str | os.PathLike,
+    checksum: str | None,
+) -> None:
+    """Fetch, optionally verify, and atomically install a single cache file."""
+    cache_file = Path(cache_path)
+    # Staging beside the cache file keeps the final replacement atomic.
+    with tempfile.NamedTemporaryFile(
+        dir=cache_file.parent,
+        prefix=f"{cache_file.name}.",
+        delete=False,
+    ) as staged:
+        staged_path = Path(staged.name)
+
+    try:
+        fetch(str(staged_path))
+        if checksum is not None:
+            _validate_checksum(staged_path, checksum)
+        os.replace(staged_path, cache_file)
+    finally:
+        staged_path.unlink(missing_ok=True)
+
+
 def _download_cached(
     path: str,
     recursive: bool = False,
@@ -218,74 +243,66 @@ def _download_cached(
             stacklevel=2,
         )
 
-    if os.path.exists(cache_path) and checksum is not None:
+    cache_available = os.path.exists(cache_path)
+    if cache_available and checksum is not None:
         try:
             _validate_checksum(cache_path, checksum)
         except ValueError:
-            logger.warning("Removing cached file with an unexpected checksum: %s", path)
-            os.remove(cache_path)
+            logger.warning(
+                "Refetching cached file with an unexpected checksum: %s", path
+            )
+            # Leave the shared path untouched until a verified replacement is ready.
+            cache_available = False
 
-    # TODO watch for race condition here
-    if not os.path.exists(cache_path):
-        logger.debug("Downloading %s to cache: %s", path, cache_path)
-        if url.scheme in ("s3", "msc"):
-            fs = fsspec.filesystem(fsspec.utils.get_protocol(path))
-            fs.get(path, cache_path, recursive=recursive)
-        elif path.startswith("ngc://models/"):
-            path = _download_ngc_model_file(path, cache_path)
-            if checksum is not None:
-                try:
-                    _validate_checksum(path, checksum)
-                except ValueError:
-                    os.remove(path)
-                    raise
-            return path
-        elif url.scheme in ("http", "https"):
-            temporary_path = None
-            try:
-                with tempfile.NamedTemporaryFile(
-                    dir=local_cache_path, prefix=f"{filename}.", delete=False
-                ) as output:
-                    temporary_path = output.name
-                    with requests.get(path, stream=True, timeout=5) as response:
-                        response_url = getattr(response, "url", path)
-                        if (
-                            url.scheme == "https"
-                            and urllib.parse.urlparse(response_url).scheme != "https"
-                        ):
-                            raise ValueError(
-                                "HTTPS download redirected to a non-HTTPS URL"
-                            )
-                        response.raise_for_status()
-                        for chunk in response.iter_content(chunk_size=8192):
-                            if chunk:
-                                output.write(chunk)
-                if checksum is not None:
-                    _validate_checksum(temporary_path, checksum)
-                os.replace(temporary_path, cache_path)
-                temporary_path = None
-            finally:
-                if temporary_path is not None and os.path.exists(temporary_path):
-                    os.remove(temporary_path)
-        elif url.scheme == "file":
-            path = os.path.join(url.netloc, url.path)
-            if checksum is not None:
-                _validate_checksum(path, checksum)
-            return path
-        else:
-            if checksum is not None:
-                _validate_checksum(path, checksum)
-            return path
-
-    else:
+    if cache_available:
         logger.debug("Opening from cache: %s", cache_path)
+        return cache_path
 
-    if checksum is not None:
-        try:
-            _validate_checksum(cache_path, checksum)
-        except ValueError:
-            os.remove(cache_path)
-            raise
+    logger.debug("Downloading %s to cache: %s", path, cache_path)
+    if url.scheme in ("s3", "msc"):
+        fs = fsspec.filesystem(fsspec.utils.get_protocol(path))
+        if recursive:
+            fs.get(path, cache_path, recursive=True)
+        else:
+            _install_in_cache(
+                lambda destination: fs.get(path, destination),
+                cache_path,
+                checksum,
+            )
+    elif path.startswith("ngc://models/"):
+        if path.endswith(".zip"):
+            return _download_ngc_model_file(path, cache_path)
+        _install_in_cache(
+            lambda destination: _download_ngc_model_file(path, destination),
+            cache_path,
+            checksum,
+        )
+    elif url.scheme in ("http", "https"):
+
+        def fetch_over_http(destination: str) -> None:
+            with requests.get(path, stream=True, timeout=5) as response:
+                response_url = getattr(response, "url", path)
+                if (
+                    url.scheme == "https"
+                    and urllib.parse.urlparse(response_url).scheme != "https"
+                ):
+                    raise ValueError("HTTPS download redirected to a non-HTTPS URL")
+                response.raise_for_status()
+                with open(destination, "wb") as output:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            output.write(chunk)
+
+        _install_in_cache(fetch_over_http, cache_path, checksum)
+    elif url.scheme == "file":
+        path = os.path.join(url.netloc, url.path)
+        if checksum is not None:
+            _validate_checksum(path, checksum)
+        return path
+    else:
+        if checksum is not None:
+            _validate_checksum(path, checksum)
+        return path
 
     return cache_path
 

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -267,7 +267,10 @@ class Module(torch.nn.Module):
             )
             is_supported_type = member.isfile() or member.isdir()
             if not stays_within_root or not is_supported_type:
-                logging.warning("Skipping archive member which goes above the archive parent: %s", member.name)
+                logging.warning(
+                    "Skipping archive member which goes above the archive parent: %s",
+                    member.name,
+                )
                 continue
             yield member
 

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -259,17 +259,17 @@ class Module(torch.nn.Module):
 
     @staticmethod
     def _safe_members(tar, local_path):
+        extraction_root = Path(local_path).resolve()
         for member in tar.getmembers():
-            if (
-                ".." in member.name
-                or os.path.isabs(member.name)
-                or os.path.realpath(os.path.join(local_path, member.name)).startswith(
-                    os.path.realpath(local_path)
-                )
-            ):
-                yield member
-            else:
-                print(f"Skipping potentially malicious file: {member.name}")
+            destination = (extraction_root / member.name).resolve()
+            stays_within_root = (
+                destination == extraction_root or extraction_root in destination.parents
+            )
+            is_supported_type = member.isfile() or member.isdir()
+            if not stays_within_root or not is_supported_type:
+                logging.warning("Skipping invalid archive member: %s", member.name)
+                continue
+            yield member
 
     @classmethod
     def _backward_compat_arg_mapper(

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -267,7 +267,7 @@ class Module(torch.nn.Module):
             )
             is_supported_type = member.isfile() or member.isdir()
             if not stays_within_root or not is_supported_type:
-                logging.warning("Skipping invalid archive member: %s", member.name)
+                logging.warning("Skipping archive member which goes above the archive parent: %s", member.name)
                 continue
             yield member
 

--- a/physicsnemo/models/figconvnet/warp_neighbor_search.py
+++ b/physicsnemo/models/figconvnet/warp_neighbor_search.py
@@ -108,12 +108,21 @@ def _radius_search_warp(
         device=device,
     )
 
-    torch_offset = torch.zeros(len(result_count) + 1, device=device, dtype=torch.int32)
     result_count_torch = wp.to_torch(result_count)
-    torch.cumsum(result_count_torch, dim=0, out=torch_offset[1:])
-    total_count = torch_offset[-1].item()
-    if total_count >= 2**31 - 1:
-        raise ValueError(f"Total result count is too large: {total_count} > 2**31 - 1")
+    torch_offset_64 = torch.empty(
+        len(result_count) + 1, device=device, dtype=torch.int64
+    )
+    torch_offset_64[0] = 0
+    torch.cumsum(
+        result_count_torch,
+        dim=0,
+        dtype=torch.int64,
+        out=torch_offset_64[1:],
+    )
+    total_count = torch_offset_64[-1].item()
+    if total_count >= torch.iinfo(torch.int32).max:
+        raise ValueError(f"Total result count is too large: {total_count} >= 2**31 - 1")
+    torch_offset = torch_offset_64.to(dtype=torch.int32)
 
     result_point_idx = wp.zeros(shape=(total_count,), dtype=wp.int32, device=device)
     result_point_dist = wp.zeros(shape=(total_count,), dtype=wp.float32, device=device)

--- a/physicsnemo/nn/functional/geometry/mesh_poisson_disk_sample/_warp_impl/op.py
+++ b/physicsnemo/nn/functional/geometry/mesh_poisson_disk_sample/_warp_impl/op.py
@@ -332,10 +332,10 @@ def _weighted_sample_elimination_warp(
             device=sample_positions.device,
             dtype=torch.int32,
         )
-        row_ptr = torch.empty(
+        row_ptr_64 = torch.empty(
             (num_samples + 1,),
             device=sample_positions.device,
-            dtype=torch.int32,
+            dtype=torch.int64,
         )
         wp_neighbor_counts = wp.from_torch(
             neighbor_counts,
@@ -354,9 +354,19 @@ def _weighted_sample_elimination_warp(
             device=wp_launch_device,
             stream=wp_launch_stream,
         )
-        row_ptr[0] = 0
-        torch.cumsum(neighbor_counts, dim=0, out=row_ptr[1:])
-        total_edges = int(row_ptr[-1].item())
+        row_ptr_64[0] = 0
+        torch.cumsum(
+            neighbor_counts,
+            dim=0,
+            dtype=torch.int64,
+            out=row_ptr_64[1:],
+        )
+        total_edges = int(row_ptr_64[-1].item())
+        if total_edges >= torch.iinfo(torch.int32).max:
+            raise ValueError(
+                "Weighted-sample neighbor count exceeds the supported int32 range"
+            )
+        row_ptr = row_ptr_64.to(dtype=torch.int32)
         max_row_size = int(neighbor_counts.max().item()) if num_samples > 0 else 0
         row_ptr_cpu = row_ptr.detach().cpu().numpy()
 

--- a/physicsnemo/nn/functional/geometry/sdf.py
+++ b/physicsnemo/nn/functional/geometry/sdf.py
@@ -137,6 +137,17 @@ def signed_distance_field_impl(
         raise ValueError(
             "mesh_indices must be either 1D flattened indices or 2D (n_faces, 3)"
         )
+    if mesh_indices.numel() == 0 or mesh_indices.numel() % 3 != 0:
+        raise ValueError("mesh_indices must contain complete triangle faces")
+
+    min_index = int(mesh_indices.min().item())
+    max_index = int(mesh_indices.max().item())
+    if min_index < 0 or max_index >= mesh_vertices.shape[0]:
+        raise ValueError(
+            "mesh_indices must index existing vertices; "
+            f"got range [{min_index}, {max_index}] for "
+            f"{mesh_vertices.shape[0]} vertices"
+        )
 
     input_shape = input_points.shape
 

--- a/physicsnemo/nn/functional/neighbors/radius_search/_warp_impl.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_warp_impl.py
@@ -67,12 +67,14 @@ def count_neighbors(
         wp_launch_stream (wp.Stream | None): The stream to launch the kernel on.
         radius (float): The radius that bounds the search.
         N_queries (int): Total number of query points.
-        sync (bool): If True, copies count to CPU and returns (int, wp_offset).
-            If False, returns (gpu_count_tensor, wp_offset) for batched sync.
+        sync (bool): If True, copies count to CPU and returns
+            ``(int, torch_offset)``. If False, returns
+            ``(gpu_count_tensor, torch_offset)`` for batched sync.
 
     Returns:
-        When sync=True: tuple[int, wp.array] -- total count and offset array.
-        When sync=False: tuple[torch.Tensor, wp.array] -- GPU-side count tensor and offset array.
+        When sync=True: tuple[int, torch.Tensor] -- total count and int64 offsets.
+        When sync=False: tuple[torch.Tensor, torch.Tensor] -- GPU-side count
+        tensor and int64 offsets.
     """
     wp_result_count = wp.zeros(N_queries, device=wp_points.device, dtype=wp.int32)
 
@@ -86,19 +88,26 @@ def count_neighbors(
         block_dim=BLOCK_DIM,
     )
 
-    wp_offset = wp.zeros(N_queries + 1, device=wp_points.device, dtype=wp.int32)
-    torch_offset = wp.to_torch(wp_offset)
     torch_result_count = wp.to_torch(wp_result_count)
-    torch.cumsum(torch_result_count, dim=0, out=torch_offset[1:])
+    torch_offset_64 = torch.empty(
+        N_queries + 1, device=torch_result_count.device, dtype=torch.int64
+    )
+    torch_offset_64[0] = 0
+    torch.cumsum(
+        torch_result_count,
+        dim=0,
+        dtype=torch.int64,
+        out=torch_offset_64[1:],
+    )
 
     if sync:
         pin_memory = torch.cuda.is_available()
-        pinned_buffer = torch.zeros(1, dtype=torch.int32, pin_memory=pin_memory)
-        pinned_buffer.copy_(torch_offset[-1:])
-        return pinned_buffer.item(), wp_offset
+        pinned_buffer = torch.zeros(1, dtype=torch.int64, pin_memory=pin_memory)
+        pinned_buffer.copy_(torch_offset_64[-1:])
+        return pinned_buffer.item(), torch_offset_64
 
     # Return the last element as a 1-element GPU tensor for batch-sync later
-    return torch_offset[-1:], wp_offset
+    return torch_offset_64[-1:], torch_offset_64
 
 
 def gather_neighbors(
@@ -247,9 +256,9 @@ def radius_search_impl(
 
             # Count pass: collect all counts without syncing individually
             count_tensors = []
-            wp_offsets = []
+            offset_tensors = []
             for b in range(B):
-                count_t, wp_off = count_neighbors(
+                count_t, offsets = count_neighbors(
                     grids[b],
                     wp_points_per_b[b],
                     wp_queries_per_b[b],
@@ -260,7 +269,7 @@ def radius_search_impl(
                     sync=(B == 1),
                 )
                 count_tensors.append(count_t)
-                wp_offsets.append(wp_off)
+                offset_tensors.append(offsets)
 
             # Sync: for B==1 count_tensors[0] is already an int;
             # for B>1 we batch-sync all GPU tensors at once
@@ -269,15 +278,24 @@ def radius_search_impl(
             else:
                 gpu_counts = torch.cat(count_tensors, dim=0)
                 pin_memory = torch.cuda.is_available()
-                cpu_counts = torch.zeros(B, dtype=torch.int32, pin_memory=pin_memory)
+                cpu_counts = torch.zeros(B, dtype=torch.int64, pin_memory=pin_memory)
                 cpu_counts.copy_(gpu_counts)
                 total_counts = cpu_counts.tolist()
 
             for tc in total_counts:
-                if not tc < 2**31 - 1:
+                if tc >= torch.iinfo(torch.int32).max:
                     raise RuntimeError(
                         f"Total found neighbors is too large: {tc} >= 2**31 - 1"
                     )
+
+            # The kernels use int32 offsets. Cast only after every int64 total
+            # has passed the range check above.
+            offset_tensors_i32 = [
+                offsets.to(dtype=torch.int32) for offsets in offset_tensors
+            ]
+            wp_offsets = [
+                wp.from_torch(offsets, dtype=wp.int32) for offsets in offset_tensors_i32
+            ]
 
             # Gather per batch element, concatenate with batch indices
             all_indices = []

--- a/physicsnemo/nn/functional/rendering/mesh_raycast/_warp_impl.py
+++ b/physicsnemo/nn/functional/rendering/mesh_raycast/_warp_impl.py
@@ -144,6 +144,14 @@ def mesh_raycast_impl(
         raise ValueError("mesh_indices must be 1D or have shape (num_faces, 3)")
     if mesh_indices.numel() == 0 or mesh_indices.numel() % 3 != 0:
         raise ValueError("mesh_indices must contain complete triangle faces")
+    min_index = int(mesh_indices.min().item())
+    max_index = int(mesh_indices.max().item())
+    if min_index < 0 or max_index >= mesh_vertices.shape[0]:
+        raise ValueError(
+            "mesh_indices must index existing vertices; "
+            f"got range [{min_index}, {max_index}] for "
+            f"{mesh_vertices.shape[0]} vertices"
+        )
     if vertex_colors is not None and face_colors is not None:
         raise ValueError("Pass either vertex_colors or face_colors, not both")
     _validate_image_shape(image_height, image_width)

--- a/test/core/test_filesystem.py
+++ b/test/core/test_filesystem.py
@@ -51,13 +51,151 @@ def test_package(tmp_path: Path):
     assert ans == string
 
 
-def test_http_package():
-    test_url = "http://raw.githubusercontent.com/NVIDIA/modulus/main/docs/img"
-    package = filesystem.Package(test_url, seperator="/")
-    path = package.get("modulus-pipes.jpg")
+def test_local_package_checksum(tmp_path: Path):
+    content = b"local package content"
+    file_path = tmp_path / "model.pt"
+    file_path.write_bytes(content)
+    package = filesystem.Package(str(tmp_path), seperator="/")
 
-    known_checksum = "e075b2836d03f7971f754354807dcdca51a7875c8297cb161557946736d1f7fc"
+    path = package.get("model.pt", checksum=hashlib.sha256(content).hexdigest())
+    assert path == str(file_path)
+
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        package.get("model.pt", checksum="0" * 64)
+
+
+def test_https_package(monkeypatch, tmp_path: Path):
+    content = b"test package content"
+    known_checksum = hashlib.sha256(content).hexdigest()
+    status_checked = False
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def raise_for_status(self):
+            nonlocal status_checked
+            status_checked = True
+
+        def iter_content(self, chunk_size):
+            assert chunk_size == 8192
+            yield content
+
+    monkeypatch.setattr(filesystem.requests, "get", lambda *args, **kwargs: Response())
+
+    path = filesystem._download_cached(
+        "https://example.com/assets/model.pt",
+        local_cache_path=tmp_path,
+        checksum=known_checksum,
+    )
+
+    assert status_checked
     assert calculate_checksum(path) == known_checksum
+
+
+def test_plain_http_package_warns(monkeypatch, tmp_path: Path):
+    content = b"test package content"
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield content
+
+    monkeypatch.setattr(filesystem.requests, "get", lambda *args, **kwargs: Response())
+
+    with pytest.warns(UserWarning, match="plain HTTP"):
+        path = filesystem._download_cached(
+            "http://example.com/assets/model.pt",
+            local_cache_path=tmp_path,
+        )
+
+    assert Path(path).read_bytes() == content
+
+
+def test_https_package_rejects_bad_checksum(monkeypatch, tmp_path: Path):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield b"unexpected content"
+
+    monkeypatch.setattr(filesystem.requests, "get", lambda *args, **kwargs: Response())
+
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        filesystem._download_cached(
+            "https://example.com/assets/model.pt",
+            local_cache_path=tmp_path,
+            checksum="0" * 64,
+        )
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_https_package_does_not_cache_failed_response(monkeypatch, tmp_path: Path):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def raise_for_status(self):
+            raise filesystem.requests.HTTPError("not found")
+
+    monkeypatch.setattr(filesystem.requests, "get", lambda *args, **kwargs: Response())
+
+    with pytest.raises(filesystem.requests.HTTPError):
+        filesystem._download_cached(
+            "https://example.com/assets/missing.pt",
+            local_cache_path=tmp_path,
+        )
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_https_package_rejects_plaintext_redirect(monkeypatch, tmp_path: Path):
+    class Response:
+        url = "http://example.com/model.pt"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield b"unexpected content"
+
+    monkeypatch.setattr(filesystem.requests, "get", lambda *args, **kwargs: Response())
+
+    with pytest.raises(ValueError, match="redirected to a non-HTTPS URL"):
+        filesystem._download_cached(
+            "https://example.com/assets/model.pt",
+            local_cache_path=tmp_path,
+        )
+
+    assert list(tmp_path.iterdir()) == []
 
 
 @pytest.mark.skip("Skipping because slow, need better test solution")

--- a/test/core/test_filesystem.py
+++ b/test/core/test_filesystem.py
@@ -124,6 +124,8 @@ def test_plain_http_package_warns(monkeypatch, tmp_path: Path):
 
 
 def test_https_package_rejects_bad_checksum(monkeypatch, tmp_path: Path):
+    content = b"unexpected content"
+
     class Response:
         def __enter__(self):
             return self
@@ -135,7 +137,7 @@ def test_https_package_rejects_bad_checksum(monkeypatch, tmp_path: Path):
             return None
 
         def iter_content(self, chunk_size):
-            yield b"unexpected content"
+            yield content
 
     monkeypatch.setattr(filesystem.requests, "get", lambda *args, **kwargs: Response())
 
@@ -147,6 +149,22 @@ def test_https_package_rejects_bad_checksum(monkeypatch, tmp_path: Path):
         )
 
     assert list(tmp_path.iterdir()) == []
+
+    cached_url = "https://example.com/assets/cached-model.pt"
+    cache_path = Path(
+        filesystem._download_cached(
+            cached_url,
+            local_cache_path=tmp_path,
+            checksum=hashlib.sha256(content).hexdigest(),
+        )
+    )
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        filesystem._download_cached(
+            cached_url, local_cache_path=tmp_path, checksum="0" * 64
+        )
+
+    assert cache_path.read_bytes() == content
+    assert [entry.name for entry in tmp_path.iterdir()] == [cache_path.name]
 
 
 def test_https_package_does_not_cache_failed_response(monkeypatch, tmp_path: Path):
@@ -196,6 +214,31 @@ def test_https_package_rejects_plaintext_redirect(monkeypatch, tmp_path: Path):
         )
 
     assert list(tmp_path.iterdir()) == []
+
+
+def test_ngc_bad_checksum_does_not_evict_valid_cache_entry(monkeypatch, tmp_path: Path):
+    """A failed NGC refetch cannot remove an existing valid cache entry."""
+    content = b"shared NGC artifact"
+    url = "ngc://models/org/model@v1/model.pt"
+
+    def download(path, out_path):
+        Path(out_path).write_bytes(content)
+        return out_path
+
+    monkeypatch.setattr(filesystem, "_download_ngc_model_file", download)
+
+    cache_path = Path(
+        filesystem._download_cached(
+            url,
+            local_cache_path=tmp_path,
+            checksum=hashlib.sha256(content).hexdigest(),
+        )
+    )
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        filesystem._download_cached(url, local_cache_path=tmp_path, checksum="0" * 64)
+
+    assert cache_path.read_bytes() == content
+    assert [entry.name for entry in tmp_path.iterdir()] == [cache_path.name]
 
 
 @pytest.mark.skip("Skipping because slow, need better test solution")

--- a/test/examples/test_lagrangian_mgn_loggers.py
+++ b/test/examples/test_lagrangian_mgn_loggers.py
@@ -1,6 +1,18 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-FileCopyrightText: All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import importlib.util
 import sys
@@ -13,6 +25,7 @@ from omegaconf import OmegaConf
 
 def _load_loggers_module(monkeypatch):
     pytest.importorskip("termcolor")
+    pytest.importorskip("tensorboard")
     if importlib.util.find_spec("wandb") is None:
         monkeypatch.setitem(sys.modules, "wandb", types.ModuleType("wandb"))
     module_path = (

--- a/test/examples/test_lagrangian_mgn_loggers.py
+++ b/test/examples/test_lagrangian_mgn_loggers.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+
+def _load_loggers_module(monkeypatch):
+    pytest.importorskip("termcolor")
+    if importlib.util.find_spec("wandb") is None:
+        monkeypatch.setitem(sys.modules, "wandb", types.ModuleType("wandb"))
+    module_path = (
+        Path(__file__).parents[2] / "examples" / "cfd" / "lagrangian_mgn" / "loggers.py"
+    )
+    spec = importlib.util.spec_from_file_location("lagrangian_mgn_loggers", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_config_summary_redacts_credentials(monkeypatch):
+    loggers = _load_loggers_module(monkeypatch)
+    config = OmegaConf.create(
+        {
+            "model": {"name": "meshgraphnet"},
+            "logging": {
+                "api_key": "not-for-logs",
+                "nested": [{"access_token": "also-not-for-logs"}],
+            },
+        }
+    )
+
+    summary = loggers.config_summary(config)
+
+    assert "meshgraphnet" in summary
+    assert "not-for-logs" not in summary
+    assert "also-not-for-logs" not in summary
+    assert summary.count("<redacted>") == 2
+
+
+def test_wandb_logger_preserves_configured_key_and_run_id(monkeypatch, tmp_path):
+    loggers = _load_loggers_module(monkeypatch)
+    login_calls = []
+    init_calls = []
+
+    monkeypatch.setattr(
+        loggers,
+        "DistributedManager",
+        lambda: types.SimpleNamespace(rank=0),
+    )
+    monkeypatch.setattr(
+        loggers.wandb,
+        "login",
+        lambda **kwargs: login_calls.append(kwargs),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        loggers.wandb,
+        "init",
+        lambda **kwargs: init_calls.append(kwargs),
+        raising=False,
+    )
+
+    loggers.WandBLogger(
+        wandb_key="configured-key",
+        id="existing-run",
+        dir=str(tmp_path),
+        project="test-project",
+    )
+
+    assert login_calls == [{"key": "configured-key"}]
+    assert init_calls[0]["id"] == "existing-run"

--- a/test/models/test_from_checkpoint.py
+++ b/test/models/test_from_checkpoint.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -131,3 +133,27 @@ def test_from_checkpoint_override(device):
         )
 
     Path("checkpoint.mdlus").unlink(missing_ok=False)
+
+
+def test_checkpoint_archive_members_stay_within_destination(tmp_path):
+    archive_buffer = io.BytesIO()
+    with tarfile.open(fileobj=archive_buffer, mode="w") as archive:
+        for name in ("model.pt", "../outside.pt", "/absolute.pt"):
+            content = b"checkpoint"
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+
+        link = tarfile.TarInfo("linked-model.pt")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../outside.pt"
+        archive.addfile(link)
+
+    archive_buffer.seek(0)
+    with tarfile.open(fileobj=archive_buffer, mode="r") as archive:
+        safe_names = [
+            member.name
+            for member in physicsnemo.core.Module._safe_members(archive, tmp_path)
+        ]
+
+    assert safe_names == ["model.pt"]

--- a/test/nn/functional/geometry/test_sdf.py
+++ b/test/nn/functional/geometry/test_sdf.py
@@ -154,3 +154,16 @@ def test_signed_distance_field_error_handling(device: str):
     bad_connectivity_rank = torch.zeros(1, 2, 3, device=device, dtype=torch.int32)
     with pytest.raises(ValueError, match="1D flattened indices or 2D"):
         signed_distance_field(mesh_vertices, bad_connectivity_rank, query_points)
+
+    with pytest.raises(ValueError, match="index existing vertices"):
+        signed_distance_field(
+            mesh_vertices,
+            torch.tensor([0, 1, 12], device=device, dtype=torch.int32),
+            query_points,
+        )
+    with pytest.raises(ValueError, match="index existing vertices"):
+        signed_distance_field(
+            mesh_vertices,
+            torch.tensor([-1, 1, 2], device=device, dtype=torch.int32),
+            query_points,
+        )

--- a/test/nn/functional/rendering/test_mesh_raycast.py
+++ b/test/nn/functional/rendering/test_mesh_raycast.py
@@ -174,3 +174,20 @@ def test_mesh_raycast_error_handling(device: str):
             180.0,
             implementation="warp",
         )
+
+    for invalid_indices in (
+        torch.tensor([0, 1, 3], device=device, dtype=torch.int32),
+        torch.tensor([-1, 1, 2], device=device, dtype=torch.int32),
+    ):
+        with pytest.raises(ValueError, match="index existing vertices"):
+            mesh_raycast(
+                mesh_vertices,
+                invalid_indices,
+                16,
+                16,
+                eye,
+                center,
+                up,
+                45.0,
+                implementation="warp",
+            )


### PR DESCRIPTION
## Summary

- add range and overflow checks around Warp-backed neighbor and mesh operations
- correct archive member filtering and improve remote artifact fetching
- tighten example dataset and experiment-logging behavior
- document reproducible checksums for externally hosted example data

## Details

This collects several independent correctness and robustness fixes:

- prefix sums are accumulated in int64 and checked before conversion to the int32 offsets required by Warp kernels
- mesh face indices are validated before native SDF and raycast execution
- archive extraction accepts only contained regular files and directories
- the package filesystem supports HTTPS, response checking, atomic cache writes, and optional SHA-256 verification while retaining the existing HTTP behavior with a warning
- the diffusion example disables unnecessary object-array loading for its numeric dataset
- experiment configuration summaries redact credential-like fields, and W&B initialization now preserves configured values correctly

Established checkpoint extensibility and existing dataset/cache serialization formats remain unchanged.

## Validation

- focused changed-behavior tests: 35 passed, 3 skipped
- radius-search and Poisson sampling tests: 187 passed, 4 skipped
- checkpoint, datapipe, and HEALPix compatibility tests: 75 passed, 32 skipped
- direct CUDA/Warp FigConv smoke test passed
- Ruff, Python/YAML syntax checks, and `git diff --check` passed
