### PR TITLE
Make fingerprint computation optional in apply_lora

### DIFF
--- a/physicsnemo/experimental/peft/apply.py
+++ b/physicsnemo/experimental/peft/apply.py
@@ -169,9 +169,20 @@ def _freeze_base_except_extras(
                         p.requires_grad = True
 
 
-def apply_lora(model: nn.Module, config: LoRAConfig) -> ApplyResult:
+def apply_lora(model: nn.Module, config: LoRAConfig, compute_fingerprint: bool = True) -> ApplyResult:
     """In-place: wrap matched ``Linear`` / ``te.Linear`` layers with LoRA and
     freeze the base (except ``extras_trainable``).
+
+    Parameters
+    ----------
+    model : nn.Module
+        Model to mutate in place.
+    config : LoRAConfig
+        LoRA configuration controlling target selection, rank, scaling,
+        initialization, dropout, and any extra trainable modules.
+    compute_fingerprint : bool, optional
+        If ``True``, compute and store a fingerprint of the pristine base model
+        before wrapping layers. Set to ``False`` to skip this cost.
 
     Raises
     ------
@@ -187,7 +198,10 @@ def apply_lora(model: nn.Module, config: LoRAConfig) -> ApplyResult:
 
     # Fingerprint the PRISTINE base before any mutation — once layers are
     # wrapped, the original structure can no longer be recovered.
-    fingerprint = compute_base_fingerprint(model)
+    if compute_fingerprint:
+        fingerprint = compute_base_fingerprint(model)
+    else:
+        fingerprint = ""
 
     targets = resolve_targets(model, config)
     if not targets:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Make fingerprint computation optional by adding the argument `compute_fingerprint` to `apply_lora`. This allows for more flexibility in integrating the implementation.
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
