### PR TITLE
GeoTransolver optimizations: Morton, sparse-hash and tiled-BVH radius…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,6 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# Release-provided container wheels are copied here by the release pipeline.
-/deps/*
-!/deps/README.md
-
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -167,6 +163,8 @@ cython_debug/
 
 # Additional stuff
 nsight-systems*
+*.ncu-rep
+profile_out/
 build/
 mlruns/
 mlflow.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds experimental CUDA radius-search backends for the `max_points` path,
+  selectable by name via `radius_search(..., implementation=...)`: Morton
+  hash-grid variants (`scalar`, `fma`, `gemm`), Morton dense-cell variants
+  (`dense_fma`, `dense_fma_e2e`, `dense_fma_store_opt`, `dense_fma_mem_opt`,
+  `dense_fma_mm`, `dense_gemm`), a sparse hash-grid variant (`sparse_fma_e2e`)
+  whose memory scales with occupied cells rather than the bounding box, and a
+  Morton-ordered tiled LBVH (`bvh`). All run
+  inside the existing Warp custom op, so they share its autograd backward and
+  `torch.compile` support. GeoTransolver exposes the choice through the
+  `radius_search_implementation` config key.
 - Adds `zenith_azimuth_angles` and `zenith_azimuth_angles_from_timestamp` to
   `physicsnemo.utils.zenith_angle`, returning
   `(sin_zenith, cos_zenith, sin_azimuth, cos_azimuth)` alongside the existing

--- a/docs/api/nn/functionals/neighbors.rst
+++ b/docs/api/nn/functionals/neighbors.rst
@@ -11,6 +11,26 @@ Radius Search
 
 .. autofunction:: physicsnemo.nn.functional.radius_search
 
+.. note::
+
+   **Experimental CUDA backends (selectable by name).** When ``max_points`` is set
+   and the inputs are on CUDA, alternative neighbor-search kernels can be selected
+   directly via ``radius_search(..., implementation="<name>")`` (and therefore via
+   any config that forwards ``implementation``, e.g. GeoTransolver's
+   ``radius_search_implementation``). Accepted variant names are ``scalar`` /
+   ``fma`` / ``gemm`` (hash-grid Morton), ``dense_fma`` / ``dense_fma_e2e`` /
+   ``dense_fma_store_opt`` / ``dense_fma_mem_opt`` / ``dense_fma_mm`` /
+   ``dense_gemm`` (dense-cell Morton), ``sparse_fma_e2e`` (sparse hash-grid
+   cells), and ``bvh`` (Morton-ordered tiled LBVH).
+   All of these backends are CUDA-only, require ``max_points`` to be set, and
+   return the same output contract as the default backend (neighbor order within
+   a query is unspecified).
+
+   The ``PHYSICSNEMO_RADIUS_SEARCH_MORTON`` and ``PHYSICSNEMO_RADIUS_SEARCH_BVH``
+   environment variables remain supported as a fallback (used only when no explicit
+   ``implementation`` variant is passed); leaving both unset selects the default
+   Warp hash-grid implementation.
+
 .. rubric:: Benchmarks (ASV)
 
 .. figure:: ../../../img/nn/functional/radius_search/benchmark.png

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/.gitignore
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/.gitignore
@@ -9,3 +9,5 @@ checkpoints/
 *.mdlus
 *.tfevents*
 *.parquet
+bench_out/
+profile_out/

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
@@ -24,7 +24,17 @@
 
 # -- Runtime knobs -----------------------------------------------------------
 precision: "bfloat16"
+
+# When `profile: true`, the loop drives an Nsight Systems capture window via
+# cudaProfilerStart/Stop (see profile.sh, which sets
+# `--capture-range=cudaProfilerApi --capture-range-end=stop`). The first
+# `warmup_steps` steps run un-captured so torch.compile / cuDNN autotune /
+# the CUDA allocator can settle; the next `profile_steps` steps are captured,
+# after which the run stops. Has no effect when `profile: false`.
 profile: false
+warmup_steps: 5
+profile_steps: 5
+
 augment: false
 benchmark_io: false
 

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/model/geotransolver_volume.yaml
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/model/geotransolver_volume.yaml
@@ -61,5 +61,18 @@ model:
   include_local_features: true
   radii: [0.01, 0.05, 0.25, 1.0, 2.5, 5.0]
   neighbors_in_radius: [8, 16, 32, 32, 64, 128]
+  # Radius-search backend for local geometric features. null = automatic
+  # (Warp hash grid). Base backends: warp, torch.
+  # Warp CUDA max_points variants (selectable by name): scalar, fma, gemm,
+  # dense_fma, dense_fma_e2e, dense_fma_store_opt, dense_fma_mem_opt, dense_fma_mm,
+  # dense_gemm, sparse_fma_e2e, bvh.
+  radius_search_implementation: null
   n_hidden_local: 32
   state_mixing_mode: "weighted"  # "weighted" (default) or "concat_project"
+  # geometry and local_positions both resolve to interior.points (see
+  # forward_kwargs above), so the local ball query can be shared between the
+  # context and local-skip pathways: one query per radius scale instead of two.
+  # Must be set explicitly because torch.compile (compile: true) cannot see
+  # through the runtime tensor-identity check. Set to null if you ever wire
+  # geometry and local_positions to different sources.
+  share_geometry_positions: true

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/train.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/train.py
@@ -33,17 +33,17 @@ Usage::
     python src/train.py benchmark_io=true +training.benchmark_max_steps=20
 """
 
+import json
 import os
 import time
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import nullcontext
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import hydra
 import torch
 import torch.distributed as dist
 from datasets import build_dataloaders
-from jaxtyping import Float
 from loss import LossCalculator
 from metrics import MetricCalculator, resolve_metrics
 from omegaconf import DictConfig, OmegaConf
@@ -66,16 +66,253 @@ from utils import (
 
 from physicsnemo import datapipes  # noqa: F401 - registers ${dp:...} resolver
 from physicsnemo.datapipes import DataLoader
-from physicsnemo.distributed import DistributedManager, fused_all_reduce
+from physicsnemo.distributed import DistributedManager
 from physicsnemo.mesh import MESH_FIELD_ASSOCIATIONS, DomainMesh, Mesh
+from physicsnemo.nn.functional.neighbors.radius_search.utils import (
+    radius_search_timing_enabled,
+    radius_search_timing_records,
+    reset_radius_search_timing,
+)
 from physicsnemo.utils import load_checkpoint, save_checkpoint
 from physicsnemo.utils.logging import PythonLogger, RankZeroLoggingWrapper
 from physicsnemo.utils.profiling import Profiler, profile
 
-### When `cfg.profile` is set, every train / val epoch breaks out of its
-### batch loop after this many steps. Keeps profiling traces short enough
-### to be useful without changing the rest of the training contract.
-_PROFILE_MAX_STEPS = 10
+# Radius-search backend selection is driven by the model config
+# (``model.radius_search_implementation`` in the model YAML). That value is
+# threaded into GeoTransolver's ball-query layers and selects the backend/variant
+# directly via ``physicsnemo.nn.functional.radius_search`` -- no env var needed.
+# The legacy ``PHYSICSNEMO_RADIUS_SEARCH_MORTON`` / ``PHYSICSNEMO_RADIUS_SEARCH_BVH``
+# env vars still act as a fallback when the config value is null, but are no longer
+# set here so the YAML stays the single source of truth.
+
+
+def cuda_profiler_start() -> None:
+    """Open an Nsight Systems capture range via ``cudaProfilerStart``.
+
+    No-op when CUDA is unavailable. Pairs with ``profile.sh``'s
+    ``--capture-range=cudaProfilerApi`` flag: nsys discards everything
+    until this fires, so warmup steps stay out of the report.
+    """
+    if torch.cuda.is_available():
+        torch.cuda.profiler.start()
+
+
+def cuda_profiler_stop() -> None:
+    """Close the Nsight Systems capture range via ``cudaProfilerStop``.
+
+    No-op when CUDA is unavailable. Pairs with ``profile.sh``'s
+    ``--capture-range-end=stop`` flag, which finalizes the report when
+    this fires.
+    """
+    if torch.cuda.is_available():
+        torch.cuda.profiler.stop()
+
+
+class _CudaProfilerWindow:
+    """Drive ``cudaProfilerStart`` / ``cudaProfilerStop`` around a step window.
+
+    Counts steps across the run and toggles the CUDA profiler so nsys
+    captures exactly ``profile_steps`` steps after an initial
+    ``warmup_steps`` settle-in period (``torch.compile`` warmup, cuDNN
+    autotune, allocator growth). Once the window closes the controller
+    flips :attr:`finished`, signalling the caller to end the run -- there
+    is no point running un-captured steps under nsys.
+
+    Args:
+        warmup_steps: Steps to run before ``cudaProfilerStart`` fires.
+        profile_steps: Steps to capture before ``cudaProfilerStop`` fires.
+        logger: Logger used to announce the capture boundaries.
+    """
+
+    def __init__(self, warmup_steps: int, profile_steps: int, logger: Any) -> None:
+        self.warmup_steps = warmup_steps
+        self.profile_steps = profile_steps
+        self._logger = logger
+        self._step = 0
+        self.started = False
+        self.finished = False
+
+    def on_step_begin(self) -> bool:
+        """Toggle the profiler at the window edges; call atop each step.
+
+        Returns ``True`` once the capture window has closed (the caller
+        should stop iterating), ``False`` while warming up or capturing.
+        The profiler is stopped *before* the work of the closing step, so
+        only the ``profile_steps`` fully-captured steps land in the report.
+        """
+        if self._step == self.warmup_steps:
+            self._logger.info(
+                f"[profile] cudaProfilerStart at step {self._step} "
+                f"(capturing {self.profile_steps} step(s))"
+            )
+            cuda_profiler_start()
+            self.started = True
+        if self._step == self.warmup_steps + self.profile_steps:
+            self._logger.info(f"[profile] cudaProfilerStop at step {self._step}")
+            cuda_profiler_stop()
+            self.finished = True
+            return True
+        self._step += 1
+        return False
+
+    def close(self) -> None:
+        """Close a still-open capture at run end (safety net).
+
+        Normally :meth:`on_step_begin` stops the profiler exactly at the
+        window edge. If the run exhausts its steps mid-capture (e.g. the
+        window is wider than the available steps), this stops the profiler
+        so nsys finalizes a bounded report instead of running open-ended.
+        """
+        if self.started and not self.finished:
+            self._logger.info("[profile] cudaProfilerStop at run end (window unclosed)")
+            cuda_profiler_stop()
+            self.finished = True
+
+
+# ---------------------------------------------------------------------------
+# Model-forward timing (paired with the radius-search benchmark)
+# ---------------------------------------------------------------------------
+# Per-step CUDA-event timings of the entire model forward, collected during the
+# radius-search benchmark window (see _RadiusSearchTimingCapture) so the report
+# can show radius-search cost relative to the full forward pass.
+_FORWARD_TIMING_EVENTS: list[tuple[Any, Any]] = []
+
+
+class _ForwardTimer:
+    """CUDA-event-time the enclosed model forward.
+
+    No-op unless ``PHYSICSNEMO_RADIUS_SEARCH_TIMING`` is set, CUDA is available,
+    and we run eagerly (``torch.compile`` traces the context manager away, so
+    forward timings are only collected with ``compile=false``).
+    """
+
+    def __enter__(self) -> "_ForwardTimer":
+        self._start = None
+        self._end = None
+        if not radius_search_timing_enabled():
+            return self
+        if not torch.cuda.is_available():
+            return self
+        if getattr(torch.compiler, "is_compiling", lambda: False)():
+            return self
+        self._start = torch.cuda.Event(enable_timing=True)
+        self._end = torch.cuda.Event(enable_timing=True)
+        self._start.record()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        if self._start is not None and self._end is not None:
+            self._end.record()
+            _FORWARD_TIMING_EVENTS.append((self._start, self._end))
+        return False
+
+
+def _reset_forward_timing() -> None:
+    """Discard any collected model-forward timings."""
+    _FORWARD_TIMING_EVENTS.clear()
+
+
+def _forward_timing_samples(reset: bool = False) -> list[float]:
+    """Return per-step model-forward times in ms (syncing on the events first)."""
+    events = list(_FORWARD_TIMING_EVENTS)
+    if reset:
+        _FORWARD_TIMING_EVENTS.clear()
+    for _, end_event in events:
+        end_event.synchronize()
+    return [
+        float(start_event.elapsed_time(end_event))
+        for start_event, end_event in events
+    ]
+
+
+class _RadiusSearchTimingCapture:
+    """Capture per-call radius-search CUDA-event timings over a step window.
+
+    Drop-in for the ``profile_ctrl`` slot in the training loop: it exposes the
+    same ``on_step_begin() -> bool`` / ``finished`` / ``close()`` interface, so
+    no changes to the epoch loop are needed. It runs ``warmup`` untimed steps
+    (to absorb Warp JIT, cuDNN autotune and allocator growth), resets the
+    timing buffer, then times ``steps`` steps and writes every per-call record
+    to ``out_path`` before signalling the run to stop.
+
+    Activated by :func:`main` when ``PHYSICSNEMO_RADIUS_SEARCH_TIMING_OUT`` is
+    set. Also requires ``PHYSICSNEMO_RADIUS_SEARCH_TIMING=1`` (so the
+    ``radius_search`` dispatch records events) and ``compile=false`` (so the
+    per-call Python timing hook actually runs each step rather than being traced
+    away by ``torch.compile``).
+
+    Args:
+        out_path: Destination JSON path (``{"metadata": ..., "records": [...]}``).
+        warmup: Untimed warmup steps.
+        steps: Timed steps to capture.
+        meta: Run metadata stored alongside the records (implementation, dataset,
+            sampling_resolution, device, ...).
+        logger: Logger for progress messages.
+    """
+
+    def __init__(
+        self,
+        out_path: str,
+        warmup: int,
+        steps: int,
+        meta: dict[str, Any],
+        logger: Any,
+    ) -> None:
+        self.out_path = out_path
+        self.warmup = max(0, warmup)
+        self.steps = max(1, steps)
+        self.meta = meta
+        self._logger = logger
+        self._step = 0
+        self.finished = False
+
+    def on_step_begin(self) -> bool:
+        """Advance the counter; reset after warmup, dump + stop at window end.
+
+        Returns ``True`` once the timed window is complete so the caller breaks
+        out of the epoch loop.
+        """
+        if self.finished:
+            return True
+        if self._step == self.warmup:
+            # Discard warmup samples so only steady-state steps are measured.
+            reset_radius_search_timing()
+            _reset_forward_timing()
+            self._logger.info(
+                f"[rs-bench] warmup complete ({self.warmup} steps); "
+                f"timing {self.steps} steps"
+            )
+        if self._step >= self.warmup + self.steps:
+            self._dump()
+            self.finished = True
+            return True
+        self._step += 1
+        return False
+
+    def close(self) -> None:
+        """Dump whatever was captured if the run ended before the window closed."""
+        if not self.finished:
+            self._logger.info(
+                "[rs-bench] run ended before the timing window closed; "
+                "dumping partial capture"
+            )
+            self._dump()
+            self.finished = True
+
+    def _dump(self) -> None:
+        records = radius_search_timing_records(reset=True)
+        forward_ms = _forward_timing_samples(reset=True)
+        payload = {
+            "metadata": self.meta,
+            "records": records,
+            "forward_ms": forward_ms,
+        }
+        with open(self.out_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        self._logger.info(
+            f"[rs-bench] wrote {len(records)} radius-search records and "
+            f"{len(forward_ms)} forward-pass timings -> {self.out_path}"
+        )
 
 
 ### ---------------------------------------------------------------------------
@@ -103,35 +340,38 @@ def _flatten_config(
 
 
 def _reduce_and_average(
-    loss_sum: Float[torch.Tensor, ""],
+    loss_sum: float,
     losses_td: TensorDict | None,
     metrics_td: TensorDict | None,
     n_samples: int,
     *,
     device: torch.device | str,
 ) -> tuple[float, dict[str, float], dict[str, float]]:
-    """Collapse rank-local loss/metric *sums* into a global mean-of-means.
+    """Collapse rank-local loss/metric *sums* + a sample count into global means.
 
     Under DDP each rank only sees its own shard, so the numbers we log are
-    meaningless until reduced across ranks. This divides the rank-local sums
-    (``loss_sum`` plus the 0-D ``losses_td`` / ``metrics_td`` leaves) by the
-    local sample count, then averages those per-rank means across ranks with
-    one fused ``AVG`` ``all_reduce``
-    (:func:`physicsnemo.distributed.fused_all_reduce`). Under even shards
-    (train ``drop_last=True``, val pads) that equals the true global mean and
-    keeps the integer count out of the float reduction buffer. It is
-    granularity-neutral, mirrors the inference-side ``infer._allreduce_sums``,
-    and is called at two boundaries:
+    meaningless until reduced across ranks. This takes a rank-local *sum*
+    (``loss_sum`` plus the 0-D ``losses_td`` / ``metrics_td`` leaves) and the
+    matching sample count, reduces them across ranks once, and divides by the
+    *global* count to produce sample-weighted means. It is granularity-neutral
+    and called at two boundaries:
 
-    - Per step, with ``n_samples == 1``, so the logged iteration curves are
-      global all-rank means rather than rank-0's shard.
-    - Per epoch, with ``n_samples == n_local`` and the running epoch sums, for
-      the dataset-wide summary.
+    - Per step, with ``n_samples == 1`` (one sample per batch), so the logged
+      iteration curves are global all-rank means rather than rank-0's shard.
+    - Per epoch, with ``n_samples == n_local`` and the running epoch sums, so
+      the summary is a global mean over the whole dataset.
+
+    Reducing sums and a count (rather than per-rank means) is what makes the
+    result correct for uneven shards: ``global_sum / global_count`` weights
+    every sample equally no matter how the dataset split across ranks. The
+    values are packed into a single ``float32`` buffer, so each call costs one
+    ``all_reduce`` and one device-to-host sync (the ``.tolist()``). It mirrors
+    the inference-side reducer ``infer._allreduce_sums``.
 
     Args:
         loss_sum: Rank-local sum of scalar losses over the ``n_samples`` being
-            collapsed, as a 0-D on-device tensor -- one step's detached
-            ``loss`` per step, or the running epoch-loss tensor -- not a mean.
+            collapsed -- one step's ``loss.item()`` per step, or the epoch
+            running sum -- not a mean.
         losses_td: Rank-local per-field loss sum: a 0-D (``batch_size=[]``)
             ``TensorDict`` whose leaves are summed scalar losses, one per loss
             term. ``None`` is the "zero samples" sentinel (see Notes); it does
@@ -142,44 +382,60 @@ def _reduce_and_average(
         n_samples: Number of samples this rank contributed to ``loss_sum`` and
             the accumulators (``1`` per step, ``n_local`` per epoch; equal to
             the step count because the recipe runs ``batch_size == 1``).
-        device: The rank's collective/compute device (``dist_manager.device``),
-            where the ``all_reduce`` runs.
+        device: Device on which to build the reduction buffer. Must be the
+            rank's collective/compute device (``dist_manager.device``) so the
+            NCCL ``all_reduce`` runs on the correct device.
 
     Returns:
-        A ``(avg_loss, avg_losses, avg_metrics)`` tuple of Python floats:
-        ``avg_loss`` is the global mean loss, ``avg_losses`` is
-        ``{loss_name: mean}``, and ``avg_metrics`` is ``{metric_name: mean}``.
-        The dict keys and their order are taken from ``losses_td`` /
-        ``metrics_td``. On the ``None`` sentinel it returns
-        ``(loss_sum.item() / max(n_samples, 1), {}, {})`` without entering the
-        collective.
+        A ``(avg_loss, avg_losses, avg_metrics)`` tuple where ``avg_loss`` is
+        the global mean loss, ``avg_losses`` is ``{loss_name: global_mean}``,
+        and ``avg_metrics`` is ``{metric_name: global_mean}``. The dict keys
+        and their order are taken from ``losses_td`` / ``metrics_td``. On the
+        ``None`` sentinel it returns ``(loss_sum / max(n_samples, 1), {}, {})``
+        without entering the collective.
 
     Notes:
-        The per-step collective is deadlock-free only because every rank runs
-        the same step count (train ``drop_last=True``, val pads) and packs the
-        same leaves in the same order (all ranks share one ``target_config``).
-        Single-process skips the reduction, leaving single-GPU logs unchanged.
+        Single-process (or ``world_size == 1``) skips the reduction, so the
+        result is identical to plain ``sum / n_samples`` averaging and
+        single-GPU logs are unchanged.
+
+        Calling this per step adds one collective per iteration, which is only
+        deadlock-free because every rank issues the same number of collectives
+        -- i.e. every rank runs the same step count. The recipe's samplers
+        guarantee that: train uses ``drop_last=True`` and val pads to even
+        shards, so no rank finishes early and skips a step's ``all_reduce``.
+
+        The one fused ``all_reduce`` is valid only because every rank packs
+        the same leaves in the same order, which holds since all ranks share
+        one ``target_config`` (identical loss/metric keys). The ``None`` early
+        return similarly assumes ranks are seeded together: under DDP every
+        rank gets at least one sample, so the accumulators are non-``None`` on
+        all ranks at once.
     """
     if losses_td is None or metrics_td is None:
-        return loss_sum.item() / max(n_samples, 1), {}, {}
-    ### Divide by the local sample count first, then AVG across ranks: a
-    ### mean-of-means equal to the global mean under even shards, with no
-    ### integer count entering the float reduction buffer.
-    n = max(n_samples, 1)
-    bundle = TensorDict(
-        {
-            "loss": loss_sum / n,
-            "losses": losses_td / n,
-            "metrics": metrics_td / n,
-        },
+        return loss_sum / max(n_samples, 1), {}, {}
+    loss_keys = cast(list[str], list(losses_td.keys()))
+    metric_keys = cast(list[str], list(metrics_td.keys()))
+    leaves = cast(
+        list[torch.Tensor], list(losses_td.values()) + list(metrics_td.values())
     )
-    ### Pull the reduced bundle host-side once; .item() off the CPU copy is then
-    ### a free index, with no per-leaf device sync (AVG is a no-op single-process).
-    reduced = fused_all_reduce(bundle, op=dist.ReduceOp.AVG, device=device).cpu()
+    ### [loss_sum, n_samples, *loss_sums, *metric_sums] -> one collective.
+    packed = torch.cat(
+        [
+            torch.tensor([loss_sum, float(n_samples)], device=device),
+            torch.stack(leaves).float().to(device),
+        ]
+    )
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+        dist.all_reduce(packed)
+    reduced_loss, reduced_n, *leaf_sums = packed.tolist()
+    n = max(reduced_n, 1.0)
+    n_loss = len(loss_keys)
+    averaged = [v / n for v in leaf_sums]
     return (
-        reduced["loss"].item(),
-        {key: value.item() for key, value in reduced["losses"].items()},
-        {key: value.item() for key, value in reduced["metrics"].items()},
+        reduced_loss / n,
+        dict(zip(loss_keys, averaged[:n_loss])),
+        dict(zip(metric_keys, averaged[n_loss:])),
     )
 
 
@@ -190,7 +446,7 @@ def _reduce_and_average(
 
 def _log_to_tensorboard(
     writer: SummaryWriter | None,
-    values: Mapping[str, float | Float[torch.Tensor, ""]],
+    values: Mapping[str, float | torch.Tensor],
     tag_prefix: str,
     global_step: int,
 ) -> None:
@@ -219,7 +475,8 @@ def forward_pass(
     *,
     output_type: IOType,
     target_config: dict[str, FieldType],
-) -> tuple[Float[torch.Tensor, ""], TensorDict, TensorDict]:
+    cfg: DictConfig = None
+) -> tuple[torch.Tensor, TensorDict, TensorDict]:
     """Run a forward pass + loss + metrics on one collated batch.
 
     Args:
@@ -254,17 +511,35 @@ def forward_pass(
 
     ### Inputs keep their native dtype; autocast handles model-internal precision.
     with get_autocast_context(precision):
-        output = model(**forward_kwargs)
+        # import ipdb; ipdb.set_trace()
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("model_forward")
+        with _ForwardTimer():
+            output = model(**forward_kwargs, cfg=cfg)
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
+
+    if os.environ.get("PROFILE_RUN") == "1":
+        torch.cuda.nvtx.range_push("normalize output to tensordict")
 
     pred_td = normalize_output_to_tensordict(output, target_config, output_type)
 
+    if os.environ.get("PROFILE_RUN") == "1":
+        torch.cuda.nvtx.range_pop()
     ### Loss runs in float32 to avoid bf16 precision loss in the reduction.
     pred_f32 = pred_td.float()
     target_f32 = targets.float()
-
+    if os.environ.get("PROFILE_RUN") == "1":
+        torch.cuda.nvtx.range_push("loss calculator")
     loss, loss_td = loss_calculator(pred_f32, target_f32)
+    if os.environ.get("PROFILE_RUN") == "1":
+        torch.cuda.nvtx.range_pop()
     with torch.no_grad():
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("metric_calc")
         metric_td = metric_calculator(pred_f32, target_f32)
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
     ### Detach (don't sync) the per-field TDs so the caller controls when
     ### a D2H copy happens; running ``.item()`` here would serialise the
     ### forward kernels against the host. ``TensorDict.detach()`` walks
@@ -295,6 +570,7 @@ def _run_epoch(
     scaler: GradScaler | None = None,
     writer: SummaryWriter | None = None,
     log_jsonl: Callable[[dict[str, Any]], None] | None = None,
+    profile_ctrl: "_CudaProfilerWindow | None" = None,
 ) -> tuple[float, dict[str, float]]:
     """Run one training-or-validation epoch.
 
@@ -330,23 +606,43 @@ def _run_epoch(
     log_prefix = "Epoch" if is_train else "Val Epoch"
     is_rank0 = dist_manager.rank == 0
 
-    ### All three accumulators live on-device, so epoch sums build up with no
-    ### per-step host sync (the only per-step D2H is inside _reduce_and_average).
-    ### total_loss is float64 for accumulation precision, downcast to float32 at
-    ### the epoch reduce. None = not yet seeded; n_local is this rank's local
-    ### sample count.
-    total_loss = torch.zeros((), dtype=torch.float64, device=dist_manager.device)
+    ### `total_loss` is a Python float fed by the per-step print line's
+    ### sync; `total_losses_td` / `total_metrics_td` are on-device
+    ### TensorDict accumulators (one 0-D leaf per field) that defer
+    ### their D2H transfer to the single batched ``.tolist()`` at
+    ### end-of-epoch. ``None`` here means "not yet seeded"; the first
+    ### iteration clones the per-step TensorDict to break aliasing.
+    ### ``n_local`` below is this rank's step/sample count. The averaging
+    ### denominator is the GLOBAL count that ``_reduce_and_average``
+    ### all-reduces from each rank's ``n_local`` at end-of-epoch; the local
+    ### value is reused directly only for the per-rank step-rate line.
+    total_loss = 0.0
     total_losses_td: TensorDict | None = None
     total_metrics_td: TensorDict | None = None
     precision = getattr(cfg, "precision", "float32")
     n_local = 0
     num_steps = len(dataloader)
     epoch_t0 = time.perf_counter()
-    with grad_ctx:
+
+    _nvtx_ctx = torch.autograd.profiler.emit_nvtx() if cfg.profile else nullcontext()
+
+    with grad_ctx, _nvtx_ctx:
         step_t0 = time.perf_counter()
         for i, batch in enumerate(dataloader):
+            ### nsys capture control: open the window after warmup, close
+            ### it (and stop the run) once `profile_steps` have been
+            ### captured. Only train passes a controller, so val never
+            ### lands inside the trace.
+            if profile_ctrl is not None and profile_ctrl.on_step_begin():
+                break
+
+
+            if cfg.profile:
+                torch.cuda.nvtx.range_push(f"step:{i}")
             batch = recursive_to_device(batch, dist_manager.device)
 
+            if cfg.profile:
+                torch.cuda.nvtx.range_push(f"forward_pass")
             loss, losses, metrics = forward_pass(
                 batch,
                 model,
@@ -355,20 +651,40 @@ def _run_epoch(
                 metric_calculator,
                 output_type=output_type,
                 target_config=target_config,
+                cfg = cfg
             )
+            if cfg.profile:
+                torch.cuda.nvtx.range_pop()
 
             if is_train:
+                if cfg.profile:
+                    torch.cuda.nvtx.range_push(f"optimizer-0-grad")
                 optimizer.zero_grad()
+                if cfg.profile:
+                    torch.cuda.nvtx.range_pop()
                 if precision == "float16" and scaler is not None:
+                    if cfg.profile:
+                        torch.cuda.nvtx.range_push(f"backward")
                     scaler.scale(loss).backward()
+                    if cfg.profile:
+                        torch.cuda.nvtx.range_pop()
                     scaler.step(optimizer)
                     scaler.update()
                 else:
+                    if cfg.profile:
+                        torch.cuda.nvtx.range_push(f"backward")
                     loss.backward()
+                    if cfg.profile:
+                        torch.cuda.nvtx.range_pop()
                     optimizer.step()
                 if cfg.training.get("scheduler_update_mode", "epoch") == "step":
                     scheduler.step()
 
+            if cfg.profile:
+                torch.cuda.nvtx.range_pop()
+
+            if cfg.profile:
+                torch.cuda.nvtx.range_push("other ops + logging")
             ### Accumulate on-device with no sync. First iteration clones
             ### so subsequent in-place ``add_`` calls don't alias the
             ### per-step TDs; both accumulators are seeded in lock-step
@@ -383,10 +699,10 @@ def _run_epoch(
                 total_metrics_td.add_(metrics)
             n_local += 1
 
-            ### Detached scalar loss: accumulate the epoch sum on-device (no
-            ### host sync) and feed the per-step reducer below.
-            loss_det = loss.detach()
-            total_loss += loss_det
+            ### Per-step sync for the print line; lands after backward +
+            ### optimizer.step so it overlaps with queued GPU work.
+            this_loss = loss.detach().item()
+            total_loss += this_loss
 
             step_dt = time.perf_counter() - step_t0
             mem_gb = (
@@ -404,7 +720,7 @@ def _run_epoch(
             ### keep the per-step collective deadlock-free (see
             ### ``_reduce_and_average``).
             step_loss, step_losses, step_metrics = _reduce_and_average(
-                loss_det, losses, metrics, 1, device=dist_manager.device
+                this_loss, losses, metrics, 1, device=dist_manager.device
             )
 
             ### Train mode includes Mem in the per-step line; val drops it
@@ -417,10 +733,13 @@ def _run_epoch(
                 f"{mem_str}"
             )
 
-            ### Per-step TensorBoard is train-only (val_writer is epoch-only);
-            ### per-step JSONL is written in both modes so downstream tooling gets
-            ### val step-times directly. The logged values are global all-rank
-            ### means (rank 0 is only the writer).
+            ### Per-step TensorBoard: train only (val_writer is intentionally
+            ### epoch-only to keep dashboards uncluttered). Per-step JSONL is
+            ### emitted in both modes so downstream tooling can compute val
+            ### step-time statistics directly instead of inferring them from
+            ### ``val_ts - train_ts``. The logged loss / metrics are the global
+            ### all-rank means from ``_reduce_and_average`` above (not rank-0's
+            ### shard); rank 0 is only the writer.
             if is_rank0:
                 if is_train:
                     global_step = epoch * num_steps + i
@@ -483,18 +802,17 @@ def _run_epoch(
                         }
                     )
 
-            if cfg.profile and i >= _PROFILE_MAX_STEPS:
-                break
             step_t0 = time.perf_counter()
+            if cfg.profile:
+                torch.cuda.nvtx.range_pop()
 
     epoch_dt = time.perf_counter() - epoch_t0
     n = max(n_local, 1)
-    ### Reduce the epoch sums + sample count across ranks once so logged
-    ### loss/metrics are global averages (not rank-0's shard) under DDP; `n`
-    ### above stays local for the per-rank step-rate line. Downcast the float64
-    ### loss accumulator to float32 so every reduced leaf shares one dtype.
+    ### Reduce the epoch sums + sample count across ranks once, so logged
+    ### loss/metrics are the GLOBAL averages (not rank-0's shard) under
+    ### DDP. `n` above is kept local for the per-rank step-rate line below.
     avg_loss, avg_losses, avg_metrics = _reduce_and_average(
-        total_loss.float(),
+        total_loss,
         total_losses_td,
         total_metrics_td,
         n_local,
@@ -542,6 +860,7 @@ def train_epoch(
     target_config: dict[str, FieldType],
     train_writer: SummaryWriter | None = None,
     log_jsonl: Callable[[dict[str, Any]], None] | None = None,
+    profile_ctrl: "_CudaProfilerWindow | None" = None,
 ) -> tuple[float, dict[str, float]]:
     """Run one training epoch (delegates to :func:`_run_epoch` in train mode)."""
     return _run_epoch(
@@ -561,6 +880,7 @@ def train_epoch(
         scaler=scaler,
         writer=train_writer,
         log_jsonl=log_jsonl,
+        profile_ctrl=profile_ctrl,
     )
 
 
@@ -660,6 +980,8 @@ def benchmark_io_epoch(
     label: str,
     logger: Any,
     max_steps: int | None = None,
+    *,
+    profile_ctrl: "_CudaProfilerWindow | None" = None,
 ) -> None:
     """Iterate a dataloader without any model logic and report I/O timing.
 
@@ -670,6 +992,10 @@ def benchmark_io_epoch(
         logger: Logger for console output.
         max_steps: Stop after this many batches. ``None`` means exhaust
             the loader.
+        profile_ctrl: Optional nsys capture-window controller. When given,
+            the loop opens / closes the ``cudaProfilerStart``/``Stop``
+            window around the configured step range and stops once the
+            window has closed.
     """
     import statistics
 
@@ -678,6 +1004,11 @@ def benchmark_io_epoch(
 
     step_t0 = time.perf_counter()
     for i, batch in enumerate(dataloader):
+        ### nsys capture control: same warmup/capture window as training,
+        ### applied to pure dataloader iteration (benchmark_io=true).
+        if profile_ctrl is not None and profile_ctrl.on_step_begin():
+            break
+
         dt = time.perf_counter() - step_t0
         times.append(dt)
 
@@ -743,8 +1074,10 @@ def main(cfg: DictConfig) -> None:
     Args:
         cfg: Hydra config containing ``model``, ``training``, ``dataset``,
             ``data``, ``output_dir``, ``run_id``, ``precision``,
-            ``compile``, ``profile``, ``benchmark_io``, ``logging``, and
-            related keys.
+            ``compile``, ``profile``, ``warmup_steps``, ``profile_steps``,
+            ``benchmark_io``, ``logging``, and related keys. ``warmup_steps``
+            / ``profile_steps`` bound the nsys capture window when
+            ``profile`` is set (see :class:`_CudaProfilerWindow`).
     """
 
     DistributedManager.initialize()
@@ -804,6 +1137,15 @@ def main(cfg: DictConfig) -> None:
             }
         )
 
+    ### nsys capture window (cudaProfilerStart/Stop), shared by the I/O
+    ### benchmark and the training loop. ``None`` when not profiling, in
+    ### which case both loops run to their normal completion.
+    profile_ctrl = (
+        _CudaProfilerWindow(cfg.warmup_steps, cfg.profile_steps, logger)
+        if cfg.profile
+        else None
+    )
+
     # -- I/O benchmark mode: iterate dataloaders, skip model entirely -----------
     if cfg.get("benchmark_io", False):
         num_epochs = cfg.training.num_epochs
@@ -816,8 +1158,22 @@ def main(cfg: DictConfig) -> None:
             for epoch in range(num_epochs):
                 logger.info(f"--- Epoch {epoch + 1}/{num_epochs} ---")
                 train_loader.set_epoch(epoch)
-                benchmark_io_epoch(train_loader, "train", logger, max_steps=max_steps)
+                benchmark_io_epoch(
+                    train_loader,
+                    "train",
+                    logger,
+                    max_steps=max_steps,
+                    profile_ctrl=profile_ctrl,
+                )
+                ### Under nsys, the capture window drives the run length:
+                ### skip val and stop as soon as the window has closed.
+                if profile_ctrl is not None:
+                    if profile_ctrl.finished:
+                        break
+                    continue
                 benchmark_io_epoch(val_loader, "val", logger, max_steps=max_steps)
+        if profile_ctrl is not None:
+            profile_ctrl.close()
         logger.info("benchmark_io complete!")
         if is_rank0:
             if train_writer is not None:
@@ -905,10 +1261,60 @@ def main(cfg: DictConfig) -> None:
         "scheduler": scheduler,
         "models": model,
     }
-    loaded_epoch = load_checkpoint(device=device, **ckpt_args)
+
+    loaded_epoch = load_checkpoint(device=dist_manager.device, **ckpt_args)
+
+    #loaded_epoch = load_checkpoint(device=device, **ckpt_args)
+
 
     if cfg.compile:
+        torch._dynamo.config.verbose = True
+        torch._dynamo.config.suppress_errors = False
+        torch._logging.set_logs(recompiles=True, graph_breaks=True)
         model = torch.compile(model)
+
+    # -- Radius-search kernel timing capture (opt-in) ---------------------------
+    # When PHYSICSNEMO_RADIUS_SEARCH_TIMING_OUT is set, take over the step-window
+    # control slot (profile_ctrl) to time radius-search calls over a fixed window
+    # and dump per-call records. This is what bench.sh drives per implementation.
+    rs_timing_out = os.environ.get("PHYSICSNEMO_RADIUS_SEARCH_TIMING_OUT")
+    if rs_timing_out:
+        if cfg.compile:
+            logger.info(
+                "[rs-bench] WARNING: compile=true prevents per-call radius-search "
+                "timing (the dispatch hook is traced away by torch.compile). "
+                "Re-run with compile=false for accurate kernel timings."
+            )
+        rs_warmup = int(os.environ.get("PHYSICSNEMO_RS_BENCH_WARMUP", "10"))
+        rs_steps = int(os.environ.get("PHYSICSNEMO_RS_BENCH_STEPS", "50"))
+        rs_impl = cfg.model.get("radius_search_implementation", None)
+        profile_ctrl = _RadiusSearchTimingCapture(
+            out_path=rs_timing_out,
+            warmup=rs_warmup,
+            steps=rs_steps,
+            meta={
+                "implementation": rs_impl if rs_impl is not None else "auto",
+                "dataset": cfg.get("dataset"),
+                "sampling_resolution": cfg.get("sampling_resolution"),
+                "batch_size": cfg.training.get("batch_size"),
+                "precision": cfg.precision,
+                "compile": cfg.compile,
+                "num_parameters": num_params,
+                "device": (
+                    torch.cuda.get_device_name()
+                    if torch.cuda.is_available()
+                    else "cpu"
+                ),
+                "torch_version": torch.__version__,
+                "warmup": rs_warmup,
+                "steps": rs_steps,
+            },
+            logger=logger,
+        )
+        logger.info(
+            f"[rs-bench] capturing radius-search timings for "
+            f"implementation='{profile_ctrl.meta['implementation']}' -> {rs_timing_out}"
+        )
 
     num_epochs = cfg.training.num_epochs
     logger.info(f"Starting training for {num_epochs} epochs...")
@@ -935,7 +1341,17 @@ def main(cfg: DictConfig) -> None:
                 target_config=target_config,
                 train_writer=train_writer,
                 log_jsonl=log_jsonl,
+                profile_ctrl=profile_ctrl,
             )
+
+            ### Under nsys, the capture window bounds the run: skip
+            ### validation / checkpointing and exit as soon as the window
+            ### has closed (the report is already finalized by then).
+            if profile_ctrl is not None:
+                if profile_ctrl.finished:
+                    logger.info("[profile] capture window complete; ending run")
+                    break
+                continue
 
             val_loss, val_metrics = val_epoch(
                 val_loader,
@@ -982,7 +1398,13 @@ def main(cfg: DictConfig) -> None:
             if cfg.training.get("scheduler_update_mode", "epoch") == "epoch":
                 scheduler.step()
 
-    if is_rank0:
+
+    ### Safety net: if the run ended mid-capture (window wider than the
+    ### available steps), make sure nsys gets its cudaProfilerStop.
+    if profile_ctrl is not None:
+        profile_ctrl.close()
+
+    if dist_manager.rank == 0:
         if train_writer is not None:
             train_writer.close()
         if val_writer is not None:
@@ -999,13 +1421,19 @@ def main(cfg: DictConfig) -> None:
 def launch(cfg: DictConfig) -> None:
     """Hydra entry point: configure profiling and delegate to :func:`main`.
 
+    Profiling in this recipe is driven by Nsight Systems via ``profile.sh``
+    (``--capture-range=cudaProfilerApi``): when ``cfg.profile`` is set,
+    :func:`main` opens a ``cudaProfilerStart``/``cudaProfilerStop`` window
+    around ``warmup_steps``..``warmup_steps + profile_steps``. The torch
+    (kineto) profiler is intentionally *not* enabled here -- it contends
+    with nsys for CUPTI, which corrupts the capture -- so the
+    :class:`~physicsnemo.utils.profiling.Profiler` context stays inert and
+    only its NVTX annotation hooks remain available.
+
     Args:
         cfg: Hydra-composed config (override with ``--config-name``).
-            When ``cfg.profile`` is truthy, torch profiling is enabled.
     """
     profiler = Profiler()
-    if cfg.profile:
-        profiler.enable("torch")
     profiler.initialize()
     main(cfg)
     profiler.finalize()

--- a/physicsnemo/domain_parallel/shard_utils/point_cloud_ops.py
+++ b/physicsnemo/domain_parallel/shard_utils/point_cloud_ops.py
@@ -26,7 +26,6 @@ from torch.distributed.tensor.placement_types import (
     Shard,
 )
 
-from physicsnemo.core.function_spec import FunctionSpec
 from physicsnemo.domain_parallel import ShardTensor, ShardTensorSpec
 from physicsnemo.domain_parallel.shard_utils.patch_core import (
     MissingShardPatch,
@@ -206,6 +205,8 @@ def ringless_ball_query(
         **bq_kwargs,
     )
 
+    
+
     max_points = bq_kwargs["max_points"]
 
     indices_placement = {}
@@ -351,40 +352,39 @@ def merge_outputs(
         n_points = current_indices.shape[0]
         max_neighbors = current_indices.shape[1]
 
-    _, stream = FunctionSpec.warp_launch_context(current_indices)
+    stream = wp.stream_from_torch(current_indices.device)
 
-    with FunctionSpec.warp_stream_scope(stream):
-        if batched:
-            for b in range(B):
-                wp.launch(
-                    merge_indices_and_points,
-                    dim=n_points,
-                    inputs=[
-                        wp.from_torch(current_indices[b], return_ctype=True),
-                        wp.from_torch(current_num_neighbors[b], return_ctype=True),
-                        wp.from_torch(current_points[b], return_ctype=True),
-                        wp.from_torch(incoming_indices[b], return_ctype=True),
-                        wp.from_torch(incoming_num_neighbors[b], return_ctype=True),
-                        wp.from_torch(incoming_points[b], return_ctype=True),
-                        max_neighbors,
-                    ],
-                    stream=stream,
-                )
-        else:
+    if batched:
+        for b in range(B):
             wp.launch(
                 merge_indices_and_points,
                 dim=n_points,
                 inputs=[
-                    wp.from_torch(current_indices, return_ctype=True),
-                    wp.from_torch(current_num_neighbors, return_ctype=True),
-                    wp.from_torch(current_points, return_ctype=True),
-                    wp.from_torch(incoming_indices, return_ctype=True),
-                    wp.from_torch(incoming_num_neighbors, return_ctype=True),
-                    wp.from_torch(incoming_points, return_ctype=True),
+                    wp.from_torch(current_indices[b], return_ctype=True),
+                    wp.from_torch(current_num_neighbors[b], return_ctype=True),
+                    wp.from_torch(current_points[b], return_ctype=True),
+                    wp.from_torch(incoming_indices[b], return_ctype=True),
+                    wp.from_torch(incoming_num_neighbors[b], return_ctype=True),
+                    wp.from_torch(incoming_points[b], return_ctype=True),
                     max_neighbors,
                 ],
                 stream=stream,
             )
+    else:
+        wp.launch(
+            merge_indices_and_points,
+            dim=n_points,
+            inputs=[
+                wp.from_torch(current_indices, return_ctype=True),
+                wp.from_torch(current_num_neighbors, return_ctype=True),
+                wp.from_torch(current_points, return_ctype=True),
+                wp.from_torch(incoming_indices, return_ctype=True),
+                wp.from_torch(incoming_num_neighbors, return_ctype=True),
+                wp.from_torch(incoming_points, return_ctype=True),
+                max_neighbors,
+            ],
+            stream=stream,
+        )
 
     return current_indices, current_num_neighbors, current_points
 
@@ -458,6 +458,10 @@ class RingBallQuery(torch.autograd.Function):
         ctx.radius = bq_kwargs["radius"]
         ctx.return_dists = bq_kwargs["return_dists"]
         ctx.return_points = bq_kwargs["return_points"]
+        # Explicit radius-search variant (e.g. Morton/BVH), if any. Threaded into
+        # the custom op so the sharded ring path honors config-driven selection
+        # instead of silently falling back to the env var.
+        ctx.variant = bq_kwargs.get("variant", None)
 
         for i in range(world_size):
             source_rank = (mesh_rank - i) % world_size
@@ -474,6 +478,7 @@ class RingBallQuery(torch.autograd.Function):
                 ctx.max_points,
                 ctx.return_dists,
                 ctx.return_points,
+                ctx.variant,
             )
             # Store the result with its source rank
             rank_results[source_rank] = (
@@ -707,6 +712,7 @@ def repackage_radius_search_wrapper_args(
     max_points: int | None = None,
     return_dists: bool = False,
     return_points: bool = False,
+    variant: str | None = None,
     *args,
     **kwargs,
 ) -> tuple[ShardTensor, ShardTensor, dict]:
@@ -730,6 +736,10 @@ def repackage_radius_search_wrapper_args(
         Whether to return distances.
     return_points : bool, default=False
         Whether to return points.
+    variant : str | None, optional
+        Explicit radius-search backend variant threaded into the custom op.
+        Captured here (rather than absorbed into ``*args``) so it survives the
+        repackaging and reaches both the ring and ringless paths.
     *args : Any
         Additional positional arguments.
     **kwargs : Any
@@ -747,6 +757,7 @@ def repackage_radius_search_wrapper_args(
         "max_points": max_points,
         "return_dists": return_dists,
         "return_points": return_points,
+        "variant": variant,
     }
 
     # Add any explicitly passed parameters

--- a/physicsnemo/experimental/models/geotransolver/context_projector.py
+++ b/physicsnemo/experimental/models/geotransolver/context_projector.py
@@ -35,6 +35,8 @@ GlobalContextBuilder
 
 from __future__ import annotations
 
+import os
+
 import torch
 import torch.nn as nn
 from einops import rearrange
@@ -511,6 +513,11 @@ class GeometricFeatureProcessor(nn.Module):
         Dimension of the input features to query.
     hidden_dim : int
         Output dimension after MLP processing.
+    radius_search_implementation : str | None, optional
+        Radius-search backend passed to :class:`~physicsnemo.nn.BQWarp`. If None
+        (default), selected automatically. See
+        :func:`~physicsnemo.nn.functional.radius_search` for the full list of
+        accepted backend/variant names.
 
     Forward
     -------
@@ -550,11 +557,16 @@ class GeometricFeatureProcessor(nn.Module):
         neighbors_in_radius: int,
         feature_dim: int,
         hidden_dim: int,
+        radius_search_implementation: str | None = None,
     ) -> None:
         super().__init__()
 
         # Ball query for neighbor search within radius
-        self.bq_warp = BQWarp(radius=radius, neighbors_in_radius=neighbors_in_radius)
+        self.bq_warp = BQWarp(
+            radius=radius,
+            neighbors_in_radius=neighbors_in_radius,
+            implementation=radius_search_implementation,
+        )
 
         # MLP to process flattened neighbor features
         self.mlp = Mlp(
@@ -565,27 +577,29 @@ class GeometricFeatureProcessor(nn.Module):
             drop=0.0,
         )
 
-    def forward(
+    def query_neighbors(
         self,
         query_points: Float[torch.Tensor, "batch points spatial_dim"],
         key_features: Float[torch.Tensor, "batch points features"],
-    ) -> Float[torch.Tensor, "batch points hidden_dim"]:
-        r"""Query neighbors and process features.
+    ) -> Float[torch.Tensor, "batch points flattened"]:
+        r"""Run the ball query and flatten the neighbor features.
+
+        This is the expensive, MLP-independent half of :meth:`forward`. It is
+        split out so callers that need the same neighbor gather more than once
+        (e.g. both the context and the local-skip pathway) can share a single
+        ball query. The result can be fed to :meth:`apply_mlp`.
 
         Parameters
         ----------
         query_points : torch.Tensor
-            Query coordinates of shape :math:`(B, N, 3)` where :math:`B` is batch size
-            and :math:`N` is number of query points.
+            Query coordinates of shape :math:`(B, N, 3)`.
         key_features : torch.Tensor
-            Features to query from of shape :math:`(B, N, C)` where :math:`C` is the
-            feature dimension.
+            Features to gather of shape :math:`(B, N, C)`.
 
         Returns
         -------
         torch.Tensor
-            Processed features of shape :math:`(B, N, D)` where :math:`D` is the
-            hidden dimension.
+            Flattened neighbor features of shape :math:`(B, N, K \cdot C)`.
         """
         ### Input validation
         if not torch.compiler.is_compiling():
@@ -601,13 +615,65 @@ class GeometricFeatureProcessor(nn.Module):
                 )
 
         # Query neighbors within radius: (B, N, K, C)
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("bq_warp")
         _, neighbors = self.bq_warp(query_points, key_features)
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
 
         # Flatten neighbor features for MLP: (B, N, K, C) -> (B, N, K*C)
-        neighbors_flat = rearrange(neighbors, "b n k c -> b n (k c)")
+        return rearrange(neighbors, "b n k c -> b n (k c)")
 
-        # Process through MLP with tanh activation for bounded output
+    def apply_mlp(
+        self,
+        neighbors_flat: Float[torch.Tensor, "batch points flattened"],
+    ) -> Float[torch.Tensor, "batch points hidden_dim"]:
+        r"""Process flattened neighbor features through the MLP.
+
+        The cheap, per-pathway half of :meth:`forward`. Pairs with
+        :meth:`query_neighbors`.
+
+        Parameters
+        ----------
+        neighbors_flat : torch.Tensor
+            Flattened neighbor features of shape :math:`(B, N, K \cdot C)`.
+
+        Returns
+        -------
+        torch.Tensor
+            Processed features of shape :math:`(B, N, D)`.
+        """
+        # tanh keeps the output bounded
         return torch.nn.functional.tanh(self.mlp(neighbors_flat))
+
+    def forward(
+        self,
+        query_points: Float[torch.Tensor, "batch points spatial_dim"],
+        key_features: Float[torch.Tensor, "batch points features"],
+        cfg=None,
+    ) -> Float[torch.Tensor, "batch points hidden_dim"]:
+        r"""Query neighbors and process features.
+
+        Parameters
+        ----------
+        query_points : torch.Tensor
+            Query coordinates of shape :math:`(B, N, 3)` where :math:`B` is batch size
+            and :math:`N` is number of query points.
+        key_features : torch.Tensor
+            Features to query from of shape :math:`(B, N, C)` where :math:`C` is the
+            feature dimension.
+        cfg : optional
+            Optional profiling configuration exposing a ``profile`` attribute. When
+            ``cfg.profile`` is ``True``, NVTX ranges are emitted around the ball-query
+            operation. Default is ``None``.
+
+        Returns
+        -------
+        torch.Tensor
+            Processed features of shape :math:`(B, N, D)` where :math:`D` is the
+            hidden dimension.
+        """
+        return self.apply_mlp(self.query_neighbors(query_points, key_features))
 
 
 class MultiScaleFeatureExtractor(nn.Module):
@@ -638,6 +704,11 @@ class MultiScaleFeatureExtractor(nn.Module):
         Whether to use Transformer Engine. Default is ``True``.
     plus : bool, optional
         Whether to use Transolver++ features. Default is ``False``.
+    radius_search_implementation : str | None, optional
+        Radius-search backend forwarded to each
+        :class:`GeometricFeatureProcessor`. If None (default), selected
+        automatically. See :func:`~physicsnemo.nn.functional.radius_search` for
+        the full list of accepted backend/variant names.
 
     Forward
     -------
@@ -686,6 +757,7 @@ class MultiScaleFeatureExtractor(nn.Module):
         use_te: bool = True,
         plus: bool = False,
         concrete_dropout: bool = False,
+        radius_search_implementation: str | None = None,
     ) -> None:
         super().__init__()
         self.num_scales = len(radii)
@@ -694,7 +766,11 @@ class MultiScaleFeatureExtractor(nn.Module):
         self.processors = nn.ModuleList(
             [
                 GeometricFeatureProcessor(
-                    radii[i], neighbors_in_radius[i], geometry_dim, hidden_dim
+                    radii[i],
+                    neighbors_in_radius[i],
+                    geometry_dim,
+                    hidden_dim,
+                    radius_search_implementation=radius_search_implementation,
                 )
                 for i in range(self.num_scales)
             ]
@@ -717,10 +793,88 @@ class MultiScaleFeatureExtractor(nn.Module):
             ]
         )
 
+    def extract_features(
+        self,
+        spatial_coords: Float[torch.Tensor, "batch points spatial_dim"],
+        geometry: Float[torch.Tensor, "batch points geometry_dim"],
+        cfg=None,
+        share_query: bool | None = None,
+    ) -> tuple[
+        list[Float[torch.Tensor, "batch heads slices dim"]],
+        Float[torch.Tensor, "batch points total_hidden"],
+    ]:
+        r"""Extract both context and local features, sharing the ball query.
+
+        Combines :meth:`extract_context_features` and
+        :meth:`extract_local_features`. The two pathways differ only in the
+        argument order they pass to the per-scale processor:
+
+        - context: ``processor(spatial_coords, geometry)``
+        - local:   ``processor(geometry, spatial_coords)``
+
+        When ``spatial_coords`` and ``geometry`` are the *same tensor object*
+        (the common case, e.g. both resolve to ``interior.points``), those two
+        calls issue an identical ball query and produce the identical flattened
+        neighbor tensor. In that case this method runs the ball query **once**
+        per scale and feeds the shared result to both the tokenizer (context)
+        and the local-skip pathway, roughly halving ball-query work.
+
+        When the two tensors differ, the pathways are genuinely distinct and
+        this method falls back to two separate queries per scale, exactly
+        reproducing the original behavior.
+
+        Parameters
+        ----------
+        spatial_coords : torch.Tensor
+            Spatial coordinates of shape :math:`(B, N, 3)`.
+        geometry : torch.Tensor
+            Geometry features of shape :math:`(B, N, C_{geo})`.
+        cfg : optional
+            Optional profiling configuration forwarded to each
+            :class:`GeometricFeatureProcessor`. Default is ``None``.
+
+        Returns
+        -------
+        tuple[list[torch.Tensor], torch.Tensor]
+            ``(context_feats, local_feats)`` where ``context_feats`` is a list
+            of tokenized context tensors (one per scale, each
+            :math:`(B, H, S, D)`) and ``local_feats`` is the concatenated local
+            tensor of shape :math:`(B, N, D_{total})`.
+        """
+        # Fast path: identical query/key across pathways -> one ball query.
+        #
+        # ``share_query`` may be forced by the caller. This matters under
+        # ``torch.compile``: Dynamo gives ``spatial_coords`` and ``geometry``
+        # distinct proxy identities even when they are the same runtime tensor,
+        # so the ``is`` check below traces to ``False`` and the compiled graph
+        # would always take the slow 2-query path. Passing an explicit Python
+        # bool lets Dynamo specialize on a constant and keep the fast path.
+        if share_query is None:
+            share_query = spatial_coords is geometry
+
+        context_feats: list[torch.Tensor] = []
+        local_parts: list[torch.Tensor] = []
+        for processor, tokenizer in zip(self.processors, self.tokenizers):
+            if share_query:
+                # Path A and Path B gather the same neighbors; query once.
+                neighbors_flat = processor.query_neighbors(spatial_coords, geometry)
+                shared = processor.apply_mlp(neighbors_flat)
+                context_feats.append(tokenizer(shared))
+                local_parts.append(shared)
+            else:
+                # Distinct search spaces; preserve original per-pathway calls.
+                context_feats.append(
+                    tokenizer(processor(spatial_coords, geometry, cfg=cfg))
+                )
+                local_parts.append(processor(geometry, spatial_coords, cfg=cfg))
+
+        return context_feats, torch.cat(local_parts, dim=-1)
+
     def extract_context_features(
         self,
         spatial_coords: Float[torch.Tensor, "batch points spatial_dim"],
         geometry: Float[torch.Tensor, "batch points geometry_dim"],
+        cfg=None,
     ) -> list[Float[torch.Tensor, "batch heads slices dim"]]:
         r"""Extract and tokenize features for context.
 
@@ -730,6 +884,9 @@ class MultiScaleFeatureExtractor(nn.Module):
             Spatial coordinates of shape :math:`(B, N, 3)`.
         geometry : torch.Tensor
             Geometry features of shape :math:`(B, N, C_{geo})`.
+        cfg : optional
+            Optional profiling configuration forwarded to each
+            :class:`GeometricFeatureProcessor`. Default is ``None``.
 
         Returns
         -------
@@ -738,7 +895,7 @@ class MultiScaleFeatureExtractor(nn.Module):
             :math:`(B, H, S, D)`.
         """
         return [
-            tokenizer(processor(spatial_coords, geometry))
+            tokenizer(processor(spatial_coords, geometry, cfg=cfg))
             for processor, tokenizer in zip(self.processors, self.tokenizers)
         ]
 
@@ -746,6 +903,7 @@ class MultiScaleFeatureExtractor(nn.Module):
         self,
         spatial_coords: Float[torch.Tensor, "batch points spatial_dim"],
         geometry: Float[torch.Tensor, "batch points geometry_dim"],
+        cfg=None,
     ) -> Float[torch.Tensor, "batch points total_hidden"]:
         r"""Extract and concatenate features for local pathway.
 
@@ -755,6 +913,9 @@ class MultiScaleFeatureExtractor(nn.Module):
             Spatial coordinates of shape :math:`(B, N, 3)`.
         geometry : torch.Tensor
             Geometry features of shape :math:`(B, N, C_{geo})`.
+        cfg : optional
+            Optional profiling configuration forwarded to each
+            :class:`GeometricFeatureProcessor`. Default is ``None``.
 
         Returns
         -------
@@ -763,7 +924,10 @@ class MultiScaleFeatureExtractor(nn.Module):
             :math:`D_{total}` is ``hidden_dim * num_scales``.
         """
         return torch.cat(
-            [processor(geometry, spatial_coords) for processor in self.processors],
+            [
+                processor(geometry, spatial_coords, cfg=cfg)
+                for processor in self.processors
+            ],
             dim=-1,
         )
 
@@ -809,6 +973,11 @@ class GlobalContextBuilder(nn.Module):
         If set, disables ball-query extractors and uses
         :class:`StructuredContextProjector` for geometry when ``geometry_dim``
         is set. Default is ``None``.
+    radius_search_implementation : str | None, optional
+        Radius-search backend forwarded to the local multi-scale extractors. If
+        None (default), selected automatically. See
+        :func:`~physicsnemo.nn.functional.radius_search` for the full list of
+        accepted backend/variant names.
 
     Forward
     -------
@@ -859,6 +1028,8 @@ class GlobalContextBuilder(nn.Module):
         include_local_features: bool = False,
         structured_shape: tuple[int, ...] | None = None,
         concrete_dropout: bool = False,
+        radius_search_implementation: str | None = None,
+        share_geometry_positions: bool | None = None,
     ) -> None:
         super().__init__()
 
@@ -867,6 +1038,15 @@ class GlobalContextBuilder(nn.Module):
             radii = [0.05, 0.25]
         if neighbors_in_radius is None:
             neighbors_in_radius = [8, 32]
+
+        # When True, assume geometry and local_positions are the same tensor so
+        # the local ball query is shared between the context and local-skip
+        # pathways (one query per scale instead of two). When None, this is
+        # decided per-call by a runtime identity check, which is correct in
+        # eager mode but always resolves False under torch.compile. Set True
+        # from configs where forward_kwargs wire geometry and local_positions
+        # to the same source (e.g. both interior.points).
+        self.share_geometry_positions = share_geometry_positions
 
         dim_head = n_hidden // n_head
         context_dim = 0
@@ -895,6 +1075,7 @@ class GlobalContextBuilder(nn.Module):
                         use_te,
                         plus,
                         concrete_dropout=concrete_dropout,
+                        radius_search_implementation=radius_search_implementation,
                     )
                     for _ in functional_dims
                 ]
@@ -963,6 +1144,7 @@ class GlobalContextBuilder(nn.Module):
         geometry: Float[torch.Tensor, "batch tokens geometry_dim"] | None = None,
         global_embedding: Float[torch.Tensor, "batch global_tokens global_dim"]
         | None = None,
+        cfg= None
     ) -> tuple[
         Float[torch.Tensor, "batch heads slices context_dim"] | None,
         list[Float[torch.Tensor, "batch tokens local_features"]] | None,
@@ -1022,28 +1204,44 @@ class GlobalContextBuilder(nn.Module):
             raise ValueError(
                 "Local positions are required if local features are enabled."
             )
-
+        
+        # if os.environ.get("PROFILE_RUN") == "1":
+        #     torch.cuda.nvtx.range_push("multi-scale-features")
+   
         # Extract multi-scale features if enabled
         if self.local_extractors is not None and geometry is not None:
             local_features = []
             for i, embedding in enumerate(local_embeddings):
                 spatial_coords = local_positions[i]  # Extract coordinates
-
-                # Get tokenized context features from multi-scale extractor
-                context_feats = self.local_extractors[i].extract_context_features(
-                    spatial_coords, geometry
+                if os.environ.get("PROFILE_RUN") == "1":
+                    torch.cuda.nvtx.range_push(f"loc_embed:{i} features")
+                # Get tokenized context features and concatenated local skip
+                # features in one pass. When spatial_coords and geometry are the
+                # same tensor, the shared ball query is run once instead of
+                # twice per scale.
+                context_feats, local_feats = self.local_extractors[i].extract_features(
+                    spatial_coords,
+                    geometry,
+                    cfg=cfg,
+                    share_query=self.share_geometry_positions,
                 )
+                if os.environ.get("PROFILE_RUN") == "1":
+                    torch.cuda.nvtx.range_pop()
                 context_parts.extend(context_feats)
-
-                # Get concatenated local features for skip connection
-                local_feats = self.local_extractors[i].extract_local_features(
-                    spatial_coords, geometry
-                )
                 local_features.append(local_feats)
+
+        # if os.environ.get("PROFILE_RUN") == "1":
+        #     torch.cuda.nvtx.range_pop()
+        
+
 
         # Tokenize geometry features
         if self.geometry_tokenizer is not None and geometry is not None:
+            if os.environ.get("PROFILE_RUN") == "1":
+                torch.cuda.nvtx.range_push("geometry")
             geometry_context = self.geometry_tokenizer(geometry)
+            if os.environ.get("PROFILE_RUN") == "1":
+                torch.cuda.nvtx.range_pop()
             # Detach the returned copy so downstream observers (e.g. the OOD
             # guard) don't keep the backward graph alive.
             geometry_context_detached = geometry_context.detach()
@@ -1051,7 +1249,11 @@ class GlobalContextBuilder(nn.Module):
 
         # Tokenize global embedding
         if self.global_tokenizer is not None and global_embedding is not None:
+            if os.environ.get("PROFILE_RUN") == "1":
+                torch.cuda.nvtx.range_push('global tokenizer')
             context_parts.append(self.global_tokenizer(global_embedding))
+            if os.environ.get("PROFILE_RUN") == "1":
+                torch.cuda.nvtx.range_pop()
 
         # Concatenate all context features along the last dimension
         context = torch.cat(context_parts, dim=-1) if context_parts else None

--- a/physicsnemo/experimental/models/geotransolver/gale.py
+++ b/physicsnemo/experimental/models/geotransolver/gale.py
@@ -41,6 +41,7 @@ from physicsnemo.nn.module.physics_attention import (
 from physicsnemo.experimental.nn.flare_attention import _flare_self_attention
 
 from physicsnemo.nn import ConcreteDropout
+import os
 
 # Check optional dependency availability
 TE_AVAILABLE = check_version_spec("transformer_engine", "0.1.0", hard_fail=False)
@@ -185,6 +186,9 @@ def _gale_forward_impl(
                     f"Expected 3D input tensor (B, N, C) at index {i}, "
                     f"got {tensor.ndim}D tensor with shape {tuple(tensor.shape)}"
                 )
+    if os.environ.get('PROFILE_RUN')=="1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+        torch.cuda.nvtx.range_push('GALE: Project INPUT TO SLICE')
+    # try:
     if module.plus:
         x_mid = [module.project_input_onto_slices(_x) for _x in x]
         fx_mid = [_x_mid for _x_mid in x_mid]
@@ -192,13 +196,29 @@ def _gale_forward_impl(
         x_mid, fx_mid = zip(
             *[module.project_input_onto_slices(_x) for _x in x]
         )
+    # finally:
+    if os.environ.get('PROFILE_RUN')=="1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+        torch.cuda.nvtx.range_pop()
+
+    if os.environ.get('PROFILE_RUN')=="1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+        torch.cuda.nvtx.range_push('GALE: SLICE Projections')
     slice_projections = [module.in_project_slice(_x_mid) for _x_mid in x_mid]
+    if os.environ.get('PROFILE_RUN')=="1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+            torch.cuda.nvtx.range_pop()
+
+    if os.environ.get('PROFILE_RUN')=="1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+        torch.cuda.nvtx.range_push('GALE: Comp. Slice')
     slice_weights, slice_tokens = zip(
         *[
             module._compute_slices_from_projections(proj, _fx_mid)
             for proj, _fx_mid in zip(slice_projections, fx_mid)
         ]
     )
+    if os.environ.get('PROFILE_RUN')=="1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+            torch.cuda.nvtx.range_pop()
+    
+    if os.environ.get('PROFILE_RUN')=="1":
+        torch.cuda.nvtx.range_push('GALE: Comp. Slice Attention')
     if module.use_te:
         self_slice_token = [
             module._compute_slice_attention_te(_slice_token)
@@ -209,7 +229,12 @@ def _gale_forward_impl(
             module._compute_slice_attention_sdpa(_slice_token)
             for _slice_token in slice_tokens
         ]
+    if os.environ.get('PROFILE_RUN')=="1":
+        torch.cuda.nvtx.range_pop()
+    
     if context is not None:
+        if os.environ.get('PROFILE_RUN')=="1":
+            torch.cuda.nvtx.range_push('GALE: Comp. CROSS Attn Slice ')
         cross_slice_token = [
             module.compute_slice_attention_cross([_slice_token], context)[0]
             for _slice_token in slice_tokens
@@ -222,13 +247,22 @@ def _gale_forward_impl(
             )
             for sst, cst in zip(self_slice_token, cross_slice_token)
         ]
+        if os.environ.get('PROFILE_RUN')=="1":
+            torch.cuda.nvtx.range_pop()
+
     else:
         # Use only self-attention when no context is provided
         out_slice_token = self_slice_token
+    
+    if os.environ.get('PROFILE_RUN')=="1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+        torch.cuda.nvtx.range_push('Project attention outputs')
     outputs = [
         module._project_attention_outputs(ost, sw)
         for ost, sw in zip(out_slice_token, slice_weights)
     ]
+
+    if os.environ.get('PROFILE_RUN')=="1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+        torch.cuda.nvtx.range_pop()
     return outputs
 
 
@@ -955,25 +989,53 @@ class GALE_block(nn.Module):
                         f"Expected 3D input tensor (B, N, C) at index {i}, "
                         f"got {tensor.ndim}D tensor with shape {tuple(tensor.shape)}"
                     )
-
+        if os.environ.get("PROFILE_RUN_DEEP")=='1':
+            torch.cuda.nvtx.range_push("layer norm + gale attention")
         # Apply pre-normalization to all inputs
         normed_inputs = [self.ln_1(_fx) for _fx in fx]
 
         # Apply GALE attention with cross-attention to global context
         attn = self.Attn(tuple(normed_inputs), global_context)
 
+        if os.environ.get("PROFILE_RUN_DEEP")=='1':
+            torch.cuda.nvtx.range_pop()
+        
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("Res. Conn after attention")
+        
         # Residual connection after attention
         fx_out = [attn[i] + fx[i] for i in range(len(fx))]
+
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
+
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("Attention Dropout")
 
         # Concrete dropout after attention residual
         if self.attn_dropout is not None:
             fx_out = [self.attn_dropout(_fx) for _fx in fx_out]
 
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
+
+        if os.environ.get("PROFILE_RUN") == "1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+            torch.cuda.nvtx.range_push("feed forward with Res Conn.")
+        
         # Feed-forward network with residual connection
         fx_out = [self.ln_mlp1(_fx) + _fx for _fx in fx_out]
 
+        if os.environ.get("PROFILE_RUN") == "1" or os.environ.get("PROFILE_RUN_DEEP")=='1':
+            torch.cuda.nvtx.range_pop()
+
         # Concrete dropout after FFN residual
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("Concrete Dropout")
+
         if self.ffn_dropout is not None:
             fx_out = [self.ffn_dropout(_fx) for _fx in fx_out]
-
+        
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
+        
         return fx_out

--- a/physicsnemo/experimental/models/geotransolver/geotransolver.py
+++ b/physicsnemo/experimental/models/geotransolver/geotransolver.py
@@ -24,6 +24,7 @@ structure and global context throughout the forward pass.
 from __future__ import annotations
 
 import math
+import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -265,13 +266,32 @@ class GeoTransolver(Module):
         training, and emits warnings on out-of-distribution inputs during
         inference. Default is ``None``.
     attention_type : str, optional
-        attention_type is used to choose the attention type (GALE or GALE_FA). 
+        attention_type is used to choose the attention type (GALE or GALE_FA).
         Default is ``"GALE"``.
     state_mixing_mode : str, optional
         How to blend self-attention and cross-attention outputs in GALE layers.
         ``"weighted"`` uses a learnable sigmoid-gated weighted sum.
         ``"concat_project"`` concatenates the two along the head dimension and
         projects back with a linear layer. Default is ``"weighted"``.
+    share_geometry_positions : bool | None, optional
+        Controls whether the local ball query is shared between the context and
+        local-skip pathways. When ``geometry`` and ``local_positions`` are the
+        same tensor, both pathways issue an identical radius search, so it can
+        run once per scale instead of twice. Set ``True`` to force sharing
+        (required under ``torch.compile``, which cannot see through the runtime
+        tensor-identity check). ``None`` (default) decides per-call via an
+        identity check—correct in eager mode, but always falls back to the
+        slower two-query path when compiled. Only affects the
+        ``include_local_features=True`` mesh path. Default is ``None``.
+
+    radius_search_implementation : str | None, optional
+        Radius-search backend used for local geometric features, forwarded to
+        :func:`~physicsnemo.nn.functional.radius_search`. If None (default), the
+        backend is selected automatically. Base backends: ``"warp"``, ``"torch"``.
+        Warp CUDA ``max_points`` variants selectable by name: ``"scalar"``,
+        ``"fma"``, ``"gemm"``, ``"dense_fma"``, ``"dense_fma_e2e"``,
+        ``"dense_fma_store_opt"``, ``"dense_fma_mem_opt"``, ``"dense_fma_mm"``,
+        ``"dense_gemm"``, ``"sparse_fma_e2e"``, ``"bvh"``.
 
     Forward
     -------
@@ -303,7 +323,7 @@ class GeoTransolver(Module):
         layout—flattened :math:`(B, N, C_{out})` or spatial
         :math:`(B, H, W, C_{out})` / :math:`(B, H, W, D, C_{out})` when
         inputs were 4D/5D.
-        
+
         When ``return_embedding_states=True``, returns a 2-tuple
         ``(output, embedding_states)`` where ``output`` follows the same
         rules above, and ``embedding_states`` is of shape
@@ -425,6 +445,8 @@ class GeoTransolver(Module):
         attention_type: str = "GALE",
         concrete_dropout: bool = False,
         state_mixing_mode: str = "weighted",
+        radius_search_implementation: str | None = None,
+        share_geometry_positions: bool | None = None,
     ) -> None:
         super().__init__(meta=GeoTransolverMetaData())
         self.__name__ = "GeoTransolver"
@@ -483,6 +505,8 @@ class GeoTransolver(Module):
             include_local_features=self.include_local_features,
             structured_shape=structured_shape,
             concrete_dropout=concrete_dropout,
+            radius_search_implementation=radius_search_implementation,
+            share_geometry_positions=share_geometry_positions,
         )
         context_dim = self.context_builder.get_context_dim()
 
@@ -612,6 +636,7 @@ class GeoTransolver(Module):
         geometry: Float[torch.Tensor, "batch tokens geometry_dim"] | None = None,
         time: torch.Tensor | None = None,
         return_embedding_states: bool = False,
+        cfg: DictConfig= None
     ) -> (
         Float[torch.Tensor, "batch tokens out_dim"]
         | tuple[Float[torch.Tensor, "batch tokens out_dim"], ...]
@@ -661,7 +686,6 @@ class GeoTransolver(Module):
         """
         # Track whether input was a single tensor for output format
         single_input = isinstance(local_embedding, torch.Tensor)
-
         # Time embedding not yet supported
         if time is not None:
             raise NotImplementedError(
@@ -670,9 +694,15 @@ class GeoTransolver(Module):
             )
 
         # Normalize inputs to tuple format
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push('normalize local embedding tensor')
+
         local_embedding = _normalize_tensor(local_embedding)
         if local_positions is not None:
             local_positions = _normalize_tensor(local_positions)
+
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
 
         unflatten_output = False
         if self.structured_shape is not None:
@@ -717,12 +747,19 @@ class GeoTransolver(Module):
                 )
 
         # Build context embeddings and extract local features
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("build context")
+
         embedding_states, local_embedding_bq, geo_ctx = (
             self.context_builder.build_context(
-                local_embedding, local_positions, geometry, global_embedding
+                local_embedding, local_positions, geometry, global_embedding, cfg
             )
         )
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
 
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("ood guard")
         # --- OOD Guard ---
         if self.ood_guard is not None:
             # Pool (B, H, S, D) -> (B, D); guard expects pre-pooled latents.
@@ -733,24 +770,48 @@ class GeoTransolver(Module):
                 self.ood_guard.collect(global_embedding, geo_latent)
             else:
                 self.ood_guard.check(global_embedding, geo_latent)
-
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
         # Project inputs to hidden dimension: (B, N, C) -> (B, N, n_hidden)
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("project inp to hidden DIM")
         x = [self.preprocess[i](le) for i, le in enumerate(local_embedding)]
 
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
         # Concatenate local features if enabled
         if self.include_local_features and local_embedding_bq is not None:
+            if os.environ.get("PROFILE_RUN") == "1":
+                torch.cuda.nvtx.range_push('concatenate local features')
             x = [
                 torch.cat([x[i], local_embedding_bq[i]], dim=-1)
                 for i in range(len(x))
             ]
+            if os.environ.get("PROFILE_RUN") == "1":
+                torch.cuda.nvtx.range_pop()
 
         # Pass through GALE transformer blocks with context cross-attention
-        for block in self.blocks:
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push(f"GALE BLOCKS")
+        
+        for block_idx_prof, block in enumerate(self.blocks):
+            if os.environ.get("PROFILE_RUN") == "1":
+                torch.cuda.nvtx.range_push(f"GALE block idx:{block_idx_prof}")
             x = block(tuple(x), embedding_states)
+            if os.environ.get("PROFILE_RUN") == "1":
+                torch.cuda.nvtx.range_pop()
+            
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
 
         # Project to output dimensions: (B, N, n_hidden) -> (B, N, out_dim)
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push('project to output dim')
         x = [self.ln_mlp_out[i](x[i]) for i in range(len(x))]
 
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
+        
         if self.structured_shape is not None and unflatten_output:
             B = x[0].shape[0]
             for i in range(len(x)):

--- a/physicsnemo/nn/functional/neighbors/radius_search/_morton_dense_gemm_kernels.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_morton_dense_gemm_kernels.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+GEMM benchmark kernels for the Morton-sorted compact dense-cell radius search.
+
+These live in a separate module from ``_morton_dense_kernels.py`` because Warp
+compiles a whole module for one ``block_dim`` at a time. The production FMA
+kernel launches at ``block_dim=32`` while ``radius_search_dense_gemm_kernel``
+needs ``block_dim=TILE_P`` (256) for its ``wp.untile`` over the point tile; if
+they shared a module, compiling for the FMA launch would fail to build the GEMM
+kernel. Keeping the GEMM path here means this module is only ever compiled at
+``TILE_P``.
+
+The query-tile / point-chunk task generation kernels live here too so the whole
+GEMM path is self-contained.
+"""
+
+import warp as wp
+
+from ._morton_dense_kernels import TILE_P, TILE_Q
+
+
+@wp.kernel
+def count_neighbor_tasks(
+    q_tile_b: wp.array(dtype=wp.int32),
+    q_tile_cx: wp.array(dtype=wp.int32),
+    q_tile_cy: wp.array(dtype=wp.int32),
+    q_tile_cz: wp.array(dtype=wp.int32),
+    neighbor_offsets: wp.array2d(dtype=wp.int32),
+    min_cx: wp.array(dtype=wp.int32),
+    min_cy: wp.array(dtype=wp.int32),
+    min_cz: wp.array(dtype=wp.int32),
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+    tile_p: wp.int32,
+    task_count: wp.array(dtype=wp.int32),
+):
+    """Count the ``(query-tile, point-chunk)`` tasks each query tile produces."""
+    qt = wp.tid()
+    b = q_tile_b[qt]
+    cx = q_tile_cx[qt]
+    cy = q_tile_cy[qt]
+    cz = q_tile_cz[qt]
+    gx = grid_x[b]
+    gy = grid_y[b]
+    gz = grid_z[b]
+    total = wp.int32(0)
+    for k in range(27):
+        lx = cx + neighbor_offsets[k, 0] - min_cx[b]
+        ly = cy + neighbor_offsets[k, 1] - min_cy[b]
+        lz = cz + neighbor_offsets[k, 2] - min_cz[b]
+        if lx >= 0 and lx < gx and ly >= 0 and ly < gy and lz >= 0 and lz < gz:
+            row = grid_base[b] + lx + gx * (ly + gy * lz)
+            plen = cell_count_by_row[row]
+            if plen > 0:
+                total += (plen + tile_p - 1) // tile_p
+    task_count[qt] = total
+
+
+@wp.kernel
+def fill_neighbor_tasks(
+    q_tile_begin: wp.array(dtype=wp.int32),
+    q_tile_count: wp.array(dtype=wp.int32),
+    q_tile_b: wp.array(dtype=wp.int32),
+    q_tile_cx: wp.array(dtype=wp.int32),
+    q_tile_cy: wp.array(dtype=wp.int32),
+    q_tile_cz: wp.array(dtype=wp.int32),
+    task_offset: wp.array(dtype=wp.int32),
+    neighbor_offsets: wp.array2d(dtype=wp.int32),
+    min_cx: wp.array(dtype=wp.int32),
+    min_cy: wp.array(dtype=wp.int32),
+    min_cz: wp.array(dtype=wp.int32),
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_begin_by_row: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+    tile_p: wp.int32,
+    task_q_begin: wp.array(dtype=wp.int32),
+    task_q_count: wp.array(dtype=wp.int32),
+    task_p_begin: wp.array(dtype=wp.int32),
+    task_p_count: wp.array(dtype=wp.int32),
+):
+    """Materialize the task list at each query tile's exclusive-scan offset."""
+    qt = wp.tid()
+    out = task_offset[qt]
+    qb = q_tile_begin[qt]
+    qc = q_tile_count[qt]
+    b = q_tile_b[qt]
+    cx = q_tile_cx[qt]
+    cy = q_tile_cy[qt]
+    cz = q_tile_cz[qt]
+    gx = grid_x[b]
+    gy = grid_y[b]
+    gz = grid_z[b]
+    for k in range(27):
+        lx = cx + neighbor_offsets[k, 0] - min_cx[b]
+        ly = cy + neighbor_offsets[k, 1] - min_cy[b]
+        lz = cz + neighbor_offsets[k, 2] - min_cz[b]
+        if lx >= 0 and lx < gx and ly >= 0 and ly < gy and lz >= 0 and lz < gz:
+            row = grid_base[b] + lx + gx * (ly + gy * lz)
+            ps = cell_begin_by_row[row]
+            pe = ps + cell_count_by_row[row]
+            pb = ps
+            while pb < pe:
+                task_q_begin[out] = qb
+                task_q_count[out] = qc
+                task_p_begin[out] = pb
+                task_p_count[out] = wp.min(tile_p, pe - pb)
+                out += 1
+                pb += tile_p
+
+
+@wp.kernel
+def radius_search_dense_gemm_kernel(
+    task_q_begin: wp.array(dtype=wp.int32),
+    task_q_count: wp.array(dtype=wp.int32),
+    task_p_begin: wp.array(dtype=wp.int32),
+    task_p_count: wp.array(dtype=wp.int32),
+    lane_iota: wp.array(dtype=wp.int32),
+    q_xyz4_sorted: wp.array2d(dtype=wp.float32),
+    q_norm_sorted: wp.array(dtype=wp.float32),
+    q_orig_sorted: wp.array(dtype=wp.int32),
+    pc_xyz4_sorted: wp.array2d(dtype=wp.float32),
+    pc_norm_sorted: wp.array(dtype=wp.float32),
+    pc_orig_sorted: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """Tiled GEMM distances :math:`\\lVert Q\\rVert^2 + \\lVert P\\rVert^2 - 2 Q P^T`.
+
+    Launched with ``wp.launch_tiled(dim=[num_tasks], block_dim=TILE_P)``; one block
+    per task, one lane per candidate point. ``out_count`` is an atomic slot counter
+    that can overshoot ``max_points``, so the host clamps it afterward.
+    """
+    task_id = wp.tid()
+    qb = task_q_begin[task_id]
+    qc = task_q_count[task_id]
+    pb = task_p_begin[task_id]
+    pcount = task_p_count[task_id]
+
+    q_tile = wp.tile_load(q_xyz4_sorted, shape=(TILE_Q, 4), offset=(qb, 0), storage="shared")
+    p_tile = wp.tile_load(pc_xyz4_sorted, shape=(TILE_P, 4), offset=(pb, 0), storage="shared")
+    dot_tile = wp.tile_zeros(shape=(TILE_Q, TILE_P), dtype=wp.float32)
+    wp.tile_matmul(q_tile, wp.tile_transpose(p_tile), dot_tile)
+    dot = wp.untile(dot_tile)
+    lane = wp.untile(wp.tile_load(lane_iota, shape=(TILE_P,)))
+
+    if lane < pcount:
+        sp = pb + lane
+        p_norm = pc_norm_sorted[sp]
+        porig = pc_orig_sorted[sp]
+        for iq in range(TILE_Q):
+            if iq < qc:
+                flat_q = q_orig_sorted[qb + iq]
+                if out_count[flat_q] < max_points:
+                    d2 = q_norm_sorted[qb + iq] + p_norm - 2.0 * dot[iq]
+                    if d2 <= radius2:
+                        slot = wp.atomic_add(out_count, flat_q, 1)
+                        if slot < max_points:
+                            out_idx[flat_q, slot] = porig
+                            if return_dists:
+                                out_dist[flat_q, slot] = wp.sqrt(wp.max(d2, 0.0))
+                            if return_points:
+                                out_pts[flat_q, slot] = wp.vec3(
+                                    pc_xyz4_sorted[sp, 0],
+                                    pc_xyz4_sorted[sp, 1],
+                                    pc_xyz4_sorted[sp, 2],
+                                )
+
+
+# ---------------------------------------------------------------------------
+# In-kernel-gather matmul search: one block per query, per-chunk tiled matmul
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def radius_search_dense_fma_kernel_mm(
+    q_xyz4_sorted: wp.array2d(dtype=wp.float32),
+    q_norm_sorted: wp.array(dtype=wp.float32),
+    q_orig_sorted: wp.array(dtype=wp.int32),
+    inv_radius: wp.float32,
+    Q: wp.int32,
+    neighbor_offsets: wp.array2d(dtype=wp.int32),
+    min_cx: wp.array(dtype=wp.int32),
+    min_cy: wp.array(dtype=wp.int32),
+    min_cz: wp.array(dtype=wp.int32),
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_begin_by_row: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+    pc_xyz4_sorted: wp.array2d(dtype=wp.float32),
+    pc_norm_sorted: wp.array(dtype=wp.float32),
+    pc_orig_sorted: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """One block per query: scan 27 dense cells, distances via per-chunk matmul.
+
+    Same per-query 27-cell scan as ``radius_search_dense_fma_kernel``, but each
+    ``TILE_P``-wide candidate chunk is loaded as a tile and its squared distances
+    come from the norm expansion :math:`\\lVert q\\rVert^2 + \\lVert p\\rVert^2 -
+    2 q p^T` with a tiled matmul of the single query row against the chunk, then a
+    radius mask. Hits are compacted with the same block-wide tile scan as the FMA
+    kernel. Launched with ``wp.launch_tiled(dim=[Nq], block_dim=TILE_P)``.
+    """
+    sorted_q, lane = wp.tid()
+    flat_q = q_orig_sorted[sorted_q]
+    b = flat_q // Q
+    q_norm = q_norm_sorted[sorted_q]
+    gx = grid_x[b]
+    gy = grid_y[b]
+    gz = grid_z[b]
+    mcx = min_cx[b]
+    mcy = min_cy[b]
+    mcz = min_cz[b]
+    gbase = grid_base[b]
+    lqx = wp.int32(wp.floor(q_xyz4_sorted[sorted_q, 0] * inv_radius)) - mcx
+    lqy = wp.int32(wp.floor(q_xyz4_sorted[sorted_q, 1] * inv_radius)) - mcy
+    lqz = wp.int32(wp.floor(q_xyz4_sorted[sorted_q, 2] * inv_radius)) - mcz
+
+    q_tile = wp.tile_load(q_xyz4_sorted, shape=(1, 4), offset=(sorted_q, 0), storage="shared")
+
+    found = wp.int32(0)
+    for n in range(27):
+        lx = lqx + neighbor_offsets[n, 0]
+        ly = lqy + neighbor_offsets[n, 1]
+        lz = lqz + neighbor_offsets[n, 2]
+        if lx >= 0 and lx < gx and ly >= 0 and ly < gy and lz >= 0 and lz < gz:
+            row = gbase + lx + gx * (ly + gy * lz)
+            start = cell_begin_by_row[row]
+            end = start + cell_count_by_row[row]
+            base = start
+            while base < end:
+                p_tile = wp.tile_load(
+                    pc_xyz4_sorted, shape=(TILE_P, 4), offset=(base, 0), storage="shared"
+                )
+                dot_tile = wp.tile_zeros(shape=(1, TILE_P), dtype=wp.float32)
+                wp.tile_matmul(q_tile, wp.tile_transpose(p_tile), dot_tile)
+                dot = wp.untile(dot_tile)
+
+                si = base + lane
+                hit = wp.int32(0)
+                d2 = wp.float32(0.0)
+                if si < end:
+                    d2 = q_norm + pc_norm_sorted[si] - 2.0 * dot[0]
+                    if d2 <= radius2:
+                        hit = wp.int32(1)
+                hit_tile = wp.tile(hit)
+                prefix = wp.untile(wp.tile_scan_exclusive(hit_tile))
+                hits_tile = wp.tile_sum(hit_tile)
+                write_hits = wp.min(hits_tile[0], max_points - found)
+                if hit == 1 and prefix < write_hits:
+                    slot = found + prefix
+                    out_idx[flat_q, slot] = pc_orig_sorted[si]
+                    if return_dists:
+                        out_dist[flat_q, slot] = wp.sqrt(wp.max(d2, 0.0))
+                    if return_points:
+                        out_pts[flat_q, slot] = wp.vec3(
+                            pc_xyz4_sorted[si, 0],
+                            pc_xyz4_sorted[si, 1],
+                            pc_xyz4_sorted[si, 2],
+                        )
+                found += write_hits
+                if found >= max_points:
+                    break
+                base += TILE_P
+        if found >= max_points:
+            break
+    if lane == 0:
+        out_count[flat_q] = found

--- a/physicsnemo/nn/functional/neighbors/radius_search/_morton_dense_impl.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_morton_dense_impl.py
@@ -1,0 +1,1802 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Torch <-> Warp host glue for the Morton-sorted compact dense-cell radius search.
+
+This backend replaces the open-addressed cell hash of ``_morton_impl.py`` with a
+dense, directly-indexed cell table: points are mapped to radius-sized cells laid
+out in a per-batch row-major grid, the occupied bins are compacted in Morton-cell
+order for locality, and a ``(begin, count)`` table indexed by dense row id gives
+O(1) cell lookup at search time (no hash, no binary search).
+
+Two search paths share the same index:
+
+* ``dense_fma``  -- :func:`radius_search_morton_warp_fma`, one warp per query.
+* ``dense_gemm`` -- :func:`radius_search_morton_tiled_gemm`, a tiled-matmul
+  benchmark path.
+
+:func:`radius_search_morton_dense` is the single entry point used by the dispatch
+in ``_warp_impl.py``. It mirrors the ``max_points`` return contract of
+``radius_search_impl``: ``(indices, points, distances, num_neighbors)`` with the
+batch dimension squeezed for unbatched inputs and outputs cast back to the input
+dtype. This backend is CUDA-only.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+import warp as wp
+import os
+from physicsnemo.core.function_spec import FunctionSpec
+
+from . import _morton_dense_gemm_kernels as mgk
+from . import _morton_dense_kernels as mk
+from .utils import validate_inputs
+
+TILE_Q = mk.TILE_Q
+TILE_P = mk.TILE_P
+FMA_BLOCK_DIM = mk.FMA_BLOCK_DIM
+MEM_OPT_2_BLOCK_DIM = mk.MEM_OPT_2_BLOCK_DIM
+
+FMA_V2_BLOCK_DIM = mk.FMA_V2_BLOCK_DIM
+
+DENSE_VARIANTS = (
+    "dense_fma",
+    "dense_fma_e2e",
+    "dense_fma_store_opt",
+    "dense_fma_mem_opt",
+    "dense_fma_mm",
+    "dense_gemm",
+    # WIP experimental cell-centric mem-optimized launch; see
+    # radius_search_mem_optimized_launch. Not runnable until its kernel is finished.
+    "custom_grid_cell",
+    "custom_grid_cell_2"
+)
+
+# Inflate the cell slightly past the nominal radius so the fixed 27-cell stencil
+# never misses a boundary neighbor under fp rounding in the floor() quantization.
+_CELL_INFLATION = 1.0 + 1e-3
+
+# Dense cell ids and the radix-sort count are int32, so the grid cannot exceed the
+# positive int32 range. Memory is proportional to total_cells (begin/count tables
+# plus sort scratch), so a small radius relative to the domain extent can make the
+# dense backend enormous; that is left to the caller to manage.
+_MAX_TOTAL_CELLS = (1 << 31) - 1
+
+def _grid_metadata_2(points:torch.Tensor, inv_radius: float):
+    '''
+    removes morton bits and ordering
+    '''
+    device = points.device
+    B = points.shape[0]
+    abs_cells = torch.floor(points * inv_radius).to(torch.int64)
+    min_c = abs_cells.amin(dim=1)
+    max_c = abs_cells.amax(dim=1)
+    
+    grid = max_c - min_c + 1
+
+    cells_per_batch = grid[:, 0] * grid[:, 1] * grid[:, 2]
+    grid_base = torch.zeros(B + 1, dtype=torch.int64, device=device)
+    
+    torch.cumsum(cells_per_batch, dim=0, out=grid_base[1:])
+
+    total_cells_device = grid_base[B]
+
+    return min_c, grid, grid_base, total_cells_device
+
+
+
+
+
+
+    
+
+def _grid_metadata(points: torch.Tensor, inv_radius: float):
+    """Per-batch dense-grid extents and the Morton bit budget for ``points``.
+
+    Returns ``(min_c, grid, grid_base, total_cells, bits, morton_bits)`` where
+    ``min_c``/``grid`` are ``(B, 3)`` int64 cell minima/extents, ``grid_base`` is
+    the ``(B + 1,)`` exclusive scan of per-batch cell counts, and ``bits`` is the
+    Morton bits per axis.
+    """
+    device = points.device
+    B = points.shape[0]
+    abs_cells = torch.floor(points * inv_radius).to(torch.int64)
+    min_c = abs_cells.amin(dim=1)
+    max_c = abs_cells.amax(dim=1)
+    
+    grid = max_c - min_c + 1
+
+    cells_per_batch = grid[:, 0] * grid[:, 1] * grid[:, 2]
+    grid_base = torch.zeros(B + 1, dtype=torch.int64, device=device)
+    
+    torch.cumsum(cells_per_batch, dim=0, out=grid_base[1:])
+    
+    total_cells = int(grid_base[B].item())
+ 
+    max_extent = int(grid.max().item())
+    bits = max(1, max_extent.bit_length())
+    batch_bits = 0 if B <= 1 else (B - 1).bit_length()
+    morton_bits = 3 * bits
+    if morton_bits + batch_bits > 63:
+        raise ValueError(
+            "Morton key would overflow int64: "
+            f"{morton_bits} morton bits + {batch_bits} batch bits > 63. "
+            "Use a larger radius or process fewer batches per call."
+        )
+    return min_c, grid, grid_base, total_cells, bits, morton_bits
+
+
+def _neighbor_offsets_27(device: torch.device) -> torch.Tensor:
+    """The 27 cell offsets in ``{-1, 0, 1}^3``, ordered near to far for early exit."""
+    rng = (-1, 0, 1)
+    offs = [(dx, dy, dz) for dx in rng for dy in rng for dz in rng]
+    offs.sort(key=lambda o: o[0] * o[0] + o[1] * o[1] + o[2] * o[2])
+    return torch.tensor(offs, dtype=torch.int32, device=device)
+
+
+@dataclass
+class MortonCompactDenseIndex:
+    """Reusable PC-side dense-cell grid + Morton-sorted compact point bins.
+
+    Attributes:
+        B: Batch size.
+        P: Points per batch.
+        Np: Total points (``B * P``).
+        radius: Search radius.
+        inv_radius: Reciprocal of the (slightly inflated) cell size.
+        bits: Morton bits per axis.
+        morton_bits: Total Morton bit width (``3 * bits``).
+        total_cells: Number of dense cells across all batches.
+        min_cx/min_cy/min_cz: Per-batch cell minima, shape ``(B,)`` int32.
+        grid_x/grid_y/grid_z: Per-batch cell extents, shape ``(B,)`` int32.
+        grid_base: Per-batch dense-cell base offsets, shape ``(B + 1,)`` int32.
+        offsets: Near-to-far 27-cell offset table, shape ``(27, 3)`` int32.
+        cell_begin_by_row: Compact start index per dense row, shape ``(total_cells,)``.
+        cell_count_by_row: Point count per dense row, shape ``(total_cells,)``.
+        pc_x_sorted/pc_y_sorted/pc_z_sorted: Morton-cell-sorted point coords as SoA,
+            ``(Np,)`` each. The FMA search reads these per-lane; the SoA layout keeps
+            those reads coalesced with no wasted bandwidth.
+        pc_orig_sorted: Local point index per sorted slot, ``(Np,)``.
+        pc_xyz4_sorted: Padded ``(x, y, z, 0)`` coords, ``(>=Np, 4)``, for the GEMM
+            path's tile loads.
+        pc_norm_sorted: Squared norm per sorted slot for the GEMM path.
+    """
+
+    B: int
+    P: int
+    Np: int
+    radius: float
+    inv_radius: float
+    bits: int
+    morton_bits: int
+    total_cells: int
+    min_cx: torch.Tensor
+    min_cy: torch.Tensor
+    min_cz: torch.Tensor
+    grid_x: torch.Tensor
+    grid_y: torch.Tensor
+    grid_z: torch.Tensor
+    grid_base: torch.Tensor
+    offsets: torch.Tensor
+    cell_begin_by_row: torch.Tensor
+    cell_count_by_row: torch.Tensor
+    pc_x_sorted: torch.Tensor
+    pc_y_sorted: torch.Tensor
+    pc_z_sorted: torch.Tensor
+    pc_orig_sorted: torch.Tensor
+    pc_xyz4_sorted: torch.Tensor
+    pc_norm_sorted: torch.Tensor
+
+
+@dataclass
+class SortedQueryData:
+    """Morton-sorted query arrays produced by :func:`prepare_morton_sorted_queries`.
+
+    Attributes:
+        B: Batch size.
+        Q: Queries per batch.
+        Nq: Total queries (``B * Q``).
+        q_orig_sorted: Original flat query id (``b * Q + q``) per sorted slot. The
+            batch id and absolute cell coords are derived from this and the coords
+            where needed (``b = flat_q // Q``, cell = ``floor(coord / cell_size)``).
+        q_x_sorted/q_y_sorted/q_z_sorted: Sorted query coords (SoA), read per-query
+            by the FMA search.
+        q_xyz4_sorted: Padded ``(x, y, z, 0)`` query coords, ``(>=Nq, 4)``, for the
+            GEMM path's tile loads.
+        q_norm_sorted: Squared norm per sorted query for the GEMM path.
+        qkeys_sorted: Sorted packed query keys (for GEMM query-cell grouping).
+    """
+
+    B: int
+    Q: int
+    Nq: int
+    q_orig_sorted: torch.Tensor
+    q_x_sorted: torch.Tensor
+    q_y_sorted: torch.Tensor
+    q_z_sorted: torch.Tensor
+    q_xyz4_sorted: torch.Tensor
+    q_norm_sorted: torch.Tensor
+    qkeys_sorted: torch.Tensor
+
+
+def build_morton_compact_dense_index(
+    points: torch.Tensor,
+    radius: float,
+    wp_device,
+    wp_stream,
+    sort_cells: bool = True,
+    is_e2e:bool = False
+) -> MortonCompactDenseIndex:
+    """Build the dense-cell index: histogram, order cells, compact points.
+
+    Args:
+        points: Reference points of shape ``(B, N, 3)``, float32, CUDA.
+        radius: Search radius.
+        wp_device: Warp launch device (from ``warp_launch_context``).
+        wp_stream: Warp launch stream (from ``warp_launch_context``).
+        sort_cells: When ``True`` (default) the compact point bins are laid out in
+            Morton-cell order via a ``radix_sort_pairs`` over all ``total_cells``.
+            When ``False`` the bins are laid out in row-major dense-cell order via a
+            single exclusive scan of ``cell_count_by_row`` -- no radix sort and no
+            ``2 * total_cells`` scratch. Both orders are correct (the search kernel
+            indexes cells by row-major dense id); Morton only changes locality.
+
+    Returns:
+        The populated :class:`MortonCompactDenseIndex`.
+
+    Raises:
+        ValueError: If the Morton key would overflow int64, or the dense grid
+            exceeds the int32 cell-id limit.
+    """
+    device = points.device
+    B, P, _ = points.shape
+    Np = B * P
+
+    cell_size = float(radius) * _CELL_INFLATION
+    inv_radius = 1.0 / cell_size
+
+    if os.environ.get('PROFILE_RUN', '0') == '1':
+        torch.cuda.nvtx.range_push('GRID METADATA')
+    
+    if is_e2e:
+        min_c, grid, grid_base_t, total_cells_device = _grid_metadata_2(points, inv_radius)
+        bits = 0
+        morton_bits =0
+    else:
+        min_c, grid, grid_base_t, total_cells, bits, morton_bits = _grid_metadata(
+            points, inv_radius
+        )
+
+    if os.environ.get('PROFILE_RUN', '0') == '1':
+        torch.cuda.nvtx.range_pop()
+    
+    if is_e2e:
+        total_cells = int(total_cells_device.item())
+        #total_cells = 845853361
+        #total_cells = 100
+    # print(f"TOTAL CELLS : {total_cells}")
+    # import ipdb; ipdb.set_trace()
+    if total_cells > _MAX_TOTAL_CELLS:
+        raise ValueError(
+            f"dense grid has {total_cells} cells, exceeding the int32 cell-id "
+            f"limit ({_MAX_TOTAL_CELLS}). Use a larger radius."
+        )
+
+    min_cx = min_c[:, 0].to(torch.int32).contiguous()
+    min_cy = min_c[:, 1].to(torch.int32).contiguous()
+    min_cz = min_c[:, 2].to(torch.int32).contiguous()
+
+    grid_x = grid[:, 0].to(torch.int32).contiguous()
+    grid_y = grid[:, 1].to(torch.int32).contiguous()
+    grid_z = grid[:, 2].to(torch.int32).contiguous()
+    grid_base = grid_base_t.to(torch.int32).contiguous()
+
+    points_wp = wp.from_torch(points, dtype=wp.vec3, return_ctype=True)
+    min_cx_wp = wp.from_torch(min_cx)
+    min_cy_wp = wp.from_torch(min_cy)
+    min_cz_wp = wp.from_torch(min_cz)
+    grid_x_wp = wp.from_torch(grid_x)
+    grid_y_wp = wp.from_torch(grid_y)
+    grid_z_wp = wp.from_torch(grid_z)
+    grid_base_wp = wp.from_torch(grid_base)
+
+    point_cell_row = torch.empty(Np, dtype=torch.int32, device=device)
+    cell_count_by_row = torch.zeros(total_cells, dtype=torch.int32, device=device)
+    if os.environ.get('PROFILE_RUN', '0') == '1':
+        torch.cuda.nvtx.range_push('COUNT POINTS IN CELL')
+    wp.launch(
+        kernel=mk.count_points_in_cells,
+        dim=Np,
+        inputs=[
+            points_wp,
+            float(inv_radius),
+            int(P),
+            min_cx_wp,
+            min_cy_wp,
+            min_cz_wp,
+            grid_x_wp,
+            grid_y_wp,
+            grid_base_wp,
+            wp.from_torch(point_cell_row),
+            wp.from_torch(cell_count_by_row),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+    if os.environ.get('PROFILE_RUN', '0') == '1':
+        torch.cuda.nvtx.range_pop()
+
+    # Per-row start offsets into the compact point arrays. Both layouts below are
+    # correct because the search kernel looks cells up by row-major dense id (never
+    # by Morton rank); Morton ordering only changes the spatial locality of the
+    # compact bins.
+    cell_begin_by_row = torch.empty(total_cells, dtype=torch.int32, device=device)
+    if sort_cells:
+        # Morton-cell order: sort every dense cell by its (batch, Morton) key, then
+        # scatter the rank-order prefix offsets back into row-indexed starts. This
+        # is the expensive radix_sort_pairs over all `total_cells` int64 keys.
+        cell_key_tmp = torch.empty(2 * total_cells, dtype=torch.int64, device=device)
+        cell_row_tmp = torch.empty(2 * total_cells, dtype=torch.int32, device=device)
+        cell_key_wp = wp.from_torch(cell_key_tmp)
+        cell_row_wp = wp.from_torch(cell_row_tmp)
+        wp.launch(
+            kernel=mk.enumerate_cell_morton_keys,
+            dim=total_cells,
+            inputs=[
+                grid_x_wp,
+                grid_y_wp,
+                grid_base_wp,
+                int(B),
+                int(bits),
+                int(morton_bits),
+                cell_key_wp,
+                cell_row_wp,
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+        wp.utils.radix_sort_pairs(cell_key_wp, cell_row_wp, total_cells)
+
+        cell_counts_rank = torch.empty(total_cells, dtype=torch.int32, device=device)
+        cell_offsets_rank = torch.empty(total_cells, dtype=torch.int32, device=device)
+        counts_rank_wp = wp.from_torch(cell_counts_rank)
+        offsets_rank_wp = wp.from_torch(cell_offsets_rank)
+        wp.launch(
+            kernel=mk.gather_cell_counts_by_rank,
+            dim=total_cells,
+            inputs=[cell_row_wp, wp.from_torch(cell_count_by_row), counts_rank_wp],
+            device=wp_device,
+            stream=wp_stream,
+        )
+        wp.utils.array_scan(counts_rank_wp, offsets_rank_wp, inclusive=False)
+        wp.launch(
+            kernel=mk.fill_cell_row_ranges,
+            dim=total_cells,
+            inputs=[cell_row_wp, offsets_rank_wp, wp.from_torch(cell_begin_by_row)],
+            device=wp_device,
+            stream=wp_stream,
+        )
+    else:
+        # Row-major order: a single exclusive scan of the per-row counts gives the
+        # per-row starts directly. No radix sort, no key/rank scratch buffers.
+        if os.environ.get('PROFILE_RUN', '0') == '1':
+            torch.cuda.nvtx.range_push('Array Scan')
+        # _warp_exclusive_scan(
+        #     cell_count_by_row, cell_begin_by_row, wp_device, wp_stream
+        # )
+        wp.utils.array_scan(
+            wp.from_torch(cell_count_by_row),
+            wp.from_torch(cell_begin_by_row),
+            inclusive=False,
+        )
+        if os.environ.get('PROFILE_RUN', '0') == '1':
+            torch.cuda.nvtx.range_pop()
+
+    n_pad = Np + TILE_P
+    pc_x_sorted = torch.empty(Np, dtype=torch.float32, device=device)
+    pc_y_sorted = torch.empty(Np, dtype=torch.float32, device=device)
+    pc_z_sorted = torch.empty(Np, dtype=torch.float32, device=device)
+    pc_orig_sorted = torch.empty(Np, dtype=torch.int32, device=device)
+    pc_xyz4_sorted = torch.zeros((n_pad, 4), dtype=torch.float32, device=device)
+    pc_norm_sorted = torch.zeros(n_pad, dtype=torch.float32, device=device)
+    cell_write_by_row = cell_begin_by_row.clone()
+
+    if os.environ.get('PROFILE_RUN', '0') == '1':
+        torch.cuda.nvtx.range_push('Scatter Points to cells')
+    wp.launch(
+        kernel=mk.scatter_points_to_cells,
+        dim=Np,
+        inputs=[
+            points_wp,
+            wp.from_torch(point_cell_row),
+            int(P),
+            wp.from_torch(cell_write_by_row),
+            wp.from_torch(pc_x_sorted),
+            wp.from_torch(pc_y_sorted),
+            wp.from_torch(pc_z_sorted),
+            wp.from_torch(pc_orig_sorted),
+            wp.from_torch(pc_xyz4_sorted),
+            wp.from_torch(pc_norm_sorted),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+    if os.environ.get('PROFILE_RUN', '0') == '1':
+        torch.cuda.nvtx.range_pop()
+
+    return MortonCompactDenseIndex(
+        B=B,
+        P=P,
+        Np=Np,
+        radius=float(radius),
+        inv_radius=float(inv_radius),
+        bits=int(bits),
+        morton_bits=int(morton_bits),
+        total_cells=total_cells,
+        min_cx=min_cx,
+        min_cy=min_cy,
+        min_cz=min_cz,
+        grid_x=grid_x,
+        grid_y=grid_y,
+        grid_z=grid_z,
+        grid_base=grid_base,
+        offsets=_neighbor_offsets_27(device),
+        cell_begin_by_row=cell_begin_by_row,
+        cell_count_by_row=cell_count_by_row,
+        pc_x_sorted=pc_x_sorted,
+        pc_y_sorted=pc_y_sorted,
+        pc_z_sorted=pc_z_sorted,
+        pc_orig_sorted=pc_orig_sorted,
+        pc_xyz4_sorted=pc_xyz4_sorted,
+        pc_norm_sorted=pc_norm_sorted,
+    )
+
+
+def prepare_morton_sorted_queries(
+    index: MortonCompactDenseIndex,
+    queries: torch.Tensor,
+    wp_device,
+    wp_stream,
+    sort_queries: bool = True,
+) -> SortedQueryData:
+    """Order the queries and gather their coords, absolute cells, and norms.
+
+    Args:
+        index: The PC-side dense index (provides the shared ``inv_radius`` / bits).
+        queries: Query points of shape ``(B, Q, 3)``, float32, CUDA.
+        wp_device: Warp launch device.
+        wp_stream: Warp launch stream.
+        sort_queries: When ``True`` (default) the queries are Morton-sorted via a
+            ``radix_sort_pairs`` over ``Nq`` (for search-time locality), and
+            ``qkeys_sorted`` is populated for the GEMM query-cell grouping. When
+            ``False`` the queries are kept in original (identity) order -- no radix
+            sort -- and ``qkeys_sorted`` is empty. The FMA search is
+            order-independent (one block per query, output written at the original
+            flat id), so only the GEMM path needs ``sort_queries=True``.
+
+    Returns:
+        The populated :class:`SortedQueryData`.
+    """
+    device = queries.device
+    B, Q, _ = queries.shape
+    Nq = B * Q
+    inv_radius = index.inv_radius
+
+    queries_wp = wp.from_torch(queries, dtype=wp.vec3, return_ctype=True)
+
+    if sort_queries:
+        # Morton-sort the queries so adjacent blocks touch overlapping cells (L2
+        # locality); also yields qkeys_sorted for the GEMM query-cell grouping.
+        q_abs = torch.floor(queries * inv_radius).to(torch.int64)
+        q_min = q_abs.amin(dim=1)
+        q_min_cx = q_min[:, 0].to(torch.int32).contiguous()
+        q_min_cy = q_min[:, 1].to(torch.int32).contiguous()
+        q_min_cz = q_min[:, 2].to(torch.int32).contiguous()
+
+        q_key_tmp = torch.empty(2 * Nq, dtype=torch.int64, device=device)
+        q_val_tmp = torch.empty(2 * Nq, dtype=torch.int32, device=device)
+        q_key_wp = wp.from_torch(q_key_tmp)
+        q_val_wp = wp.from_torch(q_val_tmp)
+        wp.launch(
+            kernel=mk.make_query_morton_keys,
+            dim=Nq,
+            inputs=[
+                queries_wp,
+                float(inv_radius),
+                int(Q),
+                wp.from_torch(q_min_cx),
+                wp.from_torch(q_min_cy),
+                wp.from_torch(q_min_cz),
+                int(index.bits),
+                int(index.morton_bits),
+                q_key_wp,
+                q_val_wp,
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+        wp.utils.radix_sort_pairs(q_key_wp, q_val_wp, Nq)
+        qkeys_sorted = q_key_tmp[:Nq].clone()
+    else:
+        # Identity order: no key build, no radix sort. gather_sorted_queries still
+        # runs below to build the SoA/vec4/norm arrays the search kernel reads.
+        # qkeys_sorted is consumed only by the GEMM task builder -> leave empty.
+        q_val_tmp = torch.arange(Nq, dtype=torch.int32, device=device)
+        q_val_wp = wp.from_torch(q_val_tmp)
+        qkeys_sorted = torch.empty(0, dtype=torch.int64, device=device)
+
+    bq_pad = Nq + TILE_Q
+    q_orig_sorted = torch.empty(Nq, dtype=torch.int32, device=device)
+    q_x_sorted = torch.empty(Nq, dtype=torch.float32, device=device)
+    q_y_sorted = torch.empty(Nq, dtype=torch.float32, device=device)
+    q_z_sorted = torch.empty(Nq, dtype=torch.float32, device=device)
+    q_xyz4_sorted = torch.zeros((bq_pad, 4), dtype=torch.float32, device=device)
+    q_norm_sorted = torch.zeros(bq_pad, dtype=torch.float32, device=device)
+    wp.launch(
+        kernel=mk.gather_sorted_queries,
+        dim=Nq,
+        inputs=[
+            queries_wp,
+            q_val_wp,
+            int(Q),
+            wp.from_torch(q_orig_sorted),
+            wp.from_torch(q_x_sorted),
+            wp.from_torch(q_y_sorted),
+            wp.from_torch(q_z_sorted),
+            wp.from_torch(q_xyz4_sorted),
+            wp.from_torch(q_norm_sorted),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    return SortedQueryData(
+        B=B,
+        Q=Q,
+        Nq=Nq,
+        q_orig_sorted=q_orig_sorted,
+        q_x_sorted=q_x_sorted,
+        q_y_sorted=q_y_sorted,
+        q_z_sorted=q_z_sorted,
+        q_xyz4_sorted=q_xyz4_sorted,
+        q_norm_sorted=q_norm_sorted,
+        qkeys_sorted=qkeys_sorted,
+    )
+
+
+# def _warp_exclusive_scan(
+#     counts: torch.Tensor,
+#     begins: torch.Tensor,
+#     wp_device: str,
+#     wp_stream,
+# ) -> None:
+#     """
+#     In-place async exclusive prefix scan with no cudaDeviceSynchronize.
+
+#     Uses a three-phase Warp tile kernel (see exclusive_scan_phase{1,2,3} in
+#     _morton_dense_kernels.py) that stays entirely on *wp_stream*:
+
+#       Phase 1  per-block local exclusive scan + block totals
+#       Phase 2  exclusive scan of block totals  (single block)
+#       Phase 3  global[i] = local[i] + block_offset[block(i)]
+
+#     Constraint: len(counts) <= SCAN_BLOCK^2 (= 1 048 576 with SCAN_BLOCK=1024).
+#     """
+#     n = counts.shape[0]
+#     if n == 0:
+#         return
+#     BLOCK = int(mk.SCAN_BLOCK)  # wp.constant → Python int for arithmetic
+#     num_blocks = math.ceil(n / BLOCK)
+#     if num_blocks > BLOCK:
+#         raise ValueError(
+#             f"_warp_exclusive_scan: n={n} exceeds two-level limit "
+#             f"SCAN_BLOCK^2={BLOCK * BLOCK}. Increase SCAN_BLOCK or use a "
+#             "three-level hierarchy."
+#         )
+
+#     n_pad = num_blocks * BLOCK
+
+#     # Zero-initialised padded input so the last tile load is always in-bounds.
+#     arr_pad_wp = wp.zeros(n_pad, dtype=wp.int32, device=wp_device)
+#     wp.launch(
+#         mk._scan_copy_pad,
+#         dim=n,
+#         inputs=[wp.from_torch(counts), arr_pad_wp, n],
+#         device=wp_device,
+#         stream=wp_stream,
+#     )
+
+#     partial_wp = wp.empty(n_pad, dtype=wp.int32, device=wp_device)
+#     block_sums_wp = wp.zeros(BLOCK, dtype=wp.int32, device=wp_device)
+#     block_offsets_wp = wp.empty(BLOCK, dtype=wp.int32, device=wp_device)
+
+#     wp.launch(
+#         mk.exclusive_scan_phase1,
+#         dim=num_blocks,
+#         block_dim=BLOCK,
+#         inputs=[arr_pad_wp, partial_wp, block_sums_wp],
+#         device=wp_device,
+#         stream=wp_stream,
+#     )
+#     wp.launch(
+#         mk.exclusive_scan_phase2,
+#         dim=1,
+#         block_dim=BLOCK,
+#         inputs=[block_sums_wp, block_offsets_wp],
+#         device=wp_device,
+#         stream=wp_stream,
+#     )
+#     wp.launch(
+#         mk.exclusive_scan_phase3,
+#         dim=n,
+#         inputs=[partial_wp, block_offsets_wp, wp.from_torch(begins), n, BLOCK],
+#         device=wp_device,
+#         stream=wp_stream,
+#     )
+
+
+def _exclusive_scan(counts: torch.Tensor) -> torch.Tensor:
+    """Exclusive prefix sum of a 1D integer tensor, returned as ``int64``."""
+    counts64 = counts.to(torch.int64)
+    return torch.cumsum(counts64, dim=0) - counts64
+
+
+def _alloc_outputs(B, Q, max_points, return_dists, return_points, device):
+    """Allocate the output tensors (indices/count always; dists/pts optional)."""
+    out_idx = torch.zeros((B, Q, max_points), dtype=torch.int32, device=device)
+    out_count = torch.zeros(B * Q, dtype=torch.int32, device=device)
+    out_dist = (
+        torch.zeros((B, Q, max_points), dtype=torch.float32, device=device)
+        if return_dists
+        else None
+    )
+    out_pts = (
+        torch.zeros((B, Q, max_points, 3), dtype=torch.float32, device=device)
+        if return_points
+        else None
+    )
+    return out_idx, out_count, out_dist, out_pts
+
+
+def _wp_outputs(out_idx, out_count, out_dist, out_pts, Nq, max_points):
+    """Wrap the (flattened) output tensors as Warp arrays for a search launch."""
+    idx_wp = wp.from_torch(out_idx.view(Nq, max_points))
+    count_wp = wp.from_torch(out_count)
+    dist_wp = (
+        wp.from_torch(out_dist.view(Nq, max_points)) if out_dist is not None else None
+    )
+    pts_wp = (
+        wp.from_torch(out_pts.view(Nq, max_points, 3), dtype=wp.vec3)
+        if out_pts is not None
+        else None
+    )
+    return idx_wp, count_wp, dist_wp, pts_wp
+
+
+def _gather_neighbor_points(
+    points: torch.Tensor,
+    out_idx: torch.Tensor,
+    num: torch.Tensor,
+) -> torch.Tensor:
+    """Gather neighbor coordinates from ``out_idx`` on the host (Stage 1).
+
+    Replaces the FMA kernel's old per-neighbor ``wp.vec3`` global scatter (a
+    misaligned 12-byte store NCU flagged as inefficient) with a coalesced
+    ``index_select`` gather from the reference points.
+
+    Args:
+        points: Reference points, ``(B, N, 3)`` float32.
+        out_idx: Per-query neighbor indices -- local point ids in ``[0, N)`` with 0
+            padding past the neighbor count -- ``(B, Q, max_points)`` int32.
+        num: Neighbor count per query, ``(B, Q)`` int32.
+
+    Returns:
+        Neighbor coordinates ``(B, Q, max_points, 3)`` float32, with padding slots
+        (``slot >= num``) zeroed to match the previous in-kernel output contract.
+    """
+    B, N, _ = points.shape
+    _, Q, mp = out_idx.shape
+    device = points.device
+    # Flatten (batch, local-point) -> global row so a single index_select gathers
+    # every neighbor coordinate in one coalesced pass.
+    idx = out_idx.long().clamp_(0, N - 1)
+    batch_off = (torch.arange(B, device=device, dtype=torch.long) * N).view(B, 1, 1)
+    flat = (idx + batch_off).reshape(-1)
+    gathered = points.reshape(B * N, 3).index_select(0, flat).reshape(B, Q, mp, 3)
+    # Zero the padding slots (slot >= neighbor count) to preserve the old contract.
+    slot = torch.arange(mp, device=device).view(1, 1, mp)
+    valid = slot < num.view(B, Q, 1)
+    return gathered * valid.unsqueeze(-1).to(gathered.dtype)
+
+
+def radius_search_morton_warp_fma(
+    index: MortonCompactDenseIndex,
+    queries: SortedQueryData,
+    radius: float,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    wp_device,
+    wp_stream,
+):
+    """Production search: one warp per query over the dense Morton-sorted cells.
+
+    Returns ``(indices, points, distances, num_neighbors)`` with the batch dim
+    intact; ``points``/``distances`` are ``None`` when not requested.
+    """
+    B, Q, Nq = queries.B, queries.Q, queries.Nq
+    device = index.pc_xyz4_sorted.device
+    
+    if os.environ.get('PROFILE_RUN', '0') =='1':
+        torch.cuda.nvtx.range_push('alloc outputs')
+    
+    out_idx, out_count, out_dist, out_pts = _alloc_outputs(
+        B, Q, max_points, return_dists, return_points, device
+    )
+    idx_wp, count_wp, dist_wp, pts_wp = _wp_outputs(
+        out_idx, out_count, out_dist, out_pts, Nq, max_points
+    )
+
+    if os.environ.get('PROFILE_RUN', '0') =='1':
+        torch.cuda.nvtx.range_pop()
+
+    if os.environ.get('PROFILE_RUN', '0') =='1':
+        torch.cuda.nvtx.range_push('RAD SEARCH KERNEL')
+
+    wp.launch_tiled(
+        kernel=mk.radius_search_dense_fma_kernel_v2,
+        dim=Nq,
+        inputs=[
+            wp.from_torch(queries.q_x_sorted),
+            wp.from_torch(queries.q_y_sorted),
+            wp.from_torch(queries.q_z_sorted),
+            wp.from_torch(queries.q_orig_sorted),
+            float(index.inv_radius),
+            int(queries.Q),
+            wp.from_torch(index.offsets),
+            wp.from_torch(index.min_cx),
+            wp.from_torch(index.min_cy),
+            wp.from_torch(index.min_cz),
+            wp.from_torch(index.grid_x),
+            wp.from_torch(index.grid_y),
+            wp.from_torch(index.grid_z),
+            wp.from_torch(index.grid_base),
+            wp.from_torch(index.cell_begin_by_row),
+            wp.from_torch(index.cell_count_by_row),
+            wp.from_torch(index.pc_x_sorted),
+            wp.from_torch(index.pc_y_sorted),
+            wp.from_torch(index.pc_z_sorted),
+            wp.from_torch(index.pc_orig_sorted),
+            float(radius) * float(radius),
+            int(max_points),
+            bool(return_dists),
+            bool(return_points),
+            idx_wp,
+            count_wp,
+            dist_wp,
+            pts_wp,
+        ],
+        block_dim=FMA_V2_BLOCK_DIM,
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    if os.environ.get('PROFILE_RUN', '0') =='1':
+        torch.cuda.nvtx.range_pop()
+    return out_idx, out_pts, out_dist, out_count.view(B, Q)
+
+
+def radius_search_morton_warp_fma_store_opt(
+    index: MortonCompactDenseIndex,
+    queries: SortedQueryData,
+    points: torch.Tensor,
+    radius: float,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    wp_device,
+    wp_stream,
+):
+    """Store-optimized FMA search: shared-mem staged flush + host-gathered points.
+
+    Same one-block-per-query 27-cell scan as :func:`radius_search_morton_warp_fma`,
+    but the kernel (Stage 2) stages indices/distances in a block-shared tile and
+    flushes them in one coalesced pass, and (Stage 1) does not scatter neighbor
+    coordinates -- those are gathered on the host from ``out_idx`` via
+    :func:`_gather_neighbor_points`. Together these remove the misaligned
+    ``wp.vec3`` global store and the per-chunk partial-warp scatters the profiler
+    flagged on :func:`radius_search_morton_warp_fma`. Returns the ``(indices,
+    points, distances, num_neighbors)`` 4-tuple with the batch dim intact.
+
+    Raises:
+        ValueError: If ``max_points`` exceeds the shared staging capacity
+            (``FMA_STAGE_CAP``).
+    """
+    B, Q, Nq = queries.B, queries.Q, queries.Nq
+    device = index.pc_xyz4_sorted.device
+    if max_points > mk.FMA_STAGE_CAP:
+        raise ValueError(
+            f"dense_fma_store_opt supports max_points <= {mk.FMA_STAGE_CAP} "
+            f"(got {max_points}); increase FMA_STAGE_CAP in _morton_dense_kernels.py "
+            "or use the dense_fma variant."
+        )
+
+    # The kernel writes only indices/distances; coordinates are gathered below.
+    out_idx = torch.zeros((B, Q, max_points), dtype=torch.int32, device=device)
+    out_count = torch.zeros(B * Q, dtype=torch.int32, device=device)
+    out_dist = (
+        torch.zeros((B, Q, max_points), dtype=torch.float32, device=device)
+        if return_dists
+        else None
+    )
+    idx_wp = wp.from_torch(out_idx.view(Nq, max_points))
+    count_wp = wp.from_torch(out_count)
+    dist_wp = (
+        wp.from_torch(out_dist.view(Nq, max_points)) if out_dist is not None else None
+    )
+
+    wp.launch_tiled(
+        kernel=mk.radius_search_dense_fma_store_opt_kernel,
+        dim=Nq,
+        inputs=[
+            wp.from_torch(queries.q_x_sorted),
+            wp.from_torch(queries.q_y_sorted),
+            wp.from_torch(queries.q_z_sorted),
+            wp.from_torch(queries.q_orig_sorted),
+            float(index.inv_radius),
+            int(queries.Q),
+            wp.from_torch(index.offsets),
+            wp.from_torch(index.min_cx),
+            wp.from_torch(index.min_cy),
+            wp.from_torch(index.min_cz),
+            wp.from_torch(index.grid_x),
+            wp.from_torch(index.grid_y),
+            wp.from_torch(index.grid_z),
+            wp.from_torch(index.grid_base),
+            wp.from_torch(index.cell_begin_by_row),
+            wp.from_torch(index.cell_count_by_row),
+            wp.from_torch(index.pc_x_sorted),
+            wp.from_torch(index.pc_y_sorted),
+            wp.from_torch(index.pc_z_sorted),
+            wp.from_torch(index.pc_orig_sorted),
+            float(radius) * float(radius),
+            int(max_points),
+            bool(return_dists),
+            idx_wp,
+            count_wp,
+            dist_wp,
+        ],
+        block_dim=FMA_BLOCK_DIM,
+        device=wp_device,
+        stream=wp_stream,
+    )
+    num = out_count.view(B, Q)
+    out_pts = _gather_neighbor_points(points, out_idx, num) if return_points else None
+    return out_idx, out_pts, out_dist, num
+
+
+def radius_search_morton_warp_fma_mem_opt(
+    index: MortonCompactDenseIndex,
+    queries: SortedQueryData,
+    radius: float,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    wp_device,
+    wp_stream,
+):
+    """Memory-optimized FMA search: vec4 coord loads + in-kernel offset decode.
+
+    Same one-block-per-query structure as :func:`radius_search_morton_warp_fma`,
+    but reads query/point coords as single ``wp.vec4`` loads from the padded
+    ``*_xyz4_sorted`` arrays and decodes the 27 neighbor offsets in-kernel. Returns
+    the ``(indices, points, distances, num_neighbors)`` 4-tuple with batch dim
+    intact.
+    """
+    B, Q, Nq = queries.B, queries.Q, queries.Nq
+    device = index.pc_xyz4_sorted.device
+    out_idx, out_count, out_dist, out_pts = _alloc_outputs(
+        B, Q, max_points, return_dists, return_points, device
+    )
+    idx_wp, count_wp, dist_wp, pts_wp = _wp_outputs(
+        out_idx, out_count, out_dist, out_pts, Nq, max_points
+    )
+
+    wp.launch_tiled(
+        kernel=mk.radius_search_dense_fma_kernel_mem_opt,
+        dim=Nq,
+        inputs=[
+            wp.from_torch(queries.q_xyz4_sorted, dtype=wp.vec4),
+            wp.from_torch(queries.q_orig_sorted),
+            float(index.inv_radius),
+            int(queries.Q),
+            wp.from_torch(index.min_cx),
+            wp.from_torch(index.min_cy),
+            wp.from_torch(index.min_cz),
+            wp.from_torch(index.grid_x),
+            wp.from_torch(index.grid_y),
+            wp.from_torch(index.grid_z),
+            wp.from_torch(index.grid_base),
+            wp.from_torch(index.cell_begin_by_row),
+            wp.from_torch(index.cell_count_by_row),
+            wp.from_torch(index.pc_xyz4_sorted, dtype=wp.vec4),
+            wp.from_torch(index.pc_orig_sorted),
+            float(radius) * float(radius),
+            int(max_points),
+            bool(return_dists),
+            bool(return_points),
+            idx_wp,
+            count_wp,
+            dist_wp,
+            pts_wp,
+        ],
+        block_dim=FMA_BLOCK_DIM,
+        device=wp_device,
+        stream=wp_stream,
+    )
+    return out_idx, out_pts, out_dist, out_count.view(B, Q)
+
+
+def radius_search_morton_warp_fma_mm(
+    index: MortonCompactDenseIndex,
+    queries: SortedQueryData,
+    radius: float,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    wp_device,
+    wp_stream,
+):
+    """In-kernel-gather matmul search: one block per query, per-chunk tile matmul.
+
+    Same per-query 27-cell scan and tile-scan compaction as
+    :func:`radius_search_morton_warp_fma`, but distances come from a tiled matmul
+    of the query row against each candidate chunk. Launched at ``block_dim ==
+    TILE_P``. Returns ``(indices, points, distances, num_neighbors)`` with the
+    batch dim intact.
+    """
+    B, Q, Nq = queries.B, queries.Q, queries.Nq
+    device = index.pc_xyz4_sorted.device
+    out_idx, out_count, out_dist, out_pts = _alloc_outputs(
+        B, Q, max_points, return_dists, return_points, device
+    )
+    idx_wp, count_wp, dist_wp, pts_wp = _wp_outputs(
+        out_idx, out_count, out_dist, out_pts, Nq, max_points
+    )
+
+    wp.launch_tiled(
+        kernel=mgk.radius_search_dense_fma_kernel_mm,
+        dim=Nq,
+        inputs=[
+            wp.from_torch(queries.q_xyz4_sorted),
+            wp.from_torch(queries.q_norm_sorted),
+            wp.from_torch(queries.q_orig_sorted),
+            float(index.inv_radius),
+            int(queries.Q),
+            wp.from_torch(index.offsets),
+            wp.from_torch(index.min_cx),
+            wp.from_torch(index.min_cy),
+            wp.from_torch(index.min_cz),
+            wp.from_torch(index.grid_x),
+            wp.from_torch(index.grid_y),
+            wp.from_torch(index.grid_z),
+            wp.from_torch(index.grid_base),
+            wp.from_torch(index.cell_begin_by_row),
+            wp.from_torch(index.cell_count_by_row),
+            wp.from_torch(index.pc_xyz4_sorted),
+            wp.from_torch(index.pc_norm_sorted),
+            wp.from_torch(index.pc_orig_sorted),
+            float(radius) * float(radius),
+            int(max_points),
+            bool(return_dists),
+            bool(return_points),
+            idx_wp,
+            count_wp,
+            dist_wp,
+            pts_wp,
+        ],
+        block_dim=TILE_P,
+        device=wp_device,
+        stream=wp_stream,
+    )
+    return out_idx, out_pts, out_dist, out_count.view(B, Q)
+
+
+def _build_gemm_tasks(
+    index: MortonCompactDenseIndex,
+    queries: SortedQueryData,
+    wp_device,
+    wp_stream,
+) -> dict:
+    """Build the ``(query-tile, point-chunk)`` task list for the GEMM path.
+
+    Splits each occupied query cell into ``TILE_Q`` chunks, then runs the
+    two-pass (count -> exclusive scan -> fill) task generation against the dense
+    cell table.
+    """
+    device = index.pc_xyz4_sorted.device
+    Nq = queries.Nq
+    qkeys = queries.qkeys_sorted
+
+    flags = torch.ones(Nq, dtype=torch.bool, device=device)
+    flags[1:] = qkeys[1:] != qkeys[:-1]
+    qstarts = torch.nonzero(flags, as_tuple=False).flatten()
+    num_qcells = int(qstarts.numel())
+    qends = torch.empty_like(qstarts)
+    if num_qcells > 1:
+        qends[:-1] = qstarts[1:]
+    qends[-1] = Nq
+    qcell_len = qends - qstarts
+
+    tiles_per_cell = (qcell_len + TILE_Q - 1) // TILE_Q
+    num_qtiles = int(tiles_per_cell.sum().item())
+    tile_off = _exclusive_scan(tiles_per_cell)
+    cell_of_tile = torch.repeat_interleave(
+        torch.arange(num_qcells, device=device), tiles_per_cell
+    )
+    local_tile = torch.arange(num_qtiles, device=device) - tile_off[cell_of_tile]
+    tile_begin = qstarts[cell_of_tile] + local_tile * TILE_Q
+    q_tile_begin = tile_begin.to(torch.int32).contiguous()
+    q_tile_count = (
+        torch.clamp(qends[cell_of_tile] - tile_begin, max=TILE_Q)
+        .to(torch.int32)
+        .contiguous()
+    )
+    inv_radius = index.inv_radius
+    q_coords = queries.q_xyz4_sorted[: queries.Nq]
+    q_batch = (queries.q_orig_sorted.to(torch.int64) // queries.Q).to(torch.int32)
+    q_cx = torch.floor(q_coords[:, 0] * inv_radius).to(torch.int32)
+    q_cy = torch.floor(q_coords[:, 1] * inv_radius).to(torch.int32)
+    q_cz = torch.floor(q_coords[:, 2] * inv_radius).to(torch.int32)
+    q_tile_b = q_batch[qstarts][cell_of_tile].contiguous()
+    q_tile_cx = q_cx[qstarts][cell_of_tile].contiguous()
+    q_tile_cy = q_cy[qstarts][cell_of_tile].contiguous()
+    q_tile_cz = q_cz[qstarts][cell_of_tile].contiguous()
+
+    offsets_wp = wp.from_torch(index.offsets)
+    min_cx_wp = wp.from_torch(index.min_cx)
+    min_cy_wp = wp.from_torch(index.min_cy)
+    min_cz_wp = wp.from_torch(index.min_cz)
+    grid_x_wp = wp.from_torch(index.grid_x)
+    grid_y_wp = wp.from_torch(index.grid_y)
+    grid_z_wp = wp.from_torch(index.grid_z)
+    grid_base_wp = wp.from_torch(index.grid_base)
+    cell_begin_wp = wp.from_torch(index.cell_begin_by_row)
+    cell_count_wp = wp.from_torch(index.cell_count_by_row)
+    q_tile_b_wp = wp.from_torch(q_tile_b)
+    q_tile_cx_wp = wp.from_torch(q_tile_cx)
+    q_tile_cy_wp = wp.from_torch(q_tile_cy)
+    q_tile_cz_wp = wp.from_torch(q_tile_cz)
+
+    task_count = torch.empty(num_qtiles, dtype=torch.int32, device=device)
+    wp.launch(
+        kernel=mgk.count_neighbor_tasks,
+        dim=num_qtiles,
+        inputs=[
+            q_tile_b_wp,
+            q_tile_cx_wp,
+            q_tile_cy_wp,
+            q_tile_cz_wp,
+            offsets_wp,
+            min_cx_wp,
+            min_cy_wp,
+            min_cz_wp,
+            grid_x_wp,
+            grid_y_wp,
+            grid_z_wp,
+            grid_base_wp,
+            cell_count_wp,
+            int(TILE_P),
+            wp.from_torch(task_count),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    task_offset = _exclusive_scan(task_count).to(torch.int32).contiguous()
+    num_tasks = int(task_count.sum().item())
+
+    task_q_begin = torch.empty(max(num_tasks, 1), dtype=torch.int32, device=device)
+    task_q_count = torch.empty(max(num_tasks, 1), dtype=torch.int32, device=device)
+    task_p_begin = torch.empty(max(num_tasks, 1), dtype=torch.int32, device=device)
+    task_p_count = torch.empty(max(num_tasks, 1), dtype=torch.int32, device=device)
+    if num_tasks > 0:
+        wp.launch(
+            kernel=mgk.fill_neighbor_tasks,
+            dim=num_qtiles,
+            inputs=[
+                wp.from_torch(q_tile_begin),
+                wp.from_torch(q_tile_count),
+                q_tile_b_wp,
+                q_tile_cx_wp,
+                q_tile_cy_wp,
+                q_tile_cz_wp,
+                wp.from_torch(task_offset),
+                offsets_wp,
+                min_cx_wp,
+                min_cy_wp,
+                min_cz_wp,
+                grid_x_wp,
+                grid_y_wp,
+                grid_z_wp,
+                grid_base_wp,
+                cell_begin_wp,
+                cell_count_wp,
+                int(TILE_P),
+                wp.from_torch(task_q_begin),
+                wp.from_torch(task_q_count),
+                wp.from_torch(task_p_begin),
+                wp.from_torch(task_p_count),
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+
+    return {
+        "num_tasks": num_tasks,
+        "task_q_begin": task_q_begin,
+        "task_q_count": task_q_count,
+        "task_p_begin": task_p_begin,
+        "task_p_count": task_p_count,
+    }
+
+
+def radius_search_morton_tiled_gemm(
+    index: MortonCompactDenseIndex,
+    queries: SortedQueryData,
+    tasks: dict,
+    radius: float,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    wp_device,
+    wp_stream,
+):
+    """Benchmark search: tiled GEMM distances over the dense Morton-sorted cells.
+
+    Returns ``(indices, points, distances, num_neighbors)`` with the batch dim
+    intact; the per-query atomic counter is clamped to ``max_points`` afterward.
+    """
+    B, Q, Nq = queries.B, queries.Q, queries.Nq
+    device = index.pc_xyz4_sorted.device
+    out_idx, out_count, out_dist, out_pts = _alloc_outputs(
+        B, Q, max_points, return_dists, return_points, device
+    )
+    idx_wp, count_wp, dist_wp, pts_wp = _wp_outputs(
+        out_idx, out_count, out_dist, out_pts, Nq, max_points
+    )
+
+    num_tasks = tasks["num_tasks"]
+    if num_tasks > 0:
+        lane_iota = torch.arange(TILE_P, dtype=torch.int32, device=device)
+        wp.launch_tiled(
+            kernel=mgk.radius_search_dense_gemm_kernel,
+            dim=num_tasks,
+            inputs=[
+                wp.from_torch(tasks["task_q_begin"]),
+                wp.from_torch(tasks["task_q_count"]),
+                wp.from_torch(tasks["task_p_begin"]),
+                wp.from_torch(tasks["task_p_count"]),
+                wp.from_torch(lane_iota),
+                wp.from_torch(queries.q_xyz4_sorted),
+                wp.from_torch(queries.q_norm_sorted),
+                wp.from_torch(queries.q_orig_sorted),
+                wp.from_torch(index.pc_xyz4_sorted),
+                wp.from_torch(index.pc_norm_sorted),
+                wp.from_torch(index.pc_orig_sorted),
+                float(radius) * float(radius),
+                int(max_points),
+                bool(return_dists),
+                bool(return_points),
+                idx_wp,
+                count_wp,
+                dist_wp,
+                pts_wp,
+            ],
+            block_dim=TILE_P,
+            device=wp_device,
+            stream=wp_stream,
+        )
+
+    return out_idx, out_pts, out_dist, out_count.clamp(max=max_points).view(B, Q)
+
+
+def _empty_outputs(
+    B, Q, max_points, return_dists, return_points, was_unbatched, dtype, device
+):
+    """Build a zero/empty 4-tuple matching the op contract (used for empty inputs)."""
+    indices = torch.zeros((B, Q, max_points), dtype=torch.int32, device=device)
+    num = torch.zeros((B, Q), dtype=torch.int32, device=device)
+    pts = (
+        torch.zeros((B, Q, max_points, 3), dtype=dtype, device=device)
+        if return_points
+        else torch.empty((0, max_points, 3), dtype=dtype, device=device)
+    )
+    dist = (
+        torch.zeros((B, Q, max_points), dtype=dtype, device=device)
+        if return_dists
+        else torch.empty(0, dtype=dtype, device=device)
+    )
+    if was_unbatched:
+        indices = indices.squeeze(0)
+        num = num.squeeze(0)
+        if return_points:
+            pts = pts.squeeze(0)
+        if return_dists:
+            dist = dist.squeeze(0)
+    return indices, pts, dist, num
+
+
+def radius_search_morton_dense(
+    points: torch.Tensor,
+    queries: torch.Tensor,
+    radius: float,
+    max_points: int,
+    return_dists: bool = False,
+    return_points: bool = False,
+    variant: str | None = "dense_fma",
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Morton-sorted compact dense-cell radius search entry point (CUDA-only).
+
+    Builds the reusable :class:`MortonCompactDenseIndex` from ``points``, prepares
+    the queries, and dispatches to the requested ``variant``. Returns the same
+    4-tuple contract as the ``max_points`` path of ``radius_search_impl``.
+
+    Args:
+        points: Reference points, ``(N, 3)`` or ``(B, N, 3)``.
+        queries: Query points, ``(M, 3)`` or ``(B, M, 3)``.
+        radius: Search radius.
+        max_points: Maximum neighbors per query (must not be ``None``).
+        return_dists: Whether to return neighbor distances.
+        return_points: Whether to return neighbor coordinates.
+        variant: One of ``"dense_fma"`` (production), ``"dense_fma_e2e"`` (sort-free
+            ``dense_fma``: row-major cell bins + unsorted queries, no radix sort),
+            ``"dense_fma_store_opt"`` (``dense_fma`` with shared-memory staged flush
+            and host-gathered points -- optimizes the output stores),
+            ``"dense_fma_mem_opt"``, ``"dense_fma_mm"``, or ``"dense_gemm"``
+            (benchmark), or ``"custom_grid_cell"`` (WIP experimental cell-centric
+            memory-optimized launch -- not runnable until its kernel is finished).
+            ``None`` defaults to ``"dense_fma"``.
+
+    Returns:
+        ``(indices, points, distances, num_neighbors)`` mirroring
+        ``radius_search_impl``.
+
+    Raises:
+        ValueError: If ``max_points`` is ``None``, inputs are not CUDA, or
+            ``variant`` is unknown.
+    """
+    if max_points is None:
+        raise ValueError("radius_search_morton_dense requires max_points (not None)")
+    if points.device != queries.device:
+        raise ValueError("points and queries must be on the same device")
+    if points.device.type != "cuda":
+        raise ValueError("radius_search_morton_dense requires CUDA tensors")
+
+    variant = variant or "dense_fma"
+    if variant not in DENSE_VARIANTS:
+        raise ValueError(
+            f"unknown dense morton variant '{variant}'; expected one of {DENSE_VARIANTS}"
+        )
+
+    # custom_grid_cell is self-search-only: its kernel (radius_search_mem_optimized)
+    # ignores the query set and searches the points against themselves. Capture whether
+    # points/queries alias the same storage now -- before validate_inputs reshapes them --
+    # so that branch can reject cross-search calls instead of returning silently-wrong
+    # neighbors.
+    if os.environ.get('PROFILE_RUN','0') =='1':
+        torch.cuda.nvtx.range_push('RADIUS SEARCH MORTON')
+
+    is_self_search = points is queries or (
+        points.shape == queries.shape
+        and points.stride() == queries.stride()
+        and points.data_ptr() == queries.data_ptr()
+    )
+    
+    points, queries, was_unbatched = validate_inputs(points, queries)
+
+    
+    input_dtype = points.dtype
+    if points.dtype != torch.float32:
+        points = points.to(torch.float32)
+    if queries.dtype != torch.float32:
+        queries = queries.to(torch.float32)
+    
+    if os.environ.get('PROFILE_RUN','0') =='1':
+        torch.cuda.nvtx.range_push('points contiguous')
+
+    points = points.contiguous()
+    queries = queries.contiguous()
+
+    if os.environ.get('PROFILE_RUN','0') =='1':
+        torch.cuda.nvtx.range_pop()
+    
+    B, N, _ = points.shape
+    Q = queries.shape[1]
+    if N == 0 or Q == 0:
+        # Close the range opened above; the early return would otherwise
+        # leave a dangling NVTX push (mirrors the sparse-hash e2e path).
+        if os.environ.get('PROFILE_RUN', '0') == '1':
+            torch.cuda.nvtx.range_pop()  # RADIUS SEARCH MORTON
+        return _empty_outputs(
+            B, Q, max_points, return_dists, return_points, was_unbatched,
+            input_dtype, points.device,
+        )
+
+    wp_device, wp_stream = FunctionSpec.warp_launch_context(points)
+
+    # dense_fma_e2e is the sort-free twin of dense_fma: it drops both Morton radix
+    # sorts (cell-bin ordering and query ordering), which are locality-only for the
+    # one-block-per-query FMA search, and reuses the same search kernel.
+    is_e2e = variant == "dense_fma_e2e" or variant == "custom_grid_cell" or variant == 'custom_grid_cell_2'
+
+    with wp.ScopedStream(wp_stream, sync_enter= False):
+        # import ipdb; ipdb.set_trace()
+        if os.environ.get('PROFILE_RUN','0') =='1':
+            torch.cuda.nvtx.range_push('build morton index')
+        
+        index = build_morton_compact_dense_index(
+            points, radius, wp_device, wp_stream, sort_cells=not is_e2e, is_e2e= is_e2e
+        )
+
+        if os.environ.get('PROFILE_RUN','0') =='1':
+            torch.cuda.nvtx.range_pop()
+
+        # sorted_queries = None
+        # if variant != "custom_grid_cell_2":
+        #     sorted_queries = prepare_morton_sorted_queries(
+        #         index, queries, wp_device, wp_stream, sort_queries=not is_e2e
+        #     )
+
+        if os.environ.get('PROFILE_RUN','0') =='1':
+            torch.cuda.nvtx.range_push('prep morton sorted queries')
+        
+        # sorted_queries = queries
+        # if not is_e2e:
+        sorted_queries = prepare_morton_sorted_queries(
+            index, queries, wp_device, wp_stream, sort_queries=not is_e2e
+        )
+
+        if os.environ.get('PROFILE_RUN','0') =='1':
+            torch.cuda.nvtx.range_pop()
+        
+        if os.environ.get('PROFILE_RUN','0') =='1':
+            torch.cuda.nvtx.range_push('Radius Search')
+        
+        if variant in ("dense_fma", "dense_fma_e2e"):
+            indices, pts, dist, num = radius_search_morton_warp_fma(
+                index, sorted_queries, radius, max_points, return_dists,
+                return_points, wp_device, wp_stream,
+            )
+        elif variant == "dense_fma_store_opt":
+            indices, pts, dist, num = radius_search_morton_warp_fma_store_opt(
+                index, sorted_queries, points, radius, max_points, return_dists,
+                return_points, wp_device, wp_stream,
+            )
+        elif variant == "dense_fma_mem_opt":
+            indices, pts, dist, num = radius_search_morton_warp_fma_mem_opt(
+                index, sorted_queries, radius, max_points, return_dists,
+                return_points, wp_device, wp_stream,
+            )
+        elif variant == "dense_fma_mm":
+            indices, pts, dist, num = radius_search_morton_warp_fma_mm(
+                index, sorted_queries, radius, max_points, return_dists,
+                return_points, wp_device, wp_stream,
+            )
+        elif variant == "custom_grid_cell":
+            # WIP: experimental cell-centric memory-optimized launch (one block per
+            # (batch, cell)), selected via PHYSICSNEMO_RADIUS_SEARCH_MORTON=custom_grid_cell
+            # or implementation="custom_grid_cell". The launch and its
+            # `radius_search_mem_optimized` kernel are still being authored (the kernel
+            # is currently parked as an inert string in _morton_dense_kernels.py), so
+            # this path is NOT runnable yet. The unpack order mirrors the launch's
+            # current `(out_idx, out_count, out_dist, out_points)` return signature.
+            # if not is_self_search:
+            #     raise ValueError(
+            #         "custom_grid_cell is a self-search-only radius-search variant: its "
+            #         "kernel (radius_search_mem_optimized) ignores the query set and "
+            #         "searches the points against themselves, so it is valid only when "
+            #         "queries is the same tensor as points. This call has queries != "
+            #         "points (a cross-search). Unset PHYSICSNEMO_RADIUS_SEARCH_MORTON "
+            #         "(or select variant 'dense_fma') to use the cross-search path."
+            #     )
+            indices, num, dist, pts = radius_search_mem_optimized_launch(
+                index, sorted_queries, radius, max_points, return_dists,
+                return_points, wp_device, wp_stream,
+            )
+        elif variant == 'custom_grid_cell_2':
+            indices, num, dist, pts = radius_search_mem_optimized_2_launch(
+                index,
+                radius,
+                max_points,
+                return_dists,
+                return_points,
+                wp_device,
+                wp_stream,
+            )
+        else:
+            tasks = _build_gemm_tasks(index, sorted_queries, wp_device, wp_stream)
+            indices, pts, dist, num = radius_search_morton_tiled_gemm(
+                index, sorted_queries, tasks, radius, max_points, return_dists,
+                return_points, wp_device, wp_stream,
+            )
+        if os.environ.get('PROFILE_RUN','0') =='1':
+            torch.cuda.nvtx.range_pop()
+
+    if pts is None:
+        pts = torch.empty((0, max_points, 3), dtype=torch.float32, device=points.device)
+    if dist is None:
+        dist = torch.empty(0, dtype=torch.float32, device=points.device)
+
+    if was_unbatched:
+        indices = indices.squeeze(0)
+        num = num.squeeze(0)
+        if return_points:
+            pts = pts.squeeze(0)
+        if return_dists:
+            dist = dist.squeeze(0)
+
+    pts = pts.to(input_dtype)
+    dist = dist.to(input_dtype)
+    if os.environ.get('PROFILE_RUN','0') =='1':
+        torch.cuda.nvtx.range_pop()
+    return indices, pts, dist, num
+
+
+# def radius_search_mem_optimized(
+#     index,
+#     queries, 
+#     radius, 
+#     max_points, 
+#     return_dists,
+#     return_points,
+#     wp_device,
+#     wp_stream
+# ):
+
+#     B, Q, Nq = queries.B, queries.Q, queries.Nq
+#     device = index.pc_xyz4_sorted.device
+
+#     def __alloc_outputs(B, Q, max_points, return_dists, return_points, device):
+#         pass 
+    
+#     grid_x, grid_y, grid_z = index.grid_x, index.grid_y, index.grid_z
+
+#     int num_cells = grid_x * grid_y * grid_z
+#     TILE_DIM = 16
+#     BLOCK_DIM= 128
+    
+#     wp.launch_tiled(
+#         kernel = ...,
+#         dim = num_cells,
+#         inputs = [
+
+#             TILE_DIM
+#         ],
+#         block_dim = BLOCK_DIM,
+#         device = wp_device,
+#         stream= wp_stream  
+#     )
+
+#     return ....outputs
+
+
+def radius_search_mem_optimized_launch(
+    index, queries, radius, max_points, return_dists, return_points, wp_device, wp_stream,
+    use_matmul=True,
+):
+    # The kernel caps neighbours at the compile-time MAX_POINTS and always writes
+    # MAX_POINTS output slots per query (its shared staging tiles are sized
+    # (TILE_DIM, MAX_POINTS)); the out_* arrays below are only ``max_points`` rows, so a
+    # mismatch makes the kernel write out of bounds. Enforce equality instead of the OOB.
+    # if int(max_points) != int(mk.MAX_POINTS.val):
+    #     raise ValueError(
+    #         f"custom_grid_cell requires max_points == compile-time MAX_POINTS "
+    #         f"(={int(mk.MAX_POINTS.val)}); got {int(max_points)}. Rebuild the module with "
+    #         f"MAX_POINTS set to your max_points (in _morton_dense_kernels.py), or use the "
+    #         f"dense_fma variant, which supports arbitrary max_points."
+    #     )
+
+    # One block per *global* dense cell row. Cells are laid out per batch in a
+    # variable-size row-major grid and concatenated, so the launch spans
+    # ``total_cells`` (== grid_base[B]) and the kernel recovers the batch from
+    # grid_base -- the same per-batch indexing the FMA search uses. ``Ntot`` is the
+    # count of sorted points across all batches (the output row dimension).
+    B           = index.B
+    Ntot        = index.Np
+    total_cells = index.total_cells
+    MP          = max_points
+    # import ipdb; ipdb.set_trace()
+    # ---- allocate outputs TRANSPOSED (slot-major) so the kernel write coalesces on qg ----
+    out_idx   = wp.full((MP, Ntot), -1, dtype=wp.int32,   device=wp_device)
+    out_count = wp.zeros(Ntot,          dtype=wp.int32,   device=wp_device)
+    out_dist  = (wp.zeros((MP, Ntot),    dtype=wp.float32, device=wp_device)
+                 if return_dists  else wp.zeros((1, 1),    dtype=wp.float32, device=wp_device))
+    out_points = (wp.zeros((MP, Ntot, 3), dtype=wp.float32, device=wp_device)
+                  if return_points else wp.zeros((1, 1, 3), dtype=wp.float32, device=wp_device))
+
+    BLOCK_DIM = 16
+    kernel = mk.radius_search_mem_optimized if use_matmul else mk.radius_search_scan
+
+    # Transposed coords (3, Ntot_pad) so the kernel loads Pᵀ as a real (K, N) tile_matmul
+    # operand instead of a tile_transpose() view, which tile_matmul rejects (Warp #1527).
+    pc_t = index.pc_xyz4_sorted[:, :3].t().contiguous()
+
+    # One block per *occupied* cell, not per dense cell. total_cells scales as
+    # (domain_extent / radius)^3 and is dominated by empty cells for small radii, so
+    # dim=total_cells (~1e9 at radius 0.01) pegs the GPU scheduling empty-cell blocks
+    # that immediately return. Occupied cells number <= Ntot, so restrict the launch grid
+    # to them. NOTE: torch.nonzero is still one O(total_cells) scan of cell_count_by_row;
+    # a cheaper source (unique of point_cell_row during index build) is a follow-up.
+    # import ipdb; ipdb.set_trace()
+    
+    occupied_rows = (
+        torch.nonzero(index.cell_count_by_row, as_tuple=False).squeeze(1).to(torch.int32).contiguous()
+    )
+    num_occupied = int(occupied_rows.numel())
+    # TEMP diagnostic (remove once validated): confirms the launch-grid reduction.
+    
+    print(
+        f"[custom_grid_cell] radius={float(radius):.4g} B={int(B)} Ntot={int(Ntot)} "
+        f"total_cells={int(total_cells)} occupied={num_occupied} "
+        f"(launching {num_occupied} blocks instead of {int(total_cells)})",
+        flush=True,
+    )
+    if num_occupied > 0:
+        # import ipdb; ipdb.set_trace()
+        wp.launch_tiled(
+            kernel=kernel,
+            dim=num_occupied,                       # one block per OCCUPIED dense cell row
+            inputs=[
+                wp.from_torch(index.pc_xyz4_sorted),    # (Ntot_pad, 4) Morton-sorted coords
+                wp.from_torch(pc_t),                    # (3, Ntot_pad) transposed coords for Pᵀ loads
+                int(B),
+                wp.from_torch(index.grid_x),            # (B,) per-batch cell extents
+                wp.from_torch(index.grid_y),
+                wp.from_torch(index.grid_z),
+                wp.from_torch(index.grid_base),         # (B+1,) per-batch cell base offsets
+                wp.from_torch(index.cell_begin_by_row),  # (total_cells,)
+                wp.from_torch(index.cell_count_by_row),  # (total_cells,)
+                wp.from_torch(occupied_rows),           # (num_occupied,) launch-grid -> global cell id
+                float(radius),
+                int(max_points),
+                bool(return_dists),
+                bool(return_points),
+                out_idx,
+                out_count,
+                out_dist,
+                out_points
+            ],
+            block_dim=BLOCK_DIM, device=wp_device, stream=wp_stream,
+        )
+    # ---- convert Warp outputs -> torch and reconcile with the dense_fma contract ----
+    # The kernel writes in SORTED point order (row qg = sorted slot), with SORTED
+    # neighbor ids, transposed (slot-major, (MP, Np)) and flat across batches. The
+    # reference (dense_fma) returns (B, P, MP) torch tensors in ORIGINAL query order with
+    # LOCAL original point ids. This variant is self-search (queries == points, enforced
+    # by the caller's guard), so the query axis IS the point axis: points are grouped
+    # batch-major, so reshape Np == B*P -> (B, P), then unsort each row to its original
+    # position and remap neighbor ids -- both via pc_orig_sorted.
+    Bx, Px = index.B, index.P
+    dev = index.pc_xyz4_sorted.device
+    orig = index.pc_orig_sorted.to(torch.long)                     # (Np,) sorted slot -> local id
+    orig_bp = orig.view(Bx, Px)                                    # (B, P)
+    batch_ix = torch.arange(Bx, device=dev).view(Bx, 1).expand(Bx, Px)  # (B, P)
+
+    # out_idx: (MP, Np) -> (Np, MP); remap sorted neighbor slot -> local original id,
+    # padding slots (-1) -> 0 (mirrors dense_fma's zero-initialized index buffer).
+    idx_s = wp.to_torch(out_idx).transpose(0, 1).contiguous()      # (Np, MP) int32
+    valid = idx_s >= 0
+    remapped = orig[idx_s.clamp_min(0).long()].to(torch.int32)     # (Np, MP) local ids
+    idx_local = torch.where(valid, remapped, torch.zeros_like(remapped)).view(Bx, Px, MP)
+    cnt_s = wp.to_torch(out_count).view(Bx, Px)                    # (B, P)
+
+    # Scatter sorted rows back to original query order: sorted slot s in batch b belongs
+    # to original local query orig_bp[b, s] (a per-batch permutation of [0, P)).
+    indices = idx_local.new_zeros((Bx, Px, MP))
+    indices[batch_ix, orig_bp] = idx_local
+    num = cnt_s.new_zeros((Bx, Px))
+    num[batch_ix, orig_bp] = cnt_s
+
+    dist = None
+    if return_dists:
+        # The kernel stores SQUARED distance; dense_fma returns Euclidean -> sqrt.
+        dist_s = wp.to_torch(out_dist).transpose(0, 1).contiguous().view(Bx, Px, MP)
+        dist_s = torch.sqrt(dist_s.clamp_min(0.0))
+        dist = dist_s.new_zeros((Bx, Px, MP))
+        dist[batch_ix, orig_bp] = dist_s
+
+    pts = None
+    if return_points:
+        # out_points: (MP, Np, 3) -> (Np, MP, 3); values are actual neighbor coordinates.
+        pts_s = wp.to_torch(out_points).transpose(0, 1).contiguous().view(Bx, Px, MP, 3)
+        pts = pts_s.new_zeros((Bx, Px, MP, 3))
+        pts[batch_ix, orig_bp] = pts_s
+
+    return indices, num, dist, pts
+
+
+
+    
+
+def _build_custom_grid_cell_2_tasks(index: MortonCompactDenseIndex):
+    """Build one launch task per ``(occupied cell, query tile)`` pair.
+
+    The compacted point range of a cell is also its query range for this
+    self-search variant. Dense cells therefore contribute multiple 32-query
+    tasks, while empty cells contribute none.
+    """
+    cell_count = index.cell_count_by_row
+    occupied_rows = torch.nonzero(cell_count, as_tuple=False).squeeze(1)
+
+    if occupied_rows.numel() == 0:
+        empty = torch.empty(0, dtype=torch.int32, device=cell_count.device)
+        return empty, empty, empty
+
+    points_per_cell = cell_count[occupied_rows]
+    tiles_per_cell = torch.div(
+        points_per_cell + MEM_OPT_2_BLOCK_DIM - 1,
+        MEM_OPT_2_BLOCK_DIM,
+        rounding_mode="floor",
+    ).to(torch.long)
+
+    task_cell = torch.repeat_interleave(
+        occupied_rows.to(torch.int32), tiles_per_cell
+    ).contiguous()
+    num_tasks = task_cell.numel()
+
+    # Convert each flattened task id into its tile number within the cell.
+    first_task_for_cell = torch.cumsum(tiles_per_cell, dim=0) - tiles_per_cell
+    task_local_tile = torch.arange(
+        num_tasks, dtype=torch.long, device=cell_count.device
+    ) - torch.repeat_interleave(first_task_for_cell, tiles_per_cell)
+
+    task_cell_long = task_cell.to(torch.long)
+    task_q_begin = (
+        index.cell_begin_by_row[task_cell_long].to(torch.long)
+        + task_local_tile * MEM_OPT_2_BLOCK_DIM
+    ).to(torch.int32)
+    task_q_count = torch.clamp(
+        cell_count[task_cell_long]
+        - task_local_tile.to(torch.int32) * MEM_OPT_2_BLOCK_DIM,
+        max=MEM_OPT_2_BLOCK_DIM,
+    ).to(torch.int32)
+
+    return task_cell, task_q_begin.contiguous(), task_q_count.contiguous()
+
+
+def radius_search_mem_optimized_2_launch(
+    index: MortonCompactDenseIndex,
+    radius: float,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    wp_device,
+    wp_stream,
+):
+    """Launch the direct-FMA cell/query-tile radius-search kernel.
+
+    The Warp kernel writes compacted/sorted neighbor indices and optional squared
+    distances in slot-major layout. This function remaps both query rows and
+    neighbor ids to the public batch/local-id layout. Neighbor coordinates are
+    gathered from the returned indices outside the search kernel.
+    """
+    batch_size = index.B
+    points_per_batch = index.P
+    num_points = index.Np
+    num_slots = int(max_points)
+
+    out_idx = wp.full(
+        (num_slots, num_points), -1, dtype=wp.int32, device=wp_device
+    )
+    out_count = wp.zeros(num_points, dtype=wp.int32, device=wp_device)
+    out_dist = (
+        wp.zeros(
+            (num_slots, num_points), dtype=wp.float32, device=wp_device
+        )
+        if return_dists
+        else wp.zeros((1, 1), dtype=wp.float32, device=wp_device)
+    )
+
+    task_cell, task_q_begin, task_q_count = _build_custom_grid_cell_2_tasks(index)
+    num_tasks = task_cell.numel()
+
+    if num_tasks > 0:
+        wp.launch_tiled(
+            kernel=mk.radius_search_mem_optimized_3,
+            dim=num_tasks,
+            inputs=[
+                wp.from_torch(index.pc_xyz4_sorted),
+                int(batch_size),
+                wp.from_torch(index.grid_x),
+                wp.from_torch(index.grid_y),
+                wp.from_torch(index.grid_z),
+                wp.from_torch(index.grid_base),
+                wp.from_torch(index.cell_begin_by_row),
+                wp.from_torch(index.cell_count_by_row),
+                wp.from_torch(index.offsets),
+                wp.from_torch(task_cell),
+                wp.from_torch(task_q_begin),
+                wp.from_torch(task_q_count),
+                float(radius),
+                num_slots,
+                bool(return_dists),
+                out_idx,
+                out_count,
+                out_dist,
+            ],
+            block_dim=MEM_OPT_2_BLOCK_DIM,
+            device=wp_device,
+            stream=wp_stream,
+        )
+
+    # Convert slot-major Warp output to one row per sorted query.
+    idx_sorted = wp.to_torch(out_idx).transpose(0, 1).contiguous()
+    count_sorted = wp.to_torch(out_count)
+    valid = idx_sorted >= 0
+    safe_sorted_idx = idx_sorted.clamp_min(0).to(torch.long)
+
+    # A compacted slot maps to a local original point id. Point bins are batch
+    # contiguous, so each batch occupies exactly points_per_batch sorted slots.
+    original_id = index.pc_orig_sorted.to(torch.long)
+    original_id_by_batch = original_id.view(batch_size, points_per_batch)
+    batch_index = torch.arange(
+        batch_size, device=idx_sorted.device
+    ).view(batch_size, 1).expand(batch_size, points_per_batch)
+
+    remapped_idx = original_id[safe_sorted_idx].to(torch.int32)
+    remapped_idx = torch.where(
+        valid, remapped_idx, torch.zeros_like(remapped_idx)
+    ).view(batch_size, points_per_batch, num_slots)
+    count_sorted = count_sorted.view(batch_size, points_per_batch)
+
+    indices = remapped_idx.new_zeros(
+        (batch_size, points_per_batch, num_slots)
+    )
+    indices[batch_index, original_id_by_batch] = remapped_idx
+    num = count_sorted.new_zeros((batch_size, points_per_batch))
+    num[batch_index, original_id_by_batch] = count_sorted
+
+    dist = None
+    if return_dists:
+        dist_sorted = wp.to_torch(out_dist).transpose(0, 1).contiguous()
+        dist_sorted = torch.sqrt(dist_sorted.clamp_min(0.0)).view(
+            batch_size, points_per_batch, num_slots
+        )
+        dist = dist_sorted.new_zeros(
+            (batch_size, points_per_batch, num_slots)
+        )
+        dist[batch_index, original_id_by_batch] = dist_sorted
+
+    pts = None
+    if return_points:
+        # Gather in sorted-index space before neighbor ids are remapped. Invalid
+        # output slots contain -1, so clamp for the gather and mask them afterward.
+        points_sorted = index.pc_xyz4_sorted[safe_sorted_idx, :3]
+        points_sorted = torch.where(
+            valid.unsqueeze(-1), points_sorted, torch.zeros_like(points_sorted)
+        ).view(batch_size, points_per_batch, num_slots, 3)
+        pts = points_sorted.new_zeros(
+            (batch_size, points_per_batch, num_slots, 3)
+        )
+        pts[batch_index, original_id_by_batch] = points_sorted
+
+    return indices, num, dist, pts

--- a/physicsnemo/nn/functional/neighbors/radius_search/_morton_dense_kernels.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_morton_dense_kernels.py
@@ -1,0 +1,1548 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Warp kernels for the Morton-sorted compact dense-cell radius search backend.
+
+This module is pure Warp code (no PyTorch). It is self-contained and does not
+share device helpers with the hash-based Morton backend in ``_morton_kernels.py``.
+
+The backend maps points to radius-sized cells, lays them out in a dense
+row-major grid indexed directly by cell id (no hash table), and sorts the
+compacted point bins in Morton-cell order for locality. The host glue that
+drives these kernels lives in ``_morton_dense_impl.py``.
+"""
+
+import warp as wp
+
+# Query-tile and point-chunk widths for the GEMM benchmark path. Module-level
+# Python ints so they are captured as compile-time tile shapes. ``TILE_P`` also
+# doubles as the GEMM launch ``block_dim`` (one lane per candidate point).
+TILE_Q = 8
+TILE_P = 256
+
+# Threads per query block for the production FMA search kernel. This is both the
+# launch block_dim and the candidate-chunk stride, so each query block scans this
+# many candidate points per chunk and compacts hits with a block-wide tile scan.
+# 32 is one warp; larger (e.g. 128) scans more candidates per chunk for densely
+# populated cells, at the cost of idle lanes when cells hold fewer points.
+FMA_BLOCK_DIM = 64
+FMA_V2_BLOCK_DIM = 256
+# Compile-time capacity of the per-query shared-memory staging buffer used by the
+# production FMA kernel (Stage 2). Neighbors from all 27 cells accumulate in this
+# block-shared tile and are flushed to global memory once, coalesced, so the hot
+# loop never issues the old per-chunk partial-warp global scatter. This caps the
+# supported ``max_points`` (the host raises if ``max_points`` exceeds it); 256
+# covers every realistic ball-query fan-out (production uses <= 32, tests <= 128).
+# ``FMA_STAGE_SLOTS`` adds one dump slot at index ``FMA_STAGE_CAP`` where inactive
+# lanes park their (never-read-back) write so the shared-tile store stays a single
+# block-uniform statement instead of a divergent, sync-splitting branch. 
+FMA_STAGE_CAP = 256
+FMA_STAGE_SLOTS = FMA_STAGE_CAP + 1
+
+_NEIGHBOR_X_2BIT = wp.constant(wp.int64(0x2A802A95402551))
+_NEIGHBOR_Y_2BIT = wp.constant(wp.int64(0x28282528251945))
+_NEIGHBOR_Z_2BIT = wp.constant(wp.int64(0x22221862185615))
+
+# wp.config.mode = "debug"
+# wp.config.lineinfo = False
+# wp.config.line_directives = False
+
+wp.set_module_options(
+    {
+        "mode": "release",
+        "optimization_level": 3,
+        "lineinfo": True,
+        "fuse_fp": True,
+        "fast_math": False,
+    }
+)
+# Route wp.tile_matmul through Warp's scalar-GEMM fallback instead of cuBLASDx so
+# the module never runs the libmathdx LTO device-link step. On this CUDA 13.2
+# container that link fails to build ("invalid symbol"); the scalar fallback has
+# no libmathdx dependency, so the kernel compiles. Guarded with hasattr so it is a
+# harmless no-op on Warp versions that predate this config flag (added in #1228).
+if hasattr(wp.config, "enable_mathdx_gemm"):
+    wp.config.enable_mathdx_gemm = False
+# ---------------------------------------------------------------------------
+# Device helper functions
+# ---------------------------------------------------------------------------
+
+# wp.set_module_options({"mode": "release"}, module=_mk)
+
+# wp.clear_kernel_cache()
+# wp.clear_lto_cache()
+
+# wp.load_module(_mk, device="cuda")
+
+@wp.func
+def morton_encode(x: wp.int32, y: wp.int32, z: wp.int32, bits: wp.int32) -> wp.int64:
+    """Interleave the low ``bits`` of three non-negative coords into a Morton code."""
+    code = wp.int64(0)
+    for i in range(bits):
+        bx = wp.int64((x >> i) & 1)
+        by = wp.int64((y >> i) & 1)
+        bz = wp.int64((z >> i) & 1)
+        s = wp.int64(3 * i)
+        code = code | (bx << s) | (by << (s + wp.int64(1))) | (bz << (s + wp.int64(2)))
+    return code
+
+
+@wp.func
+def pack_batch_key(
+    b: wp.int32,
+    cx: wp.int32,
+    cy: wp.int32,
+    cz: wp.int32,
+    bits: wp.int32,
+    morton_bits: wp.int32,
+) -> wp.int64:
+    """Pack a batch id (high bits) and a 3D Morton code (low bits) into an int64 key."""
+    return (wp.int64(b) << wp.int64(morton_bits)) | morton_encode(cx, cy, cz, bits)
+
+
+# ---------------------------------------------------------------------------
+# PC-index build kernels
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def count_points_in_cells(
+    points: wp.array2d(dtype=wp.vec3),
+    inv_radius: wp.float32,
+    P: wp.int32,
+    min_cx: wp.array(dtype=wp.int32),
+    min_cy: wp.array(dtype=wp.int32),
+    min_cz: wp.array(dtype=wp.int32),
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    point_cell_row: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+):
+    """Histogram points into dense row-major cells and record each point's cell row."""
+    flat_p = wp.tid()
+    b = flat_p // P
+    pt = points[b, flat_p % P]
+    lx = wp.int32(wp.floor(pt[0] * inv_radius)) - min_cx[b]
+    ly = wp.int32(wp.floor(pt[1] * inv_radius)) - min_cy[b]
+    lz = wp.int32(wp.floor(pt[2] * inv_radius)) - min_cz[b]
+    row = grid_base[b] + lx + grid_x[b] * (ly + grid_y[b] * lz)
+    point_cell_row[flat_p] = row
+    wp.atomic_add(cell_count_by_row, row, 1)
+
+
+@wp.kernel
+def enumerate_cell_morton_keys(
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    B: wp.int32,
+    bits: wp.int32,
+    morton_bits: wp.int32,
+    cell_key_tmp: wp.array(dtype=wp.int64),
+    cell_row_tmp: wp.array(dtype=wp.int32),
+):
+    """Emit a (batch, Morton) sort key for every dense cell row."""
+    row = wp.tid()
+    b = wp.int32(0)
+    while b + 1 < B and grid_base[b + 1] <= row:
+        b += 1
+    gx = grid_x[b]
+    gy = grid_y[b]
+    local = row - grid_base[b]
+    lx = local % gx
+    ly = (local // gx) % gy
+    lz = local // (gx * gy)
+    cell_key_tmp[row] = pack_batch_key(b, lx, ly, lz, bits, morton_bits)
+    cell_row_tmp[row] = row
+
+
+@wp.kernel
+def gather_cell_counts_by_rank(
+    cell_row_tmp: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+    cell_counts_rank: wp.array(dtype=wp.int32),
+):
+    """Reorder per-cell counts into Morton-rank order for the prefix sum."""
+    rank = wp.tid()
+    cell_counts_rank[rank] = cell_count_by_row[cell_row_tmp[rank]]
+
+
+@wp.kernel
+def fill_cell_row_ranges(
+    cell_row_tmp: wp.array(dtype=wp.int32),
+    cell_offsets_rank: wp.array(dtype=wp.int32),
+    cell_begin_by_row: wp.array(dtype=wp.int32),
+):
+    """Scatter the Morton-rank prefix offsets back into row-indexed cell starts."""
+    rank = wp.tid()
+    cell_begin_by_row[cell_row_tmp[rank]] = cell_offsets_rank[rank]
+
+
+# ---------------------------------------------------------------------------
+# Three-phase async exclusive prefix scan (no cudaDeviceSynchronize).
+#
+# The standard wp.utils.array_scan / torch.cumsum both inject a device sync
+# because CUB's two-pass DeviceScan API requires a sync between the sizing
+# call and the execution call.  These three kernels implement the same
+# exclusive scan with three ordinary kernel launches on the caller's stream:
+#
+#   Phase 1  (num_blocks blocks × SCAN_BLOCK threads)
+#            Each block runs a tile-local exclusive scan of its SCAN_BLOCK
+#            elements and writes the block total to block_sums[b].
+#
+#   Phase 2  (1 block × SCAN_BLOCK threads)
+#            Exclusive scan of the num_blocks block totals → block_offsets[b].
+#            Works as long as num_blocks <= SCAN_BLOCK (i.e. n <= SCAN_BLOCK²).
+#
+#   Phase 3  (n threads, regular kernel)
+#            global_exclusive[i] = local_exclusive[i] + block_offsets[block(i)]
+#
+# Caller must pad the input to a multiple of SCAN_BLOCK with zeros so the
+# last tile load is always in-bounds; see _warp_exclusive_scan() in the impl.
+# ---------------------------------------------------------------------------
+
+SCAN_BLOCK = wp.constant(1024)  # threads per scan block; max n = SCAN_BLOCK^2 = 1 048 576
+
+
+@wp.kernel
+def _scan_copy_pad(
+    src: wp.array(dtype=wp.int32),
+    dst: wp.array(dtype=wp.int32),
+    n: int,
+):
+    """Copy src[0:n] into dst; dst[n:] stays at the caller-provided zeros."""
+    i = wp.tid()
+    if i < n:
+        dst[i] = src[i]
+
+
+# @wp.kernel
+# def exclusive_scan_phase1(
+#     arr: wp.array(dtype=wp.int32),
+#     partial: wp.array(dtype=wp.int32),
+#     block_sums: wp.array(dtype=wp.int32),
+# ):
+#     """Per-block local exclusive scan; writes block totals to block_sums."""
+#     b = wp.tid()
+#     t = wp.tile_load(arr, b * SCAN_BLOCK, SCAN_BLOCK)
+#     wp.tile_store(partial, b * SCAN_BLOCK, wp.tile_scan_exclusive(t))
+#     block_sums[b] = wp.tile_sum(t)
+
+
+# @wp.kernel
+# def exclusive_scan_phase2(
+#     block_sums: wp.array(dtype=wp.int32),
+#     block_offsets: wp.array(dtype=wp.int32),
+# ):
+#     """Single-block exclusive scan of block_sums → block_offsets."""
+#     wp.tile_store(
+#         block_offsets, 0,
+#         wp.tile_scan_exclusive(wp.tile_load(block_sums, 0, SCAN_BLOCK)),
+#     )
+
+
+# @wp.kernel
+# def exclusive_scan_phase3(
+#     partial: wp.array(dtype=wp.int32),
+#     block_offsets: wp.array(dtype=wp.int32),
+#     begins: wp.array(dtype=wp.int32),
+#     n: int,
+#     block_size: int,
+# ):
+#     """Combine: global_exclusive[i] = local_exclusive[i] + block_offset."""
+#     i = wp.tid()
+#     if i < n:
+#         begins[i] = partial[i] + block_offsets[i // block_size]
+
+
+@wp.kernel
+def scatter_points_to_cells(
+    points: wp.array2d(dtype=wp.vec3),
+    point_cell_row: wp.array(dtype=wp.int32),
+    P: wp.int32,
+    cell_write_by_row: wp.array(dtype=wp.int32),
+    pc_x_sorted: wp.array(dtype=wp.float32),
+    pc_y_sorted: wp.array(dtype=wp.float32),
+    pc_z_sorted: wp.array(dtype=wp.float32),
+    pc_orig_sorted: wp.array(dtype=wp.int32),
+    pc_xyz4_sorted: wp.array2d(dtype=wp.float32),
+    pc_norm_sorted: wp.array(dtype=wp.float32),
+):
+    """Scatter each point into its Morton-cell-sorted compact slot."""
+    flat_p = wp.tid()
+    pt = points[flat_p // P, flat_p % P]
+    dst = wp.atomic_add(cell_write_by_row, point_cell_row[flat_p], 1)
+    pc_x_sorted[dst] = pt[0]
+    pc_y_sorted[dst] = pt[1]
+    pc_z_sorted[dst] = pt[2]
+    pc_orig_sorted[dst] = flat_p % P
+    pc_xyz4_sorted[dst, 0] = pt[0]
+    pc_xyz4_sorted[dst, 1] = pt[1]
+    pc_xyz4_sorted[dst, 2] = pt[2]
+    pc_xyz4_sorted[dst, 3] = 0.0
+    pc_norm_sorted[dst] = pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2]
+
+
+# ---------------------------------------------------------------------------
+# Query build kernels
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def make_query_morton_keys(
+    queries: wp.array2d(dtype=wp.vec3),
+    inv_radius: wp.float32,
+    Q: wp.int32,
+    q_min_cx: wp.array(dtype=wp.int32),
+    q_min_cy: wp.array(dtype=wp.int32),
+    q_min_cz: wp.array(dtype=wp.int32),
+    bits: wp.int32,
+    morton_bits: wp.int32,
+    q_key_tmp: wp.array(dtype=wp.int64),
+    q_val_tmp: wp.array(dtype=wp.int32),
+):
+    """Emit a (batch, Morton) sort key per query using per-batch query-cell minima."""
+    flat_q = wp.tid()
+    b = flat_q // Q
+    pt = queries[b, flat_q % Q]
+    lx = wp.int32(wp.floor(pt[0] * inv_radius)) - q_min_cx[b]
+    ly = wp.int32(wp.floor(pt[1] * inv_radius)) - q_min_cy[b]
+    lz = wp.int32(wp.floor(pt[2] * inv_radius)) - q_min_cz[b]
+    q_key_tmp[flat_q] = pack_batch_key(b, lx, ly, lz, bits, morton_bits)
+    q_val_tmp[flat_q] = flat_q
+
+
+@wp.kernel
+def gather_sorted_queries(
+    queries: wp.array2d(dtype=wp.vec3),
+    q_val_tmp: wp.array(dtype=wp.int32),
+    Q: wp.int32,
+    q_orig_sorted: wp.array(dtype=wp.int32),
+    q_x_sorted: wp.array(dtype=wp.float32),
+    q_y_sorted: wp.array(dtype=wp.float32),
+    q_z_sorted: wp.array(dtype=wp.float32),
+    q_xyz4_sorted: wp.array2d(dtype=wp.float32),
+    q_norm_sorted: wp.array(dtype=wp.float32),
+):
+    """Reorder queries into Morton order and record coords + GEMM data.
+
+    The per-query batch id and absolute cell coords are not stored; consumers
+    derive them as ``b = flat_q // Q`` and ``floor(coord / cell_size)``.
+    """
+    sorted_q = wp.tid()
+    flat_q = q_val_tmp[sorted_q]
+    pt = queries[flat_q // Q, flat_q % Q]
+    q_orig_sorted[sorted_q] = flat_q
+    q_x_sorted[sorted_q] = pt[0]
+    q_y_sorted[sorted_q] = pt[1]
+    q_z_sorted[sorted_q] = pt[2]
+    q_xyz4_sorted[sorted_q, 0] = pt[0]
+    q_xyz4_sorted[sorted_q, 1] = pt[1]
+    q_xyz4_sorted[sorted_q, 2] = pt[2]
+    q_xyz4_sorted[sorted_q, 3] = 0.0
+    q_norm_sorted[sorted_q] = pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2]
+
+
+# ---------------------------------------------------------------------------
+# Production search: one warp per query, direct-FMA distances
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def radius_search_dense_fma_kernel(
+    q_x_sorted: wp.array(dtype=wp.float32),
+    q_y_sorted: wp.array(dtype=wp.float32),
+    q_z_sorted: wp.array(dtype=wp.float32),
+    q_orig_sorted: wp.array(dtype=wp.int32),
+    inv_radius: wp.float32,
+    Q: wp.int32,
+    neighbor_offsets: wp.array2d(dtype=wp.int32),
+    min_cx: wp.array(dtype=wp.int32),
+    min_cy: wp.array(dtype=wp.int32),
+    min_cz: wp.array(dtype=wp.int32),
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_begin_by_row: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+    pc_x_sorted: wp.array(dtype=wp.float32),
+    pc_y_sorted: wp.array(dtype=wp.float32),
+    pc_z_sorted: wp.array(dtype=wp.float32),
+    pc_orig_sorted: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """One block per query: scan 27 dense cells, block-compact in-radius hits.
+
+    Launched with ``wp.launch_tiled(dim=[Nq], block_dim=FMA_BLOCK_DIM)``. All lanes
+    reach the tile ops every chunk (inactive lanes contribute ``hit = 0``); the loop
+    conditions are block-uniform so the tile scan/sum and the early breaks stay
+    collective.
+    """
+    sorted_q, lane = wp.tid()
+    flat_q = q_orig_sorted[sorted_q]
+    b = flat_q // Q
+    qx = q_x_sorted[sorted_q]
+    qy = q_y_sorted[sorted_q]
+    qz = q_z_sorted[sorted_q]
+    gx = grid_x[b]
+    gy = grid_y[b]
+    gz = grid_z[b]
+    mcx = min_cx[b]
+    mcy = min_cy[b]
+    mcz = min_cz[b]
+    gbase = grid_base[b]
+    lqx = wp.int32(wp.floor(qx * inv_radius)) - mcx
+    lqy = wp.int32(wp.floor(qy * inv_radius)) - mcy
+    lqz = wp.int32(wp.floor(qz * inv_radius)) - mcz
+
+    found = wp.int32(0)
+    for n in range(27):
+        lx = lqx + neighbor_offsets[n, 0]
+        ly = lqy + neighbor_offsets[n, 1]
+        lz = lqz + neighbor_offsets[n, 2]
+        if lx >= 0 and lx < gx and ly >= 0 and ly < gy and lz >= 0 and lz < gz:
+            row = gbase + lx + gx * (ly + gy * lz)
+            start = cell_begin_by_row[row]
+            end = start + cell_count_by_row[row]
+            base = start
+            while base < end:
+                si = base + lane
+                hit = wp.int32(0)
+                d2 = wp.float32(0.0)
+                px = wp.float32(0.0)
+                py = wp.float32(0.0)
+                pz = wp.float32(0.0)
+                if si < end:
+                    px = pc_x_sorted[si]
+                    py = pc_y_sorted[si]
+                    pz = pc_z_sorted[si]
+                    dx = px - qx
+                    dy = py - qy
+                    dz = pz - qz
+                    d2 = dx * dx + dy * dy + dz * dz
+                    if d2 <= radius2:
+                        hit = wp.int32(1)
+                hit_tile = wp.tile(hit)
+                prefix = wp.untile(wp.tile_scan_exclusive(hit_tile))
+                hits_tile = wp.tile_sum(hit_tile)
+                write_hits = wp.min(hits_tile[0], max_points - found)
+                if hit == 1 and prefix < write_hits:
+                    slot = found + prefix
+                    out_idx[flat_q, slot] = pc_orig_sorted[si]
+                    if return_dists:
+                        out_dist[flat_q, slot] = wp.sqrt(d2)
+                    if return_points:
+                        out_pts[flat_q, slot] = wp.vec3(px, py, pz)
+                found += write_hits
+                if found >= max_points:
+                    break
+                base += FMA_BLOCK_DIM
+        if found >= max_points:
+            break
+    if lane == 0:
+        out_count[flat_q] = found
+
+@wp.func_native(
+    """
+#if defined(__CUDA_ARCH__)
+    const unsigned hit_mask = __ballot_sync(0xffffffffu, hit != 0);
+    const unsigned lower_lane_mask =
+        (1u << static_cast<unsigned>(lane)) - 1u;
+    return wp::vec2i(
+        __popc(hit_mask & lower_lane_mask),
+        __popc(hit_mask)
+    );
+#else
+    return wp::vec2i(0, hit != 0 ? 1 : 0);
+#endif
+    """
+)
+def _warp_hit_prefix_and_count(
+    hit: wp.int32, lane: wp.int32
+) -> wp.vec2i:
+    """Return ``(exclusive hit prefix, total warp hits)`` for one lane."""
+    ...
+
+
+@wp.func
+def _decode_neighbor_offset_27(neighbor: wp.int32) -> wp.vec3i:
+    """Decode one standard near-to-far 27-cell offset without a memory load."""
+    shift = wp.int64(2 * neighbor)
+    mask = wp.int64(3)
+    offset_x = wp.int32((_NEIGHBOR_X_2BIT >> shift) & mask) - 1
+    offset_y = wp.int32((_NEIGHBOR_Y_2BIT >> shift) & mask) - 1
+    offset_z = wp.int32((_NEIGHBOR_Z_2BIT >> shift) & mask) - 1
+    return wp.vec3i(offset_x, offset_y, offset_z)
+
+
+@wp.kernel(enable_backward=False, launch_bounds=FMA_V2_BLOCK_DIM)
+def radius_search_dense_fma_kernel_v2(
+    q_x_sorted: wp.array(dtype=wp.float32),
+    q_y_sorted: wp.array(dtype=wp.float32),
+    q_z_sorted: wp.array(dtype=wp.float32),
+    q_orig_sorted: wp.array(dtype=wp.int32),
+    inv_radius: wp.float32,
+    Q: wp.int32,
+    neighbor_offsets: wp.array2d(dtype=wp.int32),
+    min_cx: wp.array(dtype=wp.int32),
+    min_cy: wp.array(dtype=wp.int32),
+    min_cz: wp.array(dtype=wp.int32),
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_begin_by_row: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+    pc_x_sorted: wp.array(dtype=wp.float32),
+    pc_y_sorted: wp.array(dtype=wp.float32),
+    pc_z_sorted: wp.array(dtype=wp.float32),
+    pc_orig_sorted: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """One-warp-per-query radius search with native hit compaction.
+
+    This kernel has the exact input/output signature and result ordering of
+    :func:`radius_search_dense_fma_kernel`, but it must be launched with
+    ``block_dim=FMA_V2_BLOCK_DIM``. Each lane evaluates one candidate and a
+    single native ballot computes both its exclusive output rank and the total
+    number of hits in the 32-candidate chunk.
+
+    Compared with the original block-wide ``tile_scan``/``tile_sum`` path, this
+    design uses no Warp tiles, shared memory, or block barriers. It also checks
+    ``max_points`` every 32 candidates instead of every 64/128 candidates, so a
+    full query does less excess work before exiting.
+    """
+    sorted_q, lane = wp.tid()
+
+    # All lanes in the warp own the same query. Warp keeps these block-uniform
+    # values in uniform registers where the target architecture supports them.
+    flat_q = q_orig_sorted[sorted_q]
+    batch = flat_q // Q
+    query_x = q_x_sorted[sorted_q]
+    query_y = q_y_sorted[sorted_q]
+    query_z = q_z_sorted[sorted_q]
+
+    grid_size_x = grid_x[batch]
+    grid_size_y = grid_y[batch]
+    grid_size_z = grid_z[batch]
+    batch_grid_base = grid_base[batch]
+
+    query_cell_x = (
+        wp.int32(wp.floor(query_x * inv_radius)) - min_cx[batch]
+    )
+    query_cell_y = (
+        wp.int32(wp.floor(query_y * inv_radius)) - min_cy[batch]
+    )
+    query_cell_z = (
+        wp.int32(wp.floor(query_z * inv_radius)) - min_cz[batch]
+    )
+
+    # ``found`` stays warp-uniform: every lane receives the same total hit count
+    # from the ballot helper and adds the same accepted count after each chunk.
+    found = wp.int32(0)
+
+    for neighbor in range(27):
+        # ``neighbor_offsets`` remains part of the signature so callers can
+        # substitute v2 without rebuilding the launch argument list. The dense
+        # backend always supplies its standard near-to-far stencil, which is
+        # decoded from compile-time constants here to avoid 81 global loads per
+        # query.
+        neighbor_offset = _decode_neighbor_offset_27(neighbor)
+        cell_x = query_cell_x + neighbor_offset[0]
+        cell_y = query_cell_y + neighbor_offset[1]
+        cell_z = query_cell_z + neighbor_offset[2]
+
+        # Query-cell coordinates are uniform, so this bounds branch is taken by
+        # the full warp and never creates intra-warp divergence.
+        if (
+            cell_x >= 0
+            and cell_x < grid_size_x
+            and cell_y >= 0
+            and cell_y < grid_size_y
+            and cell_z >= 0
+            and cell_z < grid_size_z
+        ):
+            cell_row = (
+                batch_grid_base
+                + cell_x
+                + grid_size_x * (cell_y + grid_size_y * cell_z)
+            )
+            point_begin = cell_begin_by_row[cell_row]
+            point_end = point_begin + cell_count_by_row[cell_row]
+
+            chunk_begin = point_begin
+            while chunk_begin < point_end:
+                point_index = chunk_begin + lane
+                point_valid = point_index < point_end
+
+                hit = wp.int32(0)
+                distance2 = wp.float32(0.0)
+                point_x = wp.float32(0.0)
+                point_y = wp.float32(0.0)
+                point_z = wp.float32(0.0)
+
+                if point_valid:
+                    # These structure-of-arrays reads are unit-stride across the
+                    # warp, which preserves the original coalesced candidate path.
+                    point_x = pc_x_sorted[point_index]
+                    point_y = pc_y_sorted[point_index]
+                    point_z = pc_z_sorted[point_index]
+
+                    dx = point_x - query_x
+                    dy = point_y - query_y
+                    dz = point_z - query_z
+                    distance2 = dx * dx + dy * dy + dz * dz
+                    if distance2 <= radius2:
+                        hit = wp.int32(1)
+
+                compact = _warp_hit_prefix_and_count(hit, lane)
+                hit_prefix = compact[0]
+                chunk_hits = compact[1]
+                accepted_hits = wp.min(chunk_hits, max_points - found)
+
+                # Accepted hit lanes write a dense run of query-major slots.
+                # ``hit_prefix`` preserves candidate order exactly as the tile
+                # exclusive scan used by the original kernel.
+                if hit == 1 and hit_prefix < accepted_hits:
+                    output_slot = found + hit_prefix
+                    out_idx[flat_q, output_slot] = pc_orig_sorted[point_index]
+                    if return_dists:
+                        out_dist[flat_q, output_slot] = wp.sqrt(distance2)
+                    if return_points:
+                        out_pts[flat_q, output_slot] = wp.vec3(
+                            point_x, point_y, point_z
+                        )
+
+                found += accepted_hits
+                if found >= max_points:
+                    break
+
+                chunk_begin += FMA_V2_BLOCK_DIM
+
+        if found >= max_points:
+            break
+
+    if lane == 0:
+        out_count[flat_q] = found
+
+# ---------------------------------------------------------------------------
+# Store-optimized search variant: shared-mem staged flush + host-gathered points
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def radius_search_dense_fma_store_opt_kernel(
+    q_x_sorted: wp.array(dtype=wp.float32),
+    q_y_sorted: wp.array(dtype=wp.float32),
+    q_z_sorted: wp.array(dtype=wp.float32),
+    q_orig_sorted: wp.array(dtype=wp.int32),
+    inv_radius: wp.float32,
+    Q: wp.int32,
+    neighbor_offsets: wp.array2d(dtype=wp.int32),
+    min_cx: wp.array(dtype=wp.int32),
+    min_cy: wp.array(dtype=wp.int32),
+    min_cz: wp.array(dtype=wp.int32),
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_begin_by_row: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+    pc_x_sorted: wp.array(dtype=wp.float32),
+    pc_y_sorted: wp.array(dtype=wp.float32),
+    pc_z_sorted: wp.array(dtype=wp.float32),
+    pc_orig_sorted: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+):
+    """Store-optimized twin of :func:`radius_search_dense_fma_kernel`.
+
+    Same one-block-per-query 27-cell scan and block-wide hit compaction, but with
+    two changes that target the inefficient global stores NCU flagged on the
+    baseline kernel:
+
+    * Stage 1 -- neighbor *coordinates* are not stored here. The baseline's
+      ``out_pts[flat_q, slot] = wp.vec3(...)`` was a 12-byte (misaligned) global
+      scatter; callers that need coordinates gather them on the host from
+      ``out_idx`` (see ``_gather_neighbor_points``), so this kernel writes only
+      indices/distances.
+    * Stage 2 -- hits from all 27 cells accumulate in a per-query block-shared
+      staging tile (``stage_idx``/``stage_dist``) instead of a per-chunk global
+      write. After the scan a single coalesced pass flushes the compacted
+      ``[0, found)`` run, replacing many small partial-warp scatters with one
+      full-width store.
+
+    ``max_points`` must be ``<= FMA_STAGE_CAP`` (enforced host-side); the shared
+    tile carries one extra dump slot at index ``FMA_STAGE_CAP`` so the per-chunk
+    shared-tile write stays a single block-uniform statement (inactive lanes write
+    the dump slot, which is never read back).
+    """
+    sorted_q, lane = wp.tid()
+    flat_q = q_orig_sorted[sorted_q]
+    b = flat_q // Q
+    qx = q_x_sorted[sorted_q]
+    qy = q_y_sorted[sorted_q]
+    qz = q_z_sorted[sorted_q]
+    gx = grid_x[b]
+    gy = grid_y[b]
+    gz = grid_z[b]
+    mcx = min_cx[b]
+    mcy = min_cy[b]
+    mcz = min_cz[b]
+    gbase = grid_base[b]
+    lqx = wp.int32(wp.floor(qx * inv_radius)) - mcx
+    lqy = wp.int32(wp.floor(qy * inv_radius)) - mcy
+    lqz = wp.int32(wp.floor(qz * inv_radius)) - mcz
+
+    # Stage 2: block-shared staging buffers (one extra dump slot at FMA_STAGE_CAP).
+    # Writing a tile element migrates the tile to shared memory and emits a
+    # block-wide sync, so the per-chunk store below must be reached by every lane.
+    stage_idx = wp.tile_zeros(shape=(FMA_STAGE_SLOTS,), dtype=wp.int32)
+    stage_dist = wp.tile_zeros(shape=(FMA_STAGE_SLOTS,), dtype=wp.float32)
+
+    found = wp.int32(0)
+    for n in range(27):
+        lx = lqx + neighbor_offsets[n, 0]
+        ly = lqy + neighbor_offsets[n, 1]
+        lz = lqz + neighbor_offsets[n, 2]
+        if lx >= 0 and lx < gx and ly >= 0 and ly < gy and lz >= 0 and lz < gz:
+            row = gbase + lx + gx * (ly + gy * lz)
+            start = cell_begin_by_row[row]
+            end = start + cell_count_by_row[row]
+            base = start
+            while base < end:
+                si = base + lane
+                hit = wp.int32(0)
+                d2 = wp.float32(0.0)
+                if si < end:
+                    dx = pc_x_sorted[si] - qx
+                    dy = pc_y_sorted[si] - qy
+                    dz = pc_z_sorted[si] - qz
+                    d2 = dx * dx + dy * dy + dz * dz
+                    if d2 <= radius2:
+                        hit = wp.int32(1)
+                hit_tile = wp.tile(hit)
+                prefix = wp.untile(wp.tile_scan_exclusive(hit_tile))
+                hits_tile = wp.tile_sum(hit_tile)
+                write_hits = wp.min(hits_tile[0], max_points - found)
+
+                # Route inactive lanes to the dump slot so the shared-tile store is a
+                # single block-uniform statement; the value read is guarded so only
+                # in-radius lanes (si < end) touch pc_orig_sorted.
+                dst = wp.int32(FMA_STAGE_CAP)
+                idx_val = wp.int32(0)
+                dist_val = wp.float32(0.0)
+                if hit == 1 and prefix < write_hits:
+                    dst = found + prefix
+                    idx_val = pc_orig_sorted[si]
+                    if return_dists:
+                        dist_val = wp.sqrt(d2)
+                stage_idx[dst] = idx_val
+                if return_dists:
+                    stage_dist[dst] = dist_val
+
+                found += write_hits
+                if found >= max_points:
+                    break
+                base += FMA_BLOCK_DIM
+        if found >= max_points:
+            break
+
+    # Stage 2 flush: one coalesced pass writes the compacted [0, found) run.
+    # Consecutive lanes write consecutive slots, so each warp store is fully packed.
+    s = lane
+    while s < found:
+        out_idx[flat_q, s] = stage_idx[s]
+        if return_dists:
+            out_dist[flat_q, s] = stage_dist[s]
+        s += FMA_BLOCK_DIM
+    if lane == 0:
+        out_count[flat_q] = found
+
+
+# ---------------------------------------------------------------------------
+# Memory-optimized search variant: vec4 coord loads + in-kernel offset decode
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def radius_search_dense_fma_kernel_mem_opt(
+    q_pos: wp.array(dtype=wp.vec4),
+    q_orig_sorted: wp.array(dtype=wp.int32),
+    inv_radius: wp.float32,
+    Q: wp.int32,
+    min_cx: wp.array(dtype=wp.int32),
+    min_cy: wp.array(dtype=wp.int32),
+    min_cz: wp.array(dtype=wp.int32),
+    grid_x: wp.array(dtype=wp.int32),
+    grid_y: wp.array(dtype=wp.int32),
+    grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_begin_by_row: wp.array(dtype=wp.int32),
+    cell_count_by_row: wp.array(dtype=wp.int32),
+    pc_pos: wp.array(dtype=wp.vec4),
+    pc_orig_sorted: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """Memory-optimized variant of :func:`radius_search_dense_fma_kernel`.
+
+    Loads query and point coords as single ``wp.vec4`` (128-bit) loads and decodes
+    the 27 neighbor offsets from the loop index (lexicographic) instead of reading
+    an offset table. The vec4 load is one instruction but moves 16 B/point (incl.
+    padding) vs the SoA path's coalesced 12 B; benchmark against ``dense_fma``.
+    """
+    sorted_q, lane = wp.tid()
+    flat_q = q_orig_sorted[sorted_q]
+    b = flat_q // Q
+    qp = q_pos[sorted_q]
+    qx = qp[0]
+    qy = qp[1]
+    qz = qp[2]
+    gx = grid_x[b]
+    gy = grid_y[b]
+    gz = grid_z[b]
+    mcx = min_cx[b]
+    mcy = min_cy[b]
+    mcz = min_cz[b]
+    gbase = grid_base[b]
+    lqx = wp.int32(wp.floor(qx * inv_radius)) - mcx
+    lqy = wp.int32(wp.floor(qy * inv_radius)) - mcy
+    lqz = wp.int32(wp.floor(qz * inv_radius)) - mcz
+
+    found = wp.int32(0)
+    for n in range(27):
+        ox = n // 9 - 1
+        oy = (n // 3) % 3 - 1
+        oz = n % 3 - 1
+        lx = lqx + ox
+        ly = lqy + oy
+        lz = lqz + oz
+        if lx >= 0 and lx < gx and ly >= 0 and ly < gy and lz >= 0 and lz < gz:
+            row = gbase + lx + gx * (ly + gy * lz)
+            start = cell_begin_by_row[row]
+            end = start + cell_count_by_row[row]
+            base = start
+            while base < end:
+                si = base + lane
+                hit = wp.int32(0)
+                d2 = wp.float32(0.0)
+                p = wp.vec4(0.0, 0.0, 0.0, 0.0)
+                if si < end:
+                    p = pc_pos[si]
+                    dx = p[0] - qx
+                    dy = p[1] - qy
+                    dz = p[2] - qz
+                    d2 = dx * dx + dy * dy + dz * dz
+                    if d2 <= radius2:
+                        hit = wp.int32(1)
+                hit_tile = wp.tile(hit)
+                prefix = wp.untile(wp.tile_scan_exclusive(hit_tile))
+                hits_tile = wp.tile_sum(hit_tile)
+                write_hits = wp.min(hits_tile[0], max_points - found)
+                if hit == 1 and prefix < write_hits:
+                    slot = found + prefix
+                    out_idx[flat_q, slot] = pc_orig_sorted[si]
+                    if return_dists:
+                        out_dist[flat_q, slot] = wp.sqrt(d2)
+                    if return_points:
+                        out_pts[flat_q, slot] = wp.vec3(p[0], p[1], p[2])
+                found += write_hits
+                if found >= max_points:
+                    break
+                base += FMA_BLOCK_DIM
+        if found >= max_points:
+            break
+    if lane == 0:
+        out_count[flat_q] = found
+
+
+# @wp.kernel
+# def radius_search_mem_optimized(
+#     grid_cell_idx,
+#     inv_radius,
+#     queries_per_batch,
+#     min_cx,
+#     min_cy, 
+#     min_cz,
+#     num_grid_x, 
+#     num_grid_y, 
+#     num_grid_z,
+#     grid_base,
+#     cell_begin_by_grid_odx,
+#     cell_count_by_grid_idx,
+#     radius,
+#     max_points,
+#     return_dists,
+#     return_points,
+#     out_idx, 
+#     out_count, 
+#     out_dist,
+#     out_points,
+#     TILE_DIM
+
+# ):
+#     curr_cell, lane = wp.tid()
+
+#     num_cells = num_grid_x * num_grid_y * num_grid_z
+
+#     num_points = cell_count_by_grid_idx[curr_cell]
+
+#     gbase = 0
+#     queries = .. shared global load of all the points in the cell
+
+#     points = .. shared global load of all the points in the cell
+
+
+#     if num_points < max_points + 1:
+#         shared global load all points in the 27 neighbouring cells 
+#         add to the points
+#         for i in range(27):
+#             ox = n//9 -1
+#             oy = (n//3) %3 -1
+#             oz = n%3 -1
+
+#             lx = lqx + ox
+#             ly = lqy + oy
+#             lz = lqz + oz
+#             if lx >= 0 and lx < gx and ly >= 0 and ly < gy and lz >= 0 and lz < gz:
+#                 row = gbase + lx + gx * (ly + gy * lz)
+#                 ....
+    
+#     num_tiles_q = (len(queries) // TILE_DIM) +1
+#     num_tiles_pc = (len(points)//TILE_DIM) +1
+
+#     for tile_q in range(num_tiles_q):
+#         tile_idx = lane % TILE_DIM
+#         shared_out_idx = ..allocate in shared_memory (TILE_DIM x max_points)
+#         shared_out_count = ..allocate in shared memory (TILE_DIM x max_points)
+#         shared_out_dist = ..allocate in shared memory (TILE_DIM x max_points)
+#         dists_mat = ..allocate in shared memory ( TILE_DIM x TILE_DIM)
+#         for tile_q in range(num_tiles_p):
+
+#             q_points_tiled = wp.tiled_load
+#             p_points_tiles = wp.transpose(wp.tiled_load())
+
+#             dists_mat = -2.0 * wp.tiled_matmul(q_points_tiled, p_points_tiles)
+
+#             dists_mat += ...
+
+#             ..write to shared_out matrices
+#             ..each thread writes to shared_out_count
+        
+#         ..from shared do a coalesed global write
+
+TILE_DIM   = wp.constant(32)   # tile edge: queries per tile == candidates per tile
+# Compile-time capacity of the per-query shared staging tiles (sh_idx/sh_dst are
+# (TILE_DIM, MAX_POINTS)). This is an upper bound on the neighbor cap, NOT the cap
+# itself: the actual per-call cap is the runtime ``max_points`` kernel argument,
+# which the kernel clamps to MAX_POINTS so it can never stage/emit past the tile.
+# Must be >= the largest ``max_points`` any caller requests (the GeoTransolver
+# recipe uses neighbors_in_radius up to 128), otherwise results are truncated.
+MAX_POINTS = wp.constant(128)  # shared-staging capacity / upper bound on max_points
+
+
+# ===========================================================================
+# PRIMARY: tiled / tile_matmul design, TRANSPOSED (coalesced) output
+# ===========================================================================
+@wp.kernel
+def radius_search_mem_optimized(
+    pts:           wp.array2d(dtype=wp.float32),   # (Ntot, 3+) sorted coords
+    pcs_t:         wp.array2d(dtype=wp.float32),   # (3, Ntot) transposed coords for Pᵀ tile_matmul loads
+    B:             wp.int32,                       # batch size
+    num_grid_x:    wp.array(dtype=wp.int32),       # (B,) per-batch cell extents
+    num_grid_y:    wp.array(dtype=wp.int32),       # (B,)
+    num_grid_z:    wp.array(dtype=wp.int32),       # (B,)
+    grid_base:     wp.array(dtype=wp.int32),       # (B+1,) per-batch dense-cell base offsets
+    cell_begin:    wp.array(dtype=wp.int32),       # (total_cells,)
+    cell_count:    wp.array(dtype=wp.int32),       # (total_cells,)
+    occupied_rows: wp.array(dtype=wp.int32),       # (num_occupied,) global cell ids with count > 0 (the launch grid)
+    radius:        wp.float32,
+    max_points:    wp.int32,                       # runtime neighbor cap (== out_* row count)
+    return_dists:  wp.bool,
+    return_points: wp.bool,
+    out_idx:       wp.array2d(dtype=wp.int32),     # (max_points, Ntot)   TRANSPOSED
+    out_count:     wp.array(dtype=wp.int32),       # (Ntot,)
+    out_dist:      wp.array2d(dtype=wp.float32),   # (max_points, Ntot)   TRANSPOSED (dummy (1,1) if off)
+    out_points:    wp.array3d(dtype=wp.float32),   # (max_points, Ntot, 3)TRANSPOSED (dummy (1,1,3) if off)
+):
+    # One block per OCCUPIED cell: the launch grid spans only non-empty cells
+    # (num_occupied <= Ntot), not the full dense grid (total_cells, dominated by empty
+    # cells for small radii). Map the compact block id back to its global dense-cell row.
+    blk, lane = wp.tid()                           # block ↔ occupied-cell slot ; lane in [0, BLOCK_DIM)
+    curr_cell = occupied_rows[blk]                 # global row-major dense cell id (count > 0 by construction)
+    # wp.print(f"inside_kernel : {lane}")
+    # Recover the batch of this global row-major cell id from grid_base (the per-batch
+    # exclusive scan of cell counts), mirroring enumerate_cell_morton_keys and the FMA
+    # search. Cell extents and the row base are then read per-batch, so variable-size
+    # per-batch grids index correctly (no uniform-grid b*num_cells assumption).
+    b = wp.int32(0)
+    # while b + 1 < B and grid_base[b + 1] <= curr_cell:
+    #     b += 1
+    gbase = grid_base[b]                           # per-batch cell base offset
+    cell  = curr_cell - gbase                      # local row-major cell id within batch b
+    gx = num_grid_x[b]
+    gy = num_grid_y[b]
+    gz = num_grid_z[b]
+
+    n_self = cell_count[curr_cell]
+    if n_self == 0:
+        return
+    q_start = cell_begin[curr_cell]
+    r2 = radius * radius
+
+    cell_x = cell % gx                             # lin = cell_x + gx*(cell_y + gy*cell_z)
+    cell_y = (cell // gx) % gy
+    cell_z = cell // (gx * gy)
+
+    # Effective per-query cap: the caller's runtime max_points, clamped to the
+    # shared-staging capacity so sh_idx/sh_dst[..cnt] and the out_* writes can never
+    # run past their bounds (out_* have exactly max_points rows). max_points > MAX_POINTS
+    # would silently truncate to MAX_POINTS (raise MAX_POINTS to avoid that).
+    mp_eff = wp.min(max_points, MAX_POINTS)
+    use_neighbors = n_self < (max_points + 1)      # self cell alone can't fill the quota → also scan the 27-cell stencil (approximate; note #6)
+
+
+    
+        
+    num_q_tiles = (n_self + TILE_DIM - 1) // TILE_DIM
+
+    for tq in range(num_q_tiles):
+        q0 = q_start + tq * TILE_DIM
+        Q  = wp.tile_load(pts, shape=(TILE_DIM, 3), offset=(q0, 0), storage="shared", bounds_check=True)
+        qn = wp.tile_reshape(wp.tile_sum(Q * Q, axis=1), shape=(TILE_DIM, 1))  # (TILE_DIM,1) ‖x‖²
+        #qn = wp.tile_zeros(shape=(TILE_DIM, 1),   storage="shared")
+
+        # sh_idx = wp.tile_zeros(shape=(TILE_DIM, MAX_POINTS), dtype=wp.int32,   storage="register")
+        # sh_dst = wp.tile_zeros(shape=(TILE_DIM, MAX_POINTS), dtype=wp.float32, storage="register")
+        cnt = int(0)                               # per-lane running neighbour count (register)
+        # if lane ==0:
+        #     wp.breakpoint()
+        for n in range(27):
+            if (not use_neighbors):  # dense: self cell (offset 0,0,0 == n 13) only
+                continue
+            offset_x = n // 9 - 1
+            offset_y = (n // 3) % 3 - 1
+            offset_z = n % 3 - 1
+            nx = cell_x + offset_x
+            ny = cell_y + offset_y
+            nz = cell_z + offset_z
+            
+            if nx < 0 or nx >= gx or ny < 0 or ny >= gy or nz < 0 or nz >= gz:
+                continue
+            
+            ncell   = gbase + nx + gx * (ny + gy * nz)
+            
+            p_start = cell_begin[ncell]
+            p_cnt   = cell_count[ncell]
+            num_p_tiles = (p_cnt + TILE_DIM - 1) // TILE_DIM
+            # if lane == 0:
+            #     wp.breakpoint()
+            for tp in range(num_p_tiles):
+                p0 = p_start + tp * TILE_DIM
+                # Load Pᵀ directly as (3, TILE_DIM) so tile_matmul gets a real (K, N)
+                # operand: Warp's tile_matmul rejects a tile_transpose() view as an operand
+                # (issue #1527), so the transpose is materialized here via the transposed
+                # coord buffer instead of an in-kernel transpose.
+                # if lane == 0:
+                #     wp.breakpoint()
+                Pt = wp.tile_load(pcs_t, shape=(3, TILE_DIM), offset=(0, p0), storage="shared", bounds_check=True)
+                ## DEBUG
+                #Pt = wp.tile_zeros(shape=(3, TILE_DIM),  storage="shared")
+                pn = wp.tile_reshape(wp.tile_sum(Pt * Pt, axis=0), shape=(TILE_DIM, 1))  # (TILE_DIM,1) ‖y‖²
+                #pn = wp.tile_zeros(shape=(TILE_DIM, 1),   storage="shared")
+                # DEBUG
+                #pn =  wp.tile_zeros(shape=(TILE_DIM,1),  storage="shared")
+                
+                dists = wp.tile_zeros(shape=(TILE_DIM, TILE_DIM), dtype=wp.float32, storage="shared")
+                wp.tile_matmul(Q, Pt, dists, -2.0, 0.0)                           # dists = -2·Q·Pᵀ
+                dists += wp.tile_broadcast(qn, shape=(TILE_DIM, TILE_DIM))
+                dists += wp.tile_broadcast(wp.tile_transpose(pn), shape=(TILE_DIM, TILE_DIM))  # ‖x‖²+‖y‖²−2x·yᵀ
+                # dists += qn 
+                # dists += wp.tile_transpose(pn)
+                # if lane == 0:
+                #     wp.breakpoint()
+                # if lane < TILE_DIM:                # per-lane selection (per-thread branch, not cooperative)
+                #     qg = q0 + lane
+                #     if qg < q_start + n_self:
+                #         for c in range(TILE_DIM):
+                #             pg = p0 + c
+                #             if pg < p_start + p_cnt and pg != qg:
+                #                 d2 = dists[lane, c]                # ⚠️ shared-tile element read (note #4)
+                #                 if d2 <= r2 and cnt < mp_eff:
+                #                     sh_idx[lane, cnt] = pg
+                #                     sh_dst[lane, cnt] = d2
+                #                     cnt += 1
+                if lane < TILE_DIM:
+                    qg = q0 + lane
+                    if qg < q_start + n_self:
+                        for c in range(TILE_DIM):
+                            pg = p0 + c
+                            if pg < p_start + p_cnt and pg != qg:
+                                d2 = dists[lane, c]
+                                if d2 <= r2 and cnt < max_points:
+                                    out_idx[cnt, qg] = pg
+                                    if return_dists != 0:
+                                        out_dist[cnt, qg] = d2
+                                    if return_points != 0:
+                                        # out_points[cnt, qg, 0] = pts[pg, 0]
+                                        # out_points[cnt, qg, 1] = pts[pg, 1]
+                                        # out_points[cnt, qg, 2] = pts[pg, 2]
+                                        out_points[cnt, qg, 0] = Q[lane, 0]
+                                        out_points[cnt, qg, 1] = Q[lane, 1]
+                                        out_points[cnt, qg, 2] = Q[lane, 2]
+                                    cnt += 1
+
+
+
+        # ---- COALESCED write: index [m, qg]; Ntot is innermost → consecutive lanes are unit-stride ----
+        # if lane < TILE_DIM:
+        #     qg = q0 + lane
+        #     if qg < q_start + n_self:
+        #         out_count[qg] = cnt
+        #         for m in range(max_points):        # outer loop over slot (== out_* rows) → warp coalesces across qg
+        #             if m < cnt:
+        #                 j = sh_idx[lane, m]
+        #                 out_idx[m, qg] = j
+        #                 if return_dists != 0:
+        #                     out_dist[m, qg] = sh_dst[lane, m]
+        #                 if return_points != 0:
+        #                     out_points[m, qg, 0] = pts[j, 0]
+        #                     out_points[m, qg, 1] = pts[j, 1]
+        #                     out_points[m, qg, 2] = pts[j, 2]
+        #             else:
+        #                 out_idx[m, qg] = -1             
+        if lane < TILE_DIM:
+            qg = q0 + lane
+            if qg < q_start + n_self:
+                out_count[qg] = cnt
+
+
+MEM_OPT_2_BLOCK_DIM = 32
+
+@wp.kernel
+def radius_search_mem_optimized_2(
+    pts: wp.array2d(dtype=wp.float32),
+    B: wp.int32,
+    num_grid_x: wp.array(dtype=wp.int32),
+    num_grid_y: wp.array(dtype=wp.int32),
+    num_grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_begin: wp.array(dtype=wp.int32),
+    cell_count: wp.array(dtype=wp.int32),
+    neighbor_offsets: wp.array2d(dtype=wp.int32),
+    task_cell: wp.array(dtype=wp.int32),
+    task_q_begin: wp.array(dtype=wp.int32),
+    task_q_count: wp.array(dtype=wp.int32),
+    radius: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+):
+    """Cell-centric self radius search using direct squared distances.
+
+    Launch this kernel with ``block_dim=MEM_OPT_2_BLOCK_DIM`` and one task for
+    each ``(occupied cell, query tile)`` pair. ``task_q_count`` must be no larger
+    than ``MEM_OPT_2_BLOCK_DIM``. Each lane owns one query while the full block
+    cooperatively loads a candidate tile into shared memory.
+
+    ``pts`` contains compacted point coordinates in ``(x, y, z, 0)`` layout. It
+    must have at least ``MEM_OPT_2_BLOCK_DIM - 1`` padded rows because full
+    candidate tiles are loaded with bounds checking disabled. The dense index
+    currently pads this array by ``TILE_P`` rows, so it satisfies that contract.
+
+    Neighbor offsets should be ordered near-to-far, with the query cell first,
+    to make the block-wide early exit useful. Output indices are compacted-point
+    indices and distances are squared, matching ``radius_search_mem_optimized``.
+    Neighbor coordinates are deliberately not written here: callers can gather
+    them from ``pts`` using ``out_idx`` after the search has completed.
+    """
+    task, lane = wp.tid()
+
+    curr_cell = task_cell[task]
+    q_begin = task_q_begin[task]
+    q_count = task_q_count[task]
+
+    # All queries in a task belong to the same dense cell, so this batch lookup
+    # and the subsequent cell-coordinate calculations are block-uniform.
+    batch = wp.int32(0)
+    while batch + 1 < B and grid_base[batch + 1] <= curr_cell:
+        batch += 1
+
+    cell_base = grid_base[batch]
+    local_cell = curr_cell - cell_base
+    grid_x = num_grid_x[batch]
+    grid_y = num_grid_y[batch]
+    grid_z = num_grid_z[batch]
+
+    cell_x = local_cell % grid_x
+    cell_y = (local_cell // grid_x) % grid_y
+    cell_z = local_cell // (grid_x * grid_y)
+
+    # One lane owns one query for the lifetime of this task. Invalid lanes in a
+    # partial final tile participate in every cooperative operation as "done".
+    query_valid = lane < q_count
+    query_index = q_begin + lane
+    query_x = wp.float32(0.0)
+    query_y = wp.float32(0.0)
+    query_z = wp.float32(0.0)
+    if query_valid:
+        query_x = pts[query_index, 0]
+        query_y = pts[query_index, 1]
+        query_z = pts[query_index, 2]
+
+    radius2 = radius * radius
+    found = wp.int32(0)
+    all_queries_done = wp.bool(False)
+
+    for neighbor in range(27):
+        if all_queries_done:
+            break
+
+        # The reduction result is identical for every lane. Consequently the
+        # break is block-uniform and no lane skips a cooperative tile operation.
+        lane_done = wp.int32(0)
+        if not query_valid or found >= max_points:
+            lane_done = wp.int32(1)
+        done_tile = wp.tile(lane_done)
+        done_count = wp.tile_sum(done_tile)
+        if done_count[0] == MEM_OPT_2_BLOCK_DIM:
+            break
+
+        neighbor_x = cell_x + neighbor_offsets[neighbor, 0]
+        neighbor_y = cell_y + neighbor_offsets[neighbor, 1]
+        neighbor_z = cell_z + neighbor_offsets[neighbor, 2]
+
+        # Cell coordinates are shared by the block, so this branch is uniform.
+        if (
+            neighbor_x < 0
+            or neighbor_x >= grid_x
+            or neighbor_y < 0
+            or neighbor_y >= grid_y
+            or neighbor_z < 0
+            or neighbor_z >= grid_z
+        ):
+            continue
+
+        neighbor_cell = (
+            cell_base
+            + neighbor_x
+            + grid_x * (neighbor_y + grid_y * neighbor_z)
+        )
+        point_begin = cell_begin[neighbor_cell]
+        point_count = cell_count[neighbor_cell]
+        num_point_tiles = (
+            point_count + MEM_OPT_2_BLOCK_DIM - 1
+        ) // MEM_OPT_2_BLOCK_DIM
+
+        for point_tile in range(num_point_tiles):
+            point_tile_begin = (
+                point_begin + point_tile * MEM_OPT_2_BLOCK_DIM
+            )
+            valid_points = wp.min(
+                MEM_OPT_2_BLOCK_DIM,
+                point_begin + point_count - point_tile_begin,
+            )
+
+            # The last coordinate is padding. Loading 32x4 floats lets Warp use
+            # vectorized float4 transactions and gives every lane fast shared
+            # access to every candidate in this tile.
+            candidate_tile = wp.tile_load(
+                pts,
+                shape=(MEM_OPT_2_BLOCK_DIM, 4),
+                offset=(point_tile_begin, 0),
+                storage="shared",
+                bounds_check=False,
+            )
+
+            # Every lane performs the shared-tile reads in the same order. Only
+            # the scalar distance and output work below is lane-divergent.
+            for candidate in range(MEM_OPT_2_BLOCK_DIM):
+                point_x = candidate_tile[candidate, 0]
+                point_y = candidate_tile[candidate, 1]
+                point_z = candidate_tile[candidate, 2]
+
+                if (
+                    query_valid
+                    and found < max_points
+                    and candidate < valid_points
+                ):
+                    point_index = point_tile_begin + candidate
+
+                    # This kernel is for self-search, so exclude the query's own
+                    # compacted point slot.
+                    if point_index != query_index:
+                        dx = point_x - query_x
+                        dy = point_y - query_y
+                        dz = point_z - query_z
+                        distance2 = dx * dx + dy * dy + dz * dz
+
+                        if distance2 <= radius2:
+                            out_idx[found, query_index] = point_index
+                            if return_dists:
+                                out_dist[found, query_index] = distance2
+                            found += 1
+
+            # A second collective vote prevents this block from loading another
+            # P tile (or visiting another neighbor cell) after every query in the
+            # current Q tile has filled its output quota.
+            lane_done = wp.int32(0)
+            if not query_valid or found >= max_points:
+                lane_done = wp.int32(1)
+            done_tile = wp.tile(lane_done)
+            done_count = wp.tile_sum(done_tile)
+            if done_count[0] == MEM_OPT_2_BLOCK_DIM:
+                all_queries_done = wp.bool(True)
+                break
+
+    if query_valid:
+        out_count[query_index] = found
+
+
+# ``radius_search_mem_optimized_3`` is intentionally a one-warp kernel. Warp
+# does not currently expose CUDA's shuffle and vote intrinsics as ordinary
+# kernel functions, so these two small native helpers provide the missing
+# operations. The CPU branches keep the module source valid when Warp emits a
+# CPU version; this search kernel is launched only on CUDA.
+@wp.func_native(
+    """
+#if defined(__CUDA_ARCH__)
+    return __shfl_sync(0xffffffffu, value, source_lane);
+#else
+    return value;
+#endif
+    """
+)
+def _warp_broadcast_f32(
+    value: wp.float32, source_lane: wp.int32
+) -> wp.float32:
+    ...
+
+
+@wp.func_native(
+    """
+#if defined(__CUDA_ARCH__)
+    return __all_sync(0xffffffffu, predicate != 0);
+#else
+    return predicate != 0;
+#endif
+    """
+)
+def _warp_all_i32(predicate: wp.int32) -> wp.int32:
+    ...
+
+
+@wp.kernel(enable_backward=False)
+def radius_search_mem_optimized_3(
+    pts: wp.array2d(dtype=wp.float32),
+    B: wp.int32,
+    num_grid_x: wp.array(dtype=wp.int32),
+    num_grid_y: wp.array(dtype=wp.int32),
+    num_grid_z: wp.array(dtype=wp.int32),
+    grid_base: wp.array(dtype=wp.int32),
+    cell_begin: wp.array(dtype=wp.int32),
+    cell_count: wp.array(dtype=wp.int32),
+    neighbor_offsets: wp.array2d(dtype=wp.int32),
+    task_cell: wp.array(dtype=wp.int32),
+    task_q_begin: wp.array(dtype=wp.int32),
+    task_q_count: wp.array(dtype=wp.int32),
+    radius: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+):
+    """Register/shuffle version of the cell-centric self radius search.
+
+    The signature and task layout match :func:`radius_search_mem_optimized_2`.
+    Launch with ``block_dim=MEM_OPT_2_BLOCK_DIM`` so one CUDA warp owns one
+    query tile and one lane owns each query.
+
+    For every candidate tile, lane ``i`` loads candidate ``i`` into scalar
+    registers. Warp shuffles then broadcast that candidate to the other lanes,
+    retaining v2's one-global-load-per-candidate reuse without a Warp tile,
+    shared-memory staging, or block synchronization. A warp-wide ``all`` vote
+    stops the task as soon as every valid query has reached ``max_points``.
+
+    Output indices are compacted-point indices and output distances are squared,
+    exactly as in v2. The caller may gather neighbor coordinates from ``pts``
+    after the search.
+    """
+    task, lane = wp.tid()
+
+    curr_cell = task_cell[task]
+    query_begin = task_q_begin[task]
+    query_count = task_q_count[task]
+
+    # All queries in this task come from one cell. The batch lookup and cell
+    # coordinate calculations are therefore uniform across the warp.
+    batch = wp.int32(0)
+    while batch + 1 < B and grid_base[batch + 1] <= curr_cell:
+        batch += 1
+
+    cell_base = grid_base[batch]
+    local_cell = curr_cell - cell_base
+    grid_x = num_grid_x[batch]
+    grid_y = num_grid_y[batch]
+    grid_z = num_grid_z[batch]
+
+    cell_x = local_cell % grid_x
+    cell_y = (local_cell // grid_x) % grid_y
+    cell_z = local_cell // (grid_x * grid_y)
+
+    # Partial query tiles still execute as a full warp. Invalid lanes carry a
+    # zero query and report themselves done in every warp-wide vote.
+    query_valid = lane < query_count
+    query_index = query_begin + lane
+    query_x = wp.float32(0.0)
+    query_y = wp.float32(0.0)
+    query_z = wp.float32(0.0)
+    if query_valid:
+        query_x = pts[query_index, 0]
+        query_y = pts[query_index, 1]
+        query_z = pts[query_index, 2]
+
+    radius2 = radius * radius
+    found = wp.int32(0)
+
+    # This initial vote handles max_points == 0 without entering the search.
+    lane_done = wp.int32(0)
+    if not query_valid or found >= max_points:
+        lane_done = wp.int32(1)
+    all_queries_done = _warp_all_i32(lane_done) != 0
+
+    for neighbor in range(27):
+        if all_queries_done:
+            break
+
+        neighbor_x = cell_x + neighbor_offsets[neighbor, 0]
+        neighbor_y = cell_y + neighbor_offsets[neighbor, 1]
+        neighbor_z = cell_z + neighbor_offsets[neighbor, 2]
+
+        # Cell bounds are block-uniform, so every lane takes the same branch and
+        # every active lane reaches the shuffle and vote intrinsics below.
+        if (
+            neighbor_x < 0
+            or neighbor_x >= grid_x
+            or neighbor_y < 0
+            or neighbor_y >= grid_y
+            or neighbor_z < 0
+            or neighbor_z >= grid_z
+        ):
+            continue
+
+        neighbor_cell = (
+            cell_base
+            + neighbor_x
+            + grid_x * (neighbor_y + grid_y * neighbor_z)
+        )
+        point_begin = cell_begin[neighbor_cell]
+        point_count = cell_count[neighbor_cell]
+        num_point_tiles = (
+            point_count + MEM_OPT_2_BLOCK_DIM - 1
+        ) // MEM_OPT_2_BLOCK_DIM
+
+        for point_tile in range(num_point_tiles):
+            point_tile_begin = (
+                point_begin + point_tile * MEM_OPT_2_BLOCK_DIM
+            )
+            valid_points = wp.min(
+                MEM_OPT_2_BLOCK_DIM,
+                point_begin + point_count - point_tile_begin,
+            )
+
+            # Each candidate is fetched once by its source lane. Initialize the
+            # registers for lanes outside a partial P tile so all 32 lanes can
+            # safely participate in every shuffle.
+            lane_point_x = wp.float32(0.0)
+            lane_point_y = wp.float32(0.0)
+            lane_point_z = wp.float32(0.0)
+            if lane < valid_points:
+                lane_point_index = point_tile_begin + lane
+                lane_point_x = pts[lane_point_index, 0]
+                lane_point_y = pts[lane_point_index, 1]
+                lane_point_z = pts[lane_point_index, 2]
+
+            # A dynamic loop keeps the candidate state small. Shuffles occur
+            # outside the query-dependent branch, which is required for a full
+            # warp mask under CUDA independent thread scheduling.
+            candidate = wp.int32(0)
+            while candidate < valid_points:
+                point_x = _warp_broadcast_f32(lane_point_x, candidate)
+                point_y = _warp_broadcast_f32(lane_point_y, candidate)
+                point_z = _warp_broadcast_f32(lane_point_z, candidate)
+
+                if query_valid and found < max_points:
+                    point_index = point_tile_begin + candidate
+
+                    # The compacted points are both queries and candidates, so
+                    # exclude the query's own compacted slot.
+                    if point_index != query_index:
+                        dx = point_x - query_x
+                        dy = point_y - query_y
+                        dz = point_z - query_z
+                        distance2 = dx * dx + dy * dy + dz * dz
+
+                        if distance2 <= radius2:
+                            out_idx[found, query_index] = point_index
+                            if return_dists:
+                                out_dist[found, query_index] = distance2
+                            found += 1
+
+                candidate += 1
+
+            # Check once per P tile: this avoids the cost of a vote for every
+            # candidate while still preventing all later P tiles and neighbor
+            # cells from being visited after the Q tile is full.
+            lane_done = wp.int32(0)
+            if not query_valid or found >= max_points:
+                lane_done = wp.int32(1)
+            if _warp_all_i32(lane_done) != 0:
+                all_queries_done = wp.bool(True)
+                break
+
+    if query_valid:
+        out_count[query_index] = found

--- a/physicsnemo/nn/functional/neighbors/radius_search/_morton_impl.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_morton_impl.py
@@ -1,0 +1,911 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Torch <-> Warp host glue for the Morton-grid radius search backend.
+
+This module builds a reusable :class:`MortonGridIndex` from a point cloud
+(Morton-sorted grid + open-addressed cell hash) and runs the three search
+variants from the design:
+
+* ``scalar`` -- :func:`radius_search_morton_scalar_hash` (Function A)
+* ``fma``    -- :func:`radius_search_morton_tiled_fma` (Function B1)
+* ``gemm``   -- :func:`radius_search_morton_tiled_gemm` (Function B2)
+
+:func:`radius_search_morton` is the single entry point used by the dispatch in
+``_warp_impl.py``. It mirrors the return contract of the ``max_points`` path of
+``radius_search_impl``: ``(indices, points, distances, num_neighbors)`` with the
+batch dimension squeezed for unbatched inputs and outputs cast back to the input
+dtype.
+
+Implementation notes:
+
+* Sorting and prefix sums are done with ``torch`` (``argsort`` / ``cumsum``)
+  rather than ``wp.utils.radix_sort_pairs`` / ``wp.utils.array_scan``. This keeps
+  the backend robust across Warp versions and matches the existing tiled-BVH
+  path, which already Morton-orders via ``torch.argsort``. The sort still
+  produces the Morton ordering the design relies on.
+* Cell lookup uses the custom open-addressed hash table built with
+  ``wp.atomic_cas`` (see ``_morton_kernels.lookup_cell``). The unique cell keys
+  are also stored sorted, so a binary search is a drop-in fallback if a build
+  lacks ``wp.atomic_cas``.
+* This backend is CUDA-only; the caller falls back to the hash-grid path on CPU.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+import warp as wp
+
+from physicsnemo.core.function_spec import FunctionSpec
+
+from . import _morton_kernels as mk
+from .utils import validate_inputs
+
+TILE_Q = mk.TILE_Q
+TILE_P = mk.TILE_P
+
+VARIANTS = ("scalar", "fma", "gemm")
+
+
+def _next_pow2(value: int) -> int:
+    """Return the smallest power of two that is ``>= value`` (and ``>= 1``)."""
+    if value <= 1:
+        return 1
+    return 1 << (value - 1).bit_length()
+
+
+def _exclusive_scan(counts: torch.Tensor) -> torch.Tensor:
+    """Exclusive prefix sum of a 1D integer tensor, returned as ``int64``."""
+    counts64 = counts.to(torch.int64)
+    return torch.cumsum(counts64, dim=0) - counts64
+
+
+def _neighbor_offsets(cell_size_factor: float, device: torch.device) -> torch.Tensor:
+    """
+    Build the near-to-far neighbor-cell offset table.
+
+    With ``cell_size = radius * cell_size_factor`` a query must look ``R =
+    ceil(1 / cell_size_factor)`` cells out along each axis, giving a
+    ``(2R + 1)^3`` neighborhood (27 cells for factor 1, 125 for factor 0.5).
+    Offsets are sorted by squared magnitude so the scalar kernel's early exit
+    favors closer cells.
+
+    Args:
+        cell_size_factor: ``cell_size / radius`` ratio.
+        device: Device for the returned tensor.
+
+    Returns:
+        An ``(K, 3)`` int32 tensor of cell offsets ordered near to far.
+    """
+    R = int(math.ceil(1.0 / cell_size_factor))
+    rng = range(-R, R + 1)
+    offs = [(dx, dy, dz) for dx in rng for dy in rng for dz in rng]
+    offs.sort(key=lambda o: o[0] * o[0] + o[1] * o[1] + o[2] * o[2])
+    return torch.tensor(offs, dtype=torch.int32, device=device)
+
+
+@dataclass
+class MortonGridIndex:
+    """
+    Reusable PC-side Morton grid + open-addressed hash index.
+
+    Holds the Morton-sorted point arrays, the per-occupied-cell ranges, the cell
+    hash table, and the grid metadata needed to quantize queries consistently.
+    Built once per :func:`radius_search_morton` call and shared by all three
+    search variants.
+
+    Attributes:
+        B: Batch size.
+        P: Points per batch.
+        Np: Total points (``B * P``).
+        cell_size: Grid cell size (``radius * cell_size_factor``).
+        radius: Search radius.
+        bits_per_axis: Morton bits per axis.
+        morton_bits: Total Morton bit width (``3 * bits_per_axis``).
+        max_coord: Maximum cell coordinate per axis (``2**bits_per_axis - 1``).
+        hash_cap: Hash table capacity (a power of two).
+        num_cells: Number of occupied cells.
+        origin: Per-batch grid origin, shape ``(B, 3)`` float32.
+        offsets: Near-to-far neighbor offsets, shape ``(K, 3)`` int32.
+        pc_xyz4: Sorted point coordinates ``(x, y, z, 0)``, padded for tiling.
+        pc_norm: Squared norm per sorted point.
+        pc_orig: Local point index per sorted point.
+        cell_key: Per-occupied-cell packed keys (sorted ascending).
+        cell_start: Per-occupied-cell start index into the sorted arrays.
+        cell_end: Per-occupied-cell end index (exclusive).
+        hash_slot: Open-addressed hash table of occupied-cell indices.
+    """
+
+    B: int
+    P: int
+    Np: int
+    cell_size: float
+    radius: float
+    bits_per_axis: int
+    morton_bits: int
+    max_coord: int
+    hash_cap: int
+    num_cells: int
+    origin: torch.Tensor
+    offsets: torch.Tensor
+    pc_xyz4: torch.Tensor
+    pc_norm: torch.Tensor
+    pc_orig: torch.Tensor
+    cell_key: torch.Tensor
+    cell_start: torch.Tensor
+    cell_end: torch.Tensor
+    hash_slot: torch.Tensor
+
+
+def build_morton_pc_index(
+    points: torch.Tensor,
+    radius: float,
+    cell_size_factor: float,
+    wp_device,
+    wp_stream,
+) -> MortonGridIndex:
+    """
+    Build the reusable Morton grid index for a point cloud.
+
+    Quantizes points to a uniform grid (per-batch origin padded one cell below
+    the bounding box so query cells stay non-negative), Morton-sorts them, builds
+    contiguous per-occupied-cell ranges, and inserts the cells into the
+    open-addressed hash table.
+
+    Args:
+        points: Reference points of shape ``(B, N, 3)``, float32, CUDA.
+        radius: Search radius.
+        cell_size_factor: ``cell_size / radius`` ratio (1.0 -> 27-cell stencil).
+        wp_device: Warp launch device (from ``warp_launch_context``).
+        wp_stream: Warp launch stream (from ``warp_launch_context``).
+
+    Returns:
+        The populated :class:`MortonGridIndex`.
+
+    Raises:
+        ValueError: If the grid extent plus batch bits exceed the positive
+            ``int64`` key range (suggesting a larger ``radius`` / cell size or
+            per-batch processing).
+    """
+    device = points.device
+    B, N, _ = points.shape
+    P = N
+    Np = B * N
+
+    # Inflate the grid cell slightly relative to the nominal radius*factor. The
+    # neighbor stencil is R = ceil(1/cell_size_factor) cells; for correctness a
+    # neighbor within `radius` must land within R cells, i.e. radius/cell_size
+    # must stay <= R. With cell_size == radius (factor 1) floating-point in the
+    # floor() quantization makes radius*inv_cell ~1.0000001 > 1.0, so a boundary
+    # neighbor can fall 2 cells away and be missed. A ~0.1% larger cell keeps
+    # radius/cell_size strictly below R with margin >> fp epsilon.
+    cell_size = float(radius) * float(cell_size_factor) * (1.0 + 1e-3)
+    inv_cell = 1.0 / cell_size
+
+    pmin = points.amin(dim=1)
+    pmax = points.amax(dim=1)
+    origin = (pmin - cell_size).contiguous()
+    extent = pmax - origin + cell_size
+    n_cells = int(torch.ceil(extent / cell_size).max().item())
+    n_cells = max(n_cells, 1)
+    bits_per_axis = max(1, n_cells.bit_length())
+    batch_bits = 0 if B <= 1 else (B - 1).bit_length()
+    morton_bits = 3 * bits_per_axis
+    if morton_bits + batch_bits > 63:
+        raise ValueError(
+            "Morton key would overflow int64: "
+            f"{morton_bits} morton bits + {batch_bits} batch bits > 63. "
+            "Use a larger radius/cell_size or process fewer batches per call."
+        )
+    max_coord = (1 << bits_per_axis) - 1
+
+    points_wp = wp.from_torch(points, dtype=wp.vec3, return_ctype=True)
+    origin_wp = wp.from_torch(origin, dtype=wp.vec3, return_ctype=True)
+
+    keys = torch.empty(Np, dtype=torch.int64, device=device)
+    wp.launch(
+        kernel=mk.make_keys_kernel,
+        dim=Np,
+        inputs=[
+            points_wp,
+            origin_wp,
+            float(inv_cell),
+            int(bits_per_axis),
+            int(morton_bits),
+            int(max_coord),
+            int(P),
+            wp.from_torch(keys, return_ctype=True),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    # Stability is not required: we only group points by equal cell key, so any
+    # ordering within a cell is fine. The non-stable sort is faster on CUDA.
+    perm = torch.argsort(keys)
+    keys_sorted = keys[perm]
+    perm32 = perm.to(torch.int32).contiguous()
+
+    n_pad = Np + TILE_P
+    pc_xyz4 = torch.zeros((n_pad, 4), dtype=torch.float32, device=device)
+    pc_norm = torch.zeros(n_pad, dtype=torch.float32, device=device)
+    pc_orig = torch.zeros(n_pad, dtype=torch.int32, device=device)
+    wp.launch(
+        kernel=mk.gather_pc_kernel,
+        dim=Np,
+        inputs=[
+            points_wp,
+            wp.from_torch(perm32, return_ctype=True),
+            int(P),
+            wp.from_torch(pc_orig, return_ctype=True),
+            wp.from_torch(pc_xyz4, return_ctype=True),
+            wp.from_torch(pc_norm, return_ctype=True),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    # Unique occupied-cell ranges over the Morton-sorted keys (torch-side; the
+    # resulting cell_key array is ascending, which also enables a binary-search
+    # fallback for cell lookup).
+    flags = torch.ones(Np, dtype=torch.bool, device=device)
+    flags[1:] = keys_sorted[1:] != keys_sorted[:-1]
+    starts = torch.nonzero(flags, as_tuple=False).flatten()
+    num_cells = int(starts.numel())
+    cell_key = keys_sorted[starts].contiguous()
+    cell_start = starts.to(torch.int32).contiguous()
+    ends = torch.empty_like(starts)
+    if num_cells > 1:
+        ends[:-1] = starts[1:]
+    ends[-1] = Np
+    cell_end = ends.to(torch.int32).contiguous()
+
+    hash_cap = _next_pow2(max(8, 4 * num_cells))
+    hash_slot = torch.full((hash_cap,), -1, dtype=torch.int32, device=device)
+    wp.launch(
+        kernel=mk.build_cell_hash_kernel,
+        dim=num_cells,
+        inputs=[
+            wp.from_torch(cell_key, return_ctype=True),
+            int(hash_cap),
+            wp.from_torch(hash_slot, return_ctype=True),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    return MortonGridIndex(
+        B=B,
+        P=P,
+        Np=Np,
+        cell_size=cell_size,
+        radius=float(radius),
+        bits_per_axis=int(bits_per_axis),
+        morton_bits=int(morton_bits),
+        max_coord=int(max_coord),
+        hash_cap=int(hash_cap),
+        num_cells=num_cells,
+        origin=origin,
+        offsets=_neighbor_offsets(cell_size_factor, device),
+        pc_xyz4=pc_xyz4,
+        pc_norm=pc_norm,
+        pc_orig=pc_orig,
+        cell_key=cell_key,
+        cell_start=cell_start,
+        cell_end=cell_end,
+        hash_slot=hash_slot,
+    )
+
+
+def _prepare_queries(
+    index: MortonGridIndex,
+    queries: torch.Tensor,
+    wp_device,
+    wp_stream,
+) -> dict:
+    """
+    Morton-sort the queries and gather their sorted arrays + cell coordinates.
+
+    Uses the index's shared ``origin`` / ``cell_size`` so query cells align with
+    the PC grid. Returns a dict of device tensors consumed by the search and
+    task-building helpers.
+
+    Args:
+        index: The PC-side Morton index.
+        queries: Query points of shape ``(B, Q, 3)``, float32, CUDA.
+        wp_device: Warp launch device.
+        wp_stream: Warp launch stream.
+
+    Returns:
+        Dict with sorted query arrays, per-query cell coordinates, and shapes.
+    """
+    device = queries.device
+    B, Q, _ = queries.shape
+    Bq = B * Q
+    inv_cell = 1.0 / index.cell_size
+
+    queries_wp = wp.from_torch(queries, dtype=wp.vec3, return_ctype=True)
+    origin_wp = wp.from_torch(index.origin, dtype=wp.vec3, return_ctype=True)
+
+    qkeys = torch.empty(Bq, dtype=torch.int64, device=device)
+    wp.launch(
+        kernel=mk.make_keys_kernel,
+        dim=Bq,
+        inputs=[
+            queries_wp,
+            origin_wp,
+            float(inv_cell),
+            int(index.bits_per_axis),
+            int(index.morton_bits),
+            int(index.max_coord),
+            int(Q),
+            wp.from_torch(qkeys, return_ctype=True),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    perm = torch.argsort(qkeys)
+    qkeys_sorted = qkeys[perm]
+    perm32 = perm.to(torch.int32).contiguous()
+
+    bq_pad = Bq + TILE_Q
+    qp_xyz4 = torch.zeros((bq_pad, 4), dtype=torch.float32, device=device)
+    qp_norm = torch.zeros(bq_pad, dtype=torch.float32, device=device)
+    q_orig = torch.zeros(bq_pad, dtype=torch.int32, device=device)
+    qcell_b = torch.zeros(bq_pad, dtype=torch.int32, device=device)
+    qcell_cx = torch.zeros(bq_pad, dtype=torch.int32, device=device)
+    qcell_cy = torch.zeros(bq_pad, dtype=torch.int32, device=device)
+    qcell_cz = torch.zeros(bq_pad, dtype=torch.int32, device=device)
+    wp.launch(
+        kernel=mk.gather_q_kernel,
+        dim=Bq,
+        inputs=[
+            queries_wp,
+            wp.from_torch(perm32, return_ctype=True),
+            int(Q),
+            origin_wp,
+            float(inv_cell),
+            int(index.max_coord),
+            wp.from_torch(q_orig, return_ctype=True),
+            wp.from_torch(qp_xyz4, return_ctype=True),
+            wp.from_torch(qp_norm, return_ctype=True),
+            wp.from_torch(qcell_b, return_ctype=True),
+            wp.from_torch(qcell_cx, return_ctype=True),
+            wp.from_torch(qcell_cy, return_ctype=True),
+            wp.from_torch(qcell_cz, return_ctype=True),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    return {
+        "B": B,
+        "Q": Q,
+        "Bq": Bq,
+        "qkeys_sorted": qkeys_sorted,
+        "qp_xyz4": qp_xyz4,
+        "qp_norm": qp_norm,
+        "q_orig": q_orig,
+        "qcell_b": qcell_b,
+        "qcell_cx": qcell_cx,
+        "qcell_cy": qcell_cy,
+        "qcell_cz": qcell_cz,
+    }
+
+
+def _build_tiles_and_tasks(
+    index: MortonGridIndex,
+    qprep: dict,
+    wp_device,
+    wp_stream,
+) -> dict:
+    """
+    Build the query tiles and the ``(query-tile, point-chunk)`` task list.
+
+    Splits each occupied query cell into ``TILE_Q`` chunks, then runs the
+    two-pass (count -> exclusive scan -> fill) task generation so the tiled
+    kernels can map one block per task.
+
+    Args:
+        index: The PC-side Morton index.
+        qprep: The dict returned by :func:`_prepare_queries`.
+        wp_device: Warp launch device.
+        wp_stream: Warp launch stream.
+
+    Returns:
+        Dict with the task arrays and ``num_tasks``.
+    """
+    device = index.pc_xyz4.device
+    Bq = qprep["Bq"]
+    qkeys_sorted = qprep["qkeys_sorted"]
+
+    # Occupied query-cell ranges (mirrors the PC-side construction).
+    flags = torch.ones(Bq, dtype=torch.bool, device=device)
+    flags[1:] = qkeys_sorted[1:] != qkeys_sorted[:-1]
+    qstarts = torch.nonzero(flags, as_tuple=False).flatten()
+    num_qcells = int(qstarts.numel())
+    qends = torch.empty_like(qstarts)
+    if num_qcells > 1:
+        qends[:-1] = qstarts[1:]
+    qends[-1] = Bq
+    qcell_len = qends - qstarts
+
+    tiles_per_cell = (qcell_len + TILE_Q - 1) // TILE_Q
+    num_qtiles = int(tiles_per_cell.sum().item())
+    tile_off = _exclusive_scan(tiles_per_cell)
+
+    cell_of_tile = torch.repeat_interleave(
+        torch.arange(num_qcells, device=device), tiles_per_cell
+    )
+    local_tile = torch.arange(num_qtiles, device=device) - tile_off[cell_of_tile]
+    tile_begin = qstarts[cell_of_tile] + local_tile * TILE_Q
+    q_tile_begin = tile_begin.to(torch.int32).contiguous()
+    q_tile_count = (
+        torch.clamp(qends[cell_of_tile] - tile_begin, max=TILE_Q)
+        .to(torch.int32)
+        .contiguous()
+    )
+
+    # Per-tile base cell coordinates (taken at each cell's first sorted query).
+    cell_starts_long = qstarts
+    q_tile_b = qprep["qcell_b"][cell_starts_long][cell_of_tile].to(torch.int32).contiguous()
+    q_tile_cx = qprep["qcell_cx"][cell_starts_long][cell_of_tile].to(torch.int32).contiguous()
+    q_tile_cy = qprep["qcell_cy"][cell_starts_long][cell_of_tile].to(torch.int32).contiguous()
+    q_tile_cz = qprep["qcell_cz"][cell_starts_long][cell_of_tile].to(torch.int32).contiguous()
+
+    offsets_wp = wp.from_torch(index.offsets, dtype=wp.int32, return_ctype=True)
+    K = int(index.offsets.shape[0])
+
+    task_count = torch.empty(num_qtiles, dtype=torch.int32, device=device)
+    wp.launch(
+        kernel=mk.count_tasks_kernel,
+        dim=num_qtiles,
+        inputs=[
+            wp.from_torch(q_tile_b, return_ctype=True),
+            wp.from_torch(q_tile_cx, return_ctype=True),
+            wp.from_torch(q_tile_cy, return_ctype=True),
+            wp.from_torch(q_tile_cz, return_ctype=True),
+            offsets_wp,
+            K,
+            int(index.max_coord),
+            int(index.bits_per_axis),
+            int(index.morton_bits),
+            wp.from_torch(index.cell_key, return_ctype=True),
+            wp.from_torch(index.cell_start, return_ctype=True),
+            wp.from_torch(index.cell_end, return_ctype=True),
+            wp.from_torch(index.hash_slot, return_ctype=True),
+            int(index.hash_cap),
+            int(TILE_P),
+            wp.from_torch(task_count, return_ctype=True),
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    task_offset = _exclusive_scan(task_count).to(torch.int32).contiguous()
+    num_tasks = int(task_count.sum().item())
+
+    task_q_begin = torch.empty(max(num_tasks, 1), dtype=torch.int32, device=device)
+    task_q_count = torch.empty(max(num_tasks, 1), dtype=torch.int32, device=device)
+    task_p_begin = torch.empty(max(num_tasks, 1), dtype=torch.int32, device=device)
+    task_p_count = torch.empty(max(num_tasks, 1), dtype=torch.int32, device=device)
+
+    if num_tasks > 0:
+        wp.launch(
+            kernel=mk.fill_tasks_kernel,
+            dim=num_qtiles,
+            inputs=[
+                wp.from_torch(q_tile_begin, return_ctype=True),
+                wp.from_torch(q_tile_count, return_ctype=True),
+                wp.from_torch(q_tile_b, return_ctype=True),
+                wp.from_torch(q_tile_cx, return_ctype=True),
+                wp.from_torch(q_tile_cy, return_ctype=True),
+                wp.from_torch(q_tile_cz, return_ctype=True),
+                wp.from_torch(task_offset, return_ctype=True),
+                offsets_wp,
+                K,
+                int(index.max_coord),
+                int(index.bits_per_axis),
+                int(index.morton_bits),
+                wp.from_torch(index.cell_key, return_ctype=True),
+                wp.from_torch(index.cell_start, return_ctype=True),
+                wp.from_torch(index.cell_end, return_ctype=True),
+                wp.from_torch(index.hash_slot, return_ctype=True),
+                int(index.hash_cap),
+                int(TILE_P),
+                wp.from_torch(task_q_begin, return_ctype=True),
+                wp.from_torch(task_q_count, return_ctype=True),
+                wp.from_torch(task_p_begin, return_ctype=True),
+                wp.from_torch(task_p_count, return_ctype=True),
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+
+    return {
+        "num_tasks": num_tasks,
+        "task_q_begin": task_q_begin,
+        "task_q_count": task_q_count,
+        "task_p_begin": task_p_begin,
+        "task_p_count": task_p_count,
+    }
+
+
+def _alloc_outputs(
+    B: int,
+    Q: int,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    device: torch.device,
+):
+    """Allocate the output tensors for a search (indices/counts always; optional)."""
+    out_idx = torch.zeros((B, Q, max_points), dtype=torch.int32, device=device)
+    out_count = torch.zeros(B * Q, dtype=torch.int32, device=device)
+    out_dist = (
+        torch.zeros((B, Q, max_points), dtype=torch.float32, device=device)
+        if return_dists
+        else None
+    )
+    out_pts = (
+        torch.zeros((B, Q, max_points, 3), dtype=torch.float32, device=device)
+        if return_points
+        else None
+    )
+    return out_idx, out_count, out_dist, out_pts
+
+
+def _wp_out(out_idx, out_count, out_dist, out_pts, Bq, max_points, return_dists, return_points):
+    """Build the Warp ctype views of the (flattened) output tensors."""
+    idx_wp = wp.from_torch(out_idx.view(Bq, max_points), return_ctype=True)
+    count_wp = wp.from_torch(out_count, return_ctype=True)
+    dist_wp = (
+        wp.from_torch(out_dist.view(Bq, max_points), return_ctype=True)
+        if return_dists
+        else None
+    )
+    pts_wp = (
+        wp.from_torch(out_pts.view(Bq, max_points, 3), dtype=wp.vec3, return_ctype=True)
+        if return_points
+        else None
+    )
+    return idx_wp, count_wp, dist_wp, pts_wp
+
+
+def radius_search_morton_scalar_hash(
+    index: MortonGridIndex,
+    qprep: dict,
+    radius: float,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    wp_device,
+    wp_stream,
+):
+    """
+    Function A: scalar-hash search (one thread per query).
+
+    Args:
+        index: The PC-side Morton index.
+        qprep: The dict returned by :func:`_prepare_queries`.
+        radius: Search radius.
+        max_points: Maximum neighbors per query.
+        return_dists: Whether to return distances.
+        return_points: Whether to return neighbor coordinates.
+        wp_device: Warp launch device.
+        wp_stream: Warp launch stream.
+
+    Returns:
+        Tuple ``(indices, points, distances, num_neighbors)`` with batch dim
+        intact (``(B, Q, ...)``); ``points``/``distances`` are ``None`` when not
+        requested.
+    """
+    B, Q, Bq = qprep["B"], qprep["Q"], qprep["Bq"]
+    device = index.pc_xyz4.device
+    out_idx, out_count, out_dist, out_pts = _alloc_outputs(
+        B, Q, max_points, return_dists, return_points, device
+    )
+    idx_wp, count_wp, dist_wp, pts_wp = _wp_out(
+        out_idx, out_count, out_dist, out_pts, Bq, max_points, return_dists, return_points
+    )
+
+    wp.launch(
+        kernel=mk.scalar_search_kernel,
+        dim=Bq,
+        inputs=[
+            wp.from_torch(qprep["qp_xyz4"], return_ctype=True),
+            wp.from_torch(qprep["q_orig"], return_ctype=True),
+            wp.from_torch(qprep["qcell_b"], return_ctype=True),
+            wp.from_torch(qprep["qcell_cx"], return_ctype=True),
+            wp.from_torch(qprep["qcell_cy"], return_ctype=True),
+            wp.from_torch(qprep["qcell_cz"], return_ctype=True),
+            wp.from_torch(index.offsets, dtype=wp.int32, return_ctype=True),
+            int(index.offsets.shape[0]),
+            int(index.max_coord),
+            int(index.bits_per_axis),
+            int(index.morton_bits),
+            wp.from_torch(index.cell_key, return_ctype=True),
+            wp.from_torch(index.cell_start, return_ctype=True),
+            wp.from_torch(index.cell_end, return_ctype=True),
+            wp.from_torch(index.hash_slot, return_ctype=True),
+            int(index.hash_cap),
+            wp.from_torch(index.pc_xyz4, return_ctype=True),
+            wp.from_torch(index.pc_orig, return_ctype=True),
+            float(radius) * float(radius),
+            int(max_points),
+            bool(return_dists),
+            bool(return_points),
+            idx_wp,
+            count_wp,
+            dist_wp,
+            pts_wp,
+        ],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    num = out_count.view(B, Q)
+    return out_idx, out_pts, out_dist, num
+
+
+def _run_tiled(
+    index: MortonGridIndex,
+    qprep: dict,
+    tasks: dict,
+    variant: str,
+    radius: float,
+    max_points: int,
+    return_dists: bool,
+    return_points: bool,
+    wp_device,
+    wp_stream,
+):
+    """
+    Shared launcher for the tiled FMA (B1) and GEMM (B2) variants.
+
+    Both consume the same task list and write via an atomic per-query slot
+    counter that can overshoot ``max_points``; the count is clamped afterward.
+
+    Args:
+        index: The PC-side Morton index.
+        qprep: The dict returned by :func:`_prepare_queries`.
+        tasks: The dict returned by :func:`_build_tiles_and_tasks`.
+        variant: Either ``"fma"`` or ``"gemm"``.
+        radius: Search radius.
+        max_points: Maximum neighbors per query.
+        return_dists: Whether to return distances.
+        return_points: Whether to return neighbor coordinates.
+        wp_device: Warp launch device.
+        wp_stream: Warp launch stream.
+
+    Returns:
+        Tuple ``(indices, points, distances, num_neighbors)`` with batch dim
+        intact; ``points``/``distances`` are ``None`` when not requested.
+    """
+    B, Q, Bq = qprep["B"], qprep["Q"], qprep["Bq"]
+    device = index.pc_xyz4.device
+    out_idx, out_count, out_dist, out_pts = _alloc_outputs(
+        B, Q, max_points, return_dists, return_points, device
+    )
+    idx_wp, count_wp, dist_wp, pts_wp = _wp_out(
+        out_idx, out_count, out_dist, out_pts, Bq, max_points, return_dists, return_points
+    )
+
+    num_tasks = tasks["num_tasks"]
+    if num_tasks > 0:
+        radius2 = float(radius) * float(radius)
+        task_handles = [
+            wp.from_torch(tasks["task_q_begin"], return_ctype=True),
+            wp.from_torch(tasks["task_q_count"], return_ctype=True),
+            wp.from_torch(tasks["task_p_begin"], return_ctype=True),
+            wp.from_torch(tasks["task_p_count"], return_ctype=True),
+        ]
+        if variant == "fma":
+            # Regular 2D launch: dim=(task, lane); one lane per candidate point.
+            wp.launch(
+                kernel=mk.tiled_fma_kernel,
+                dim=(num_tasks, TILE_P),
+                inputs=task_handles
+                + [
+                    wp.from_torch(qprep["qp_xyz4"], return_ctype=True),
+                    wp.from_torch(qprep["q_orig"], return_ctype=True),
+                    wp.from_torch(index.pc_xyz4, return_ctype=True),
+                    wp.from_torch(index.pc_orig, return_ctype=True),
+                    radius2,
+                    int(max_points),
+                    bool(return_dists),
+                    bool(return_points),
+                    idx_wp,
+                    count_wp,
+                    dist_wp,
+                    pts_wp,
+                ],
+                device=wp_device,
+                stream=wp_stream,
+            )
+        else:  # gemm
+            lane_iota = torch.arange(TILE_P, dtype=torch.int32, device=device)
+            wp.launch_tiled(
+                kernel=mk.tiled_gemm_kernel,
+                dim=num_tasks,
+                inputs=task_handles
+                + [
+                    wp.from_torch(lane_iota, return_ctype=True),
+                    wp.from_torch(qprep["qp_xyz4"], return_ctype=True),
+                    wp.from_torch(qprep["qp_norm"], return_ctype=True),
+                    wp.from_torch(qprep["q_orig"], return_ctype=True),
+                    wp.from_torch(index.pc_xyz4, return_ctype=True),
+                    wp.from_torch(index.pc_norm, return_ctype=True),
+                    wp.from_torch(index.pc_orig, return_ctype=True),
+                    radius2,
+                    int(max_points),
+                    bool(return_dists),
+                    bool(return_points),
+                    idx_wp,
+                    count_wp,
+                    dist_wp,
+                    pts_wp,
+                ],
+                block_dim=TILE_P,
+                device=wp_device,
+                stream=wp_stream,
+            )
+
+    num = out_count.clamp(max=max_points).view(B, Q)
+    return out_idx, out_pts, out_dist, num
+
+
+def radius_search_morton_tiled_fma(index, qprep, tasks, radius, max_points, return_dists, return_points, wp_device, wp_stream):
+    """Function B1: tiled direct-FMA search (see :func:`_run_tiled`)."""
+    return _run_tiled(
+        index, qprep, tasks, "fma", radius, max_points, return_dists, return_points, wp_device, wp_stream
+    )
+
+
+def radius_search_morton_tiled_gemm(index, qprep, tasks, radius, max_points, return_dists, return_points, wp_device, wp_stream):
+    """Function B2: tiled GEMM search (see :func:`_run_tiled`)."""
+    return _run_tiled(
+        index, qprep, tasks, "gemm", radius, max_points, return_dists, return_points, wp_device, wp_stream
+    )
+
+
+def _empty_outputs(B, Q, max_points, return_dists, return_points, was_unbatched, dtype, device):
+    """Build a zero/empty 4-tuple matching the op contract (used for empty inputs)."""
+    indices = torch.zeros((B, Q, max_points), dtype=torch.int32, device=device)
+    num = torch.zeros((B, Q), dtype=torch.int32, device=device)
+    pts = (
+        torch.zeros((B, Q, max_points, 3), dtype=dtype, device=device)
+        if return_points
+        else torch.empty((0, max_points, 3), dtype=dtype, device=device)
+    )
+    dist = (
+        torch.zeros((B, Q, max_points), dtype=dtype, device=device)
+        if return_dists
+        else torch.empty(0, dtype=dtype, device=device)
+    )
+    if was_unbatched:
+        indices = indices.squeeze(0)
+        num = num.squeeze(0)
+        if return_points:
+            pts = pts.squeeze(0)
+        if return_dists:
+            dist = dist.squeeze(0)
+    return indices, pts, dist, num
+
+
+def radius_search_morton(
+    points: torch.Tensor,
+    queries: torch.Tensor,
+    radius: float,
+    max_points: int,
+    return_dists: bool = False,
+    return_points: bool = False,
+    variant: str | None = "scalar",
+    cell_size_factor: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Morton-grid radius search entry point (CUDA-only, ``max_points`` path).
+
+    Builds the reusable :class:`MortonGridIndex` from ``points``, prepares the
+    queries, and dispatches to the requested ``variant``. Returns the same
+    4-tuple contract as the ``max_points`` path of ``radius_search_impl`` so the
+    custom op's registered autograd/fake paths are unaffected.
+
+    Args:
+        points: Reference points, ``(N, 3)`` or ``(B, N, 3)``.
+        queries: Query points, ``(M, 3)`` or ``(B, M, 3)``.
+        radius: Search radius.
+        max_points: Maximum neighbors per query (must not be ``None``).
+        return_dists: Whether to return neighbor distances.
+        return_points: Whether to return neighbor coordinates.
+        variant: One of ``"scalar"`` (A), ``"fma"`` (B1), ``"gemm"`` (B2).
+            ``None`` defaults to ``"scalar"``.
+        cell_size_factor: ``cell_size / radius`` (1.0 -> 27-cell stencil; use
+            0.5 for a denser 125-cell stencil).
+
+    Returns:
+        ``(indices, points, distances, num_neighbors)`` mirroring
+        ``radius_search_impl``.
+
+    Raises:
+        ValueError: If ``max_points`` is ``None``, inputs are not CUDA, or
+            ``variant`` is unknown.
+    """
+    if max_points is None:
+        raise ValueError("radius_search_morton requires max_points to be set (not None)")
+    if points.device != queries.device:
+        raise ValueError("points and queries must be on the same device")
+    if points.device.type != "cuda":
+        raise ValueError("radius_search_morton requires CUDA tensors")
+
+    variant = variant or "scalar"
+    if variant not in VARIANTS:
+        raise ValueError(f"unknown morton variant '{variant}'; expected one of {VARIANTS}")
+
+    points, queries, was_unbatched = validate_inputs(points, queries)
+    input_dtype = points.dtype
+
+    if points.dtype != torch.float32:
+        points = points.to(torch.float32)
+    if queries.dtype != torch.float32:
+        queries = queries.to(torch.float32)
+    points = points.contiguous()
+    queries = queries.contiguous()
+
+    B, N, _ = points.shape
+    Q = queries.shape[1]
+
+    if N == 0 or Q == 0:
+        return _empty_outputs(
+            B, Q, max_points, return_dists, return_points, was_unbatched, input_dtype, points.device
+        )
+
+    wp_device, wp_stream = FunctionSpec.warp_launch_context(points)
+
+    with wp.ScopedStream(wp_stream):
+        index = build_morton_pc_index(points, radius, cell_size_factor, wp_device, wp_stream)
+        qprep = _prepare_queries(index, queries, wp_device, wp_stream)
+        if variant == "scalar":
+            indices, pts, dist, num = radius_search_morton_scalar_hash(
+                index, qprep, radius, max_points, return_dists, return_points, wp_device, wp_stream
+            )
+        else:
+            tasks = _build_tiles_and_tasks(index, qprep, wp_device, wp_stream)
+            indices, pts, dist, num = _run_tiled(
+                index, qprep, tasks, variant, radius, max_points, return_dists, return_points, wp_device, wp_stream
+            )
+
+    if pts is None:
+        pts = torch.empty((0, max_points, 3), dtype=torch.float32, device=points.device)
+    if dist is None:
+        dist = torch.empty(0, dtype=torch.float32, device=points.device)
+
+    if was_unbatched:
+        indices = indices.squeeze(0)
+        num = num.squeeze(0)
+        if return_points:
+            pts = pts.squeeze(0)
+        if return_dists:
+            dist = dist.squeeze(0)
+
+    pts = pts.to(input_dtype)
+    dist = dist.to(input_dtype)
+    return indices, pts, dist, num

--- a/physicsnemo/nn/functional/neighbors/radius_search/_morton_kernels.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_morton_kernels.py
@@ -1,0 +1,832 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Warp kernels for the Morton-grid radius search backend.
+
+This module is pure Warp code (no PyTorch). It implements the building blocks
+for the Morton-sorted spatial grid + custom open-addressed hash design:
+
+* ``@wp.func`` helpers: variable-width 3D Morton encode, batch/cell key packing,
+  a 64-bit mix hash, and the open-addressed ``lookup_cell`` probe.
+* PC-index build kernels: key generation, sorted-array gather, and hash build.
+* Query-side gather and the tiled-task generation kernels.
+* The three search kernels: scalar-hash (A), tiled-FMA (B1), tiled-GEMM (B2).
+
+The host glue that drives these kernels lives in ``_morton_impl.py``. Cell
+lookup uses a custom open-addressed hash table (built with ``wp.atomic_cas``);
+the unique cell keys are also stored sorted, so a binary search over
+``cell_key`` is a drop-in alternative for :func:`lookup_cell` if a build lacks
+``wp.atomic_cas``.
+"""
+
+import warp as wp
+
+# Tile sizes for the tiled (B1/B2) kernels. These are module-level Python ints
+# so they are captured as compile-time constants in the Warp kernels (tile
+# shapes must be known at code-generation time) while remaining usable directly
+# in the host launch code. ``TILE_P`` doubles as ``block_dim`` for the GEMM
+# tiled launch (one lane per candidate point) and as the point-chunk width for
+# the FMA launch; ``TILE_Q`` is the query-tile width.
+#
+# ``TILE_P`` must equal Warp's tile block width (default 256) so that
+# ``wp.untile`` in the GEMM kernel sees a last tile dimension matching the block
+# width when the module is code-generated. Using 256 keeps module compilation
+# (default block dim) and the ``launch_tiled(block_dim=TILE_P)`` launch in sync.
+TILE_Q = 8
+TILE_P = 256
+
+
+# ---------------------------------------------------------------------------
+# Device helper functions
+# ---------------------------------------------------------------------------
+
+
+@wp.func
+def morton_encode(x: wp.int32, y: wp.int32, z: wp.int32, bits: wp.int32) -> wp.int64:
+    """
+    Interleave the low ``bits`` of three non-negative integer coordinates into a
+    3D Morton (Z-order) code.
+
+    A loop-based interleave is used (instead of fixed "magic-bits" masks) so the
+    same function supports any ``bits`` per axis up to 21, letting the host pick
+    the minimum width that covers the data extent (and leaves room for the batch
+    id in the high bits of an ``int64`` key).
+
+    Args:
+        x: Non-negative cell coordinate along x.
+        y: Non-negative cell coordinate along y.
+        z: Non-negative cell coordinate along z.
+        bits: Number of low bits to interleave per axis.
+
+    Returns:
+        The interleaved Morton code as a non-negative ``int64``.
+    """
+    m = wp.int64(0)
+    for i in range(bits):
+        bx = wp.int64((x >> i) & 1)
+        by = wp.int64((y >> i) & 1)
+        bz = wp.int64((z >> i) & 1)
+        shift = wp.int64(3 * i)
+        m = m | (bx << shift) | (by << (shift + wp.int64(1))) | (bz << (shift + wp.int64(2)))
+    return m
+
+
+@wp.func
+def pack_key(
+    b: wp.int32,
+    cx: wp.int32,
+    cy: wp.int32,
+    cz: wp.int32,
+    bits: wp.int32,
+    morton_bits: wp.int32,
+) -> wp.int64:
+    """
+    Pack a batch id and integer cell coordinates into a single ``int64`` key.
+
+    The Morton code occupies the low ``morton_bits`` bits and the batch id is
+    shifted above it. The host guarantees ``morton_bits + ceil(log2(B))`` stays
+    within the positive ``int64`` range.
+
+    Args:
+        b: Batch index.
+        cx: Non-negative cell coordinate along x.
+        cy: Non-negative cell coordinate along y.
+        cz: Non-negative cell coordinate along z.
+        bits: Number of bits per axis used by the Morton encode.
+        morton_bits: Total Morton-code bit width (``3 * bits``).
+
+    Returns:
+        The packed ``int64`` cell key.
+    """
+    m = morton_encode(cx, cy, cz, bits)
+    return (wp.int64(b) << wp.int64(morton_bits)) | m
+
+
+@wp.func
+def hash64(x: wp.uint64) -> wp.uint64:
+    """
+    64-bit integer finalizer mix (the MurmurHash3 ``fmix64`` constants).
+
+    Args:
+        x: Input key bits.
+
+    Returns:
+        A well-mixed 64-bit hash of ``x``.
+    """
+    x = x ^ (x >> wp.uint64(33))
+    x = x * wp.uint64(0xFF51AFD7ED558CCD)
+    x = x ^ (x >> wp.uint64(33))
+    x = x * wp.uint64(0xC4CEB9FE1A85EC53)
+    x = x ^ (x >> wp.uint64(33))
+    return x
+
+
+@wp.func
+def lookup_cell(
+    key: wp.int64,
+    hash_slot: wp.array(dtype=wp.int32),
+    cell_key: wp.array(dtype=wp.int64),
+    hash_cap: wp.int32,
+) -> wp.int32:
+    """
+    Look up the occupied-cell slot for a packed cell ``key``.
+
+    Linear-probes the open-addressed hash table. ``hash_slot`` stores occupied
+    cell indices (or ``-1`` for empty), and the full key is verified against
+    ``cell_key``. No atomics are used during lookup.
+
+    Args:
+        key: Packed ``int64`` cell key (see :func:`pack_key`).
+        hash_slot: Hash table storing occupied-cell indices, ``-1`` if empty.
+        cell_key: Per-occupied-cell full keys, indexed by the value in ``hash_slot``.
+        hash_cap: Hash table capacity (a power of two).
+
+    Returns:
+        The occupied-cell slot index, or ``-1`` if the cell is empty/absent.
+    """
+    mask = hash_cap - 1
+    h = wp.int32(hash64(wp.uint64(key)) & wp.uint64(mask))
+    probe = wp.int32(0)
+    while probe < hash_cap:
+        c = hash_slot[h]
+        if c == -1:
+            return -1
+        if cell_key[c] == key:
+            return c
+        h = (h + 1) & mask
+        probe += 1
+    return -1
+
+
+# ---------------------------------------------------------------------------
+# PC-index / query build kernels
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def make_keys_kernel(
+    coords: wp.array2d(dtype=wp.vec3),
+    origin: wp.array(dtype=wp.vec3),
+    inv_cell: wp.float32,
+    bits: wp.int32,
+    morton_bits: wp.int32,
+    max_coord: wp.int32,
+    M: wp.int32,
+    keys: wp.array(dtype=wp.int64),
+):
+    """
+    Compute a packed batch+Morton cell key for every point/query.
+
+    Launched flat over ``B * M`` elements; the batch index is recovered as
+    ``tid // M``. Cell coordinates are quantized with a shared per-batch
+    ``origin`` and ``inv_cell = 1 / cell_size`` and clamped into
+    ``[0, max_coord]``.
+
+    Args:
+        coords: Coordinates of shape ``(B, M)`` (Warp ``vec3`` array).
+        origin: Per-batch grid origin (lower corner), shape ``(B,)``.
+        inv_cell: Reciprocal of the cell size.
+        bits: Number of Morton bits per axis.
+        morton_bits: Total Morton bit width (``3 * bits``).
+        max_coord: Maximum cell coordinate per axis (``2**bits - 1``).
+        M: Number of elements per batch (points or queries).
+        keys: Output packed keys of shape ``(B * M,)``.
+    """
+    tid = wp.tid()
+    b = tid // M
+    i = tid % M
+    pt = coords[b, i]
+    o = origin[b]
+    cx = wp.clamp(wp.int32(wp.floor((pt[0] - o[0]) * inv_cell)), 0, max_coord)
+    cy = wp.clamp(wp.int32(wp.floor((pt[1] - o[1]) * inv_cell)), 0, max_coord)
+    cz = wp.clamp(wp.int32(wp.floor((pt[2] - o[2]) * inv_cell)), 0, max_coord)
+    keys[tid] = pack_key(b, cx, cy, cz, bits, morton_bits)
+
+
+@wp.kernel
+def gather_pc_kernel(
+    points: wp.array2d(dtype=wp.vec3),
+    perm: wp.array(dtype=wp.int32),
+    P: wp.int32,
+    pc_orig: wp.array(dtype=wp.int32),
+    pc_xyz4: wp.array2d(dtype=wp.float32),
+    pc_norm: wp.array(dtype=wp.float32),
+):
+    """
+    Gather the Morton-sorted point arrays from the sort permutation.
+
+    For each sorted slot ``si``, ``perm[si]`` is the original flat point index;
+    this writes the local point index, the padded ``xyz4`` coordinates, and the
+    squared norm used by the GEMM distance formula.
+
+    Args:
+        points: Reference points of shape ``(B, P)`` (Warp ``vec3`` array).
+        perm: Sort permutation (original flat indices), shape ``(B * P,)``.
+        P: Number of points per batch.
+        pc_orig: Output local point index per sorted slot.
+        pc_xyz4: Output sorted coordinates ``(x, y, z, 0)``, shape ``(>=B*P, 4)``.
+        pc_norm: Output squared norm ``x^2 + y^2 + z^2`` per sorted slot.
+    """
+    si = wp.tid()
+    flat = perm[si]
+    b = flat // P
+    p = flat % P
+    pt = points[b, p]
+    pc_orig[si] = p
+    pc_xyz4[si, 0] = pt[0]
+    pc_xyz4[si, 1] = pt[1]
+    pc_xyz4[si, 2] = pt[2]
+    pc_xyz4[si, 3] = 0.0
+    pc_norm[si] = pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2]
+
+
+@wp.kernel
+def gather_q_kernel(
+    queries: wp.array2d(dtype=wp.vec3),
+    perm: wp.array(dtype=wp.int32),
+    Q: wp.int32,
+    origin: wp.array(dtype=wp.vec3),
+    inv_cell: wp.float32,
+    max_coord: wp.int32,
+    q_orig: wp.array(dtype=wp.int32),
+    qp_xyz4: wp.array2d(dtype=wp.float32),
+    qp_norm: wp.array(dtype=wp.float32),
+    qcell_b: wp.array(dtype=wp.int32),
+    qcell_cx: wp.array(dtype=wp.int32),
+    qcell_cy: wp.array(dtype=wp.int32),
+    qcell_cz: wp.array(dtype=wp.int32),
+):
+    """
+    Gather the Morton-sorted query arrays and their integer cell coordinates.
+
+    ``q_orig`` stores the *original* flat query id (``b * Q + q``) so search
+    kernels can write results back in the caller's query order. The per-query
+    cell coordinates are recomputed here (with the shared PC ``origin`` /
+    ``inv_cell``) so no host-side Morton decode is needed downstream.
+
+    Args:
+        queries: Query points of shape ``(B, Q)`` (Warp ``vec3`` array).
+        perm: Sort permutation (original flat query indices), shape ``(B * Q,)``.
+        Q: Number of queries per batch.
+        origin: Per-batch grid origin shared with the PC index, shape ``(B,)``.
+        inv_cell: Reciprocal of the cell size.
+        max_coord: Maximum cell coordinate per axis (``2**bits - 1``).
+        q_orig: Output original flat query id per sorted slot.
+        qp_xyz4: Output sorted query coordinates ``(x, y, z, 0)``.
+        qp_norm: Output squared norm per sorted query.
+        qcell_b: Output batch index per sorted query.
+        qcell_cx: Output cell coordinate x per sorted query.
+        qcell_cy: Output cell coordinate y per sorted query.
+        qcell_cz: Output cell coordinate z per sorted query.
+    """
+    si = wp.tid()
+    flat = perm[si]
+    b = flat // Q
+    q = flat % Q
+    pt = queries[b, q]
+    o = origin[b]
+    q_orig[si] = flat
+    qp_xyz4[si, 0] = pt[0]
+    qp_xyz4[si, 1] = pt[1]
+    qp_xyz4[si, 2] = pt[2]
+    qp_xyz4[si, 3] = 0.0
+    qp_norm[si] = pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2]
+    qcell_b[si] = b
+    qcell_cx[si] = wp.clamp(wp.int32(wp.floor((pt[0] - o[0]) * inv_cell)), 0, max_coord)
+    qcell_cy[si] = wp.clamp(wp.int32(wp.floor((pt[1] - o[1]) * inv_cell)), 0, max_coord)
+    qcell_cz[si] = wp.clamp(wp.int32(wp.floor((pt[2] - o[2]) * inv_cell)), 0, max_coord)
+
+
+@wp.kernel
+def build_cell_hash_kernel(
+    cell_key: wp.array(dtype=wp.int64),
+    hash_cap: wp.int32,
+    hash_slot: wp.array(dtype=wp.int32),
+):
+    """
+    Insert every occupied cell into the open-addressed hash table.
+
+    Each thread claims an empty slot for its cell index ``c`` using an ``int32``
+    compare-and-swap on ``hash_slot`` (initialized to ``-1`` by the host), then
+    linear-probes on collision. Only ``int32`` CAS is required because the full
+    64-bit key lives in ``cell_key`` and is verified during lookup.
+
+    Args:
+        cell_key: Per-occupied-cell packed keys, shape ``(num_cells,)``.
+        hash_cap: Hash table capacity (a power of two).
+        hash_slot: Hash table to fill; ``-1`` means empty.
+    """
+    c = wp.tid()
+    key = cell_key[c]
+    mask = hash_cap - 1
+    h = wp.int32(hash64(wp.uint64(key)) & wp.uint64(mask))
+    probe = wp.int32(0)
+    while probe < hash_cap:
+        old = wp.atomic_cas(hash_slot, h, wp.int32(-1), c)
+        if old == -1:
+            return
+        h = (h + 1) & mask
+        probe += 1
+
+
+# ---------------------------------------------------------------------------
+# Tiled-task generation kernels (shared by B1 and B2)
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def count_tasks_kernel(
+    q_tile_b: wp.array(dtype=wp.int32),
+    q_tile_cx: wp.array(dtype=wp.int32),
+    q_tile_cy: wp.array(dtype=wp.int32),
+    q_tile_cz: wp.array(dtype=wp.int32),
+    offsets: wp.array2d(dtype=wp.int32),
+    K: wp.int32,
+    max_coord: wp.int32,
+    bits: wp.int32,
+    morton_bits: wp.int32,
+    cell_key: wp.array(dtype=wp.int64),
+    cell_start: wp.array(dtype=wp.int32),
+    cell_end: wp.array(dtype=wp.int32),
+    hash_slot: wp.array(dtype=wp.int32),
+    hash_cap: wp.int32,
+    tile_p: wp.int32,
+    task_count: wp.array(dtype=wp.int32),
+):
+    """
+    Count the number of ``(query-tile, point-chunk)`` tasks per query tile.
+
+    For each query tile, scans the precomputed neighbor-cell offsets, looks up
+    each non-empty PC cell, and accumulates ``ceil(cell_len / tile_p)`` chunks.
+
+    Args:
+        q_tile_b: Per-query-tile batch index.
+        q_tile_cx: Per-query-tile base cell coordinate x.
+        q_tile_cy: Per-query-tile base cell coordinate y.
+        q_tile_cz: Per-query-tile base cell coordinate z.
+        offsets: Neighbor-cell offset table of shape ``(K, 3)``.
+        K: Number of neighbor offsets.
+        max_coord: Maximum cell coordinate per axis.
+        bits: Number of Morton bits per axis.
+        morton_bits: Total Morton bit width.
+        cell_key: Per-occupied-cell keys.
+        cell_start: Per-occupied-cell start index into the sorted PC arrays.
+        cell_end: Per-occupied-cell end index (exclusive).
+        hash_slot: Hash table of occupied-cell indices.
+        hash_cap: Hash table capacity.
+        tile_p: Point-chunk width (``TILE_P``).
+        task_count: Output task count per query tile.
+    """
+    qt = wp.tid()
+    b = q_tile_b[qt]
+    cx = q_tile_cx[qt]
+    cy = q_tile_cy[qt]
+    cz = q_tile_cz[qt]
+    total = wp.int32(0)
+    for k in range(K):
+        ncx = cx + offsets[k, 0]
+        ncy = cy + offsets[k, 1]
+        ncz = cz + offsets[k, 2]
+        if ncx < 0 or ncx > max_coord or ncy < 0 or ncy > max_coord or ncz < 0 or ncz > max_coord:
+            continue
+        nkey = pack_key(b, ncx, ncy, ncz, bits, morton_bits)
+        c = lookup_cell(nkey, hash_slot, cell_key, hash_cap)
+        if c >= 0:
+            plen = cell_end[c] - cell_start[c]
+            total += (plen + tile_p - 1) // tile_p
+    task_count[qt] = total
+
+
+@wp.kernel
+def fill_tasks_kernel(
+    q_tile_begin: wp.array(dtype=wp.int32),
+    q_tile_count: wp.array(dtype=wp.int32),
+    q_tile_b: wp.array(dtype=wp.int32),
+    q_tile_cx: wp.array(dtype=wp.int32),
+    q_tile_cy: wp.array(dtype=wp.int32),
+    q_tile_cz: wp.array(dtype=wp.int32),
+    task_offset: wp.array(dtype=wp.int32),
+    offsets: wp.array2d(dtype=wp.int32),
+    K: wp.int32,
+    max_coord: wp.int32,
+    bits: wp.int32,
+    morton_bits: wp.int32,
+    cell_key: wp.array(dtype=wp.int64),
+    cell_start: wp.array(dtype=wp.int32),
+    cell_end: wp.array(dtype=wp.int32),
+    hash_slot: wp.array(dtype=wp.int32),
+    hash_cap: wp.int32,
+    tile_p: wp.int32,
+    task_q_begin: wp.array(dtype=wp.int32),
+    task_q_count: wp.array(dtype=wp.int32),
+    task_p_begin: wp.array(dtype=wp.int32),
+    task_p_count: wp.array(dtype=wp.int32),
+):
+    """
+    Materialize the task list produced by :func:`count_tasks_kernel`.
+
+    Each query tile owns the contiguous output range starting at
+    ``task_offset[qt]`` (an exclusive scan of the per-tile counts), so writes are
+    sequential and need no atomics.
+
+    Args:
+        q_tile_begin: Per-query-tile start index into the sorted query arrays.
+        q_tile_count: Per-query-tile query count (``<= TILE_Q``).
+        q_tile_b: Per-query-tile batch index.
+        q_tile_cx: Per-query-tile base cell coordinate x.
+        q_tile_cy: Per-query-tile base cell coordinate y.
+        q_tile_cz: Per-query-tile base cell coordinate z.
+        task_offset: Exclusive scan of per-tile task counts.
+        offsets: Neighbor-cell offset table of shape ``(K, 3)``.
+        K: Number of neighbor offsets.
+        max_coord: Maximum cell coordinate per axis.
+        bits: Number of Morton bits per axis.
+        morton_bits: Total Morton bit width.
+        cell_key: Per-occupied-cell keys.
+        cell_start: Per-occupied-cell start index into the sorted PC arrays.
+        cell_end: Per-occupied-cell end index (exclusive).
+        hash_slot: Hash table of occupied-cell indices.
+        hash_cap: Hash table capacity.
+        tile_p: Point-chunk width (``TILE_P``).
+        task_q_begin: Output query-tile start per task.
+        task_q_count: Output query count per task.
+        task_p_begin: Output point-chunk start per task.
+        task_p_count: Output point-chunk length per task.
+    """
+    qt = wp.tid()
+    out = task_offset[qt]
+    qb = q_tile_begin[qt]
+    qc = q_tile_count[qt]
+    b = q_tile_b[qt]
+    cx = q_tile_cx[qt]
+    cy = q_tile_cy[qt]
+    cz = q_tile_cz[qt]
+    for k in range(K):
+        ncx = cx + offsets[k, 0]
+        ncy = cy + offsets[k, 1]
+        ncz = cz + offsets[k, 2]
+        if ncx < 0 or ncx > max_coord or ncy < 0 or ncy > max_coord or ncz < 0 or ncz > max_coord:
+            continue
+        nkey = pack_key(b, ncx, ncy, ncz, bits, morton_bits)
+        c = lookup_cell(nkey, hash_slot, cell_key, hash_cap)
+        if c < 0:
+            continue
+        ps = cell_start[c]
+        pe = cell_end[c]
+        pb = ps
+        while pb < pe:
+            pcount = wp.min(tile_p, pe - pb)
+            task_q_begin[out] = qb
+            task_q_count[out] = qc
+            task_p_begin[out] = pb
+            task_p_count[out] = pcount
+            out += 1
+            pb += tile_p
+
+
+# ---------------------------------------------------------------------------
+# Function A: scalar-hash search
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def scalar_search_kernel(
+    qp_xyz4: wp.array2d(dtype=wp.float32),
+    q_orig: wp.array(dtype=wp.int32),
+    qcell_b: wp.array(dtype=wp.int32),
+    qcell_cx: wp.array(dtype=wp.int32),
+    qcell_cy: wp.array(dtype=wp.int32),
+    qcell_cz: wp.array(dtype=wp.int32),
+    offsets: wp.array2d(dtype=wp.int32),
+    K: wp.int32,
+    max_coord: wp.int32,
+    bits: wp.int32,
+    morton_bits: wp.int32,
+    cell_key: wp.array(dtype=wp.int64),
+    cell_start: wp.array(dtype=wp.int32),
+    cell_end: wp.array(dtype=wp.int32),
+    hash_slot: wp.array(dtype=wp.int32),
+    hash_cap: wp.int32,
+    pc_xyz4: wp.array2d(dtype=wp.float32),
+    pc_orig: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """
+    Scalar-hash radius search (Function A): one thread per sorted query.
+
+    Scans the precomputed near-to-far neighbor cells, looks up each via the hash
+    table, and tests the contiguous sorted points in ``[cell_start, cell_end)``.
+    Up to ``max_points`` first-found neighbors (in scan order) are written; the
+    near-to-far ordering makes the early exit favor closer cells. Results are
+    written at the original flat query id, so output query order matches input.
+
+    Args:
+        qp_xyz4: Sorted query coordinates ``(x, y, z, 0)``.
+        q_orig: Original flat query id per sorted query.
+        qcell_b: Batch index per sorted query.
+        qcell_cx: Cell coordinate x per sorted query.
+        qcell_cy: Cell coordinate y per sorted query.
+        qcell_cz: Cell coordinate z per sorted query.
+        offsets: Near-to-far neighbor-cell offsets, shape ``(K, 3)``.
+        K: Number of neighbor offsets.
+        max_coord: Maximum cell coordinate per axis.
+        bits: Number of Morton bits per axis.
+        morton_bits: Total Morton bit width.
+        cell_key: Per-occupied-cell keys.
+        cell_start: Per-occupied-cell start index into the sorted PC arrays.
+        cell_end: Per-occupied-cell end index (exclusive).
+        hash_slot: Hash table of occupied-cell indices.
+        hash_cap: Hash table capacity.
+        pc_xyz4: Sorted point coordinates ``(x, y, z, 0)``.
+        pc_orig: Local point index per sorted point.
+        radius2: Squared search radius.
+        max_points: Maximum neighbors to record per query.
+        return_dists: Whether to write distances.
+        return_points: Whether to write neighbor coordinates.
+        out_idx: Output neighbor indices, shape ``(B * Q, max_points)``.
+        out_count: Output neighbor count per query, shape ``(B * Q,)``.
+        out_dist: Output distances (only written when ``return_dists``).
+        out_pts: Output neighbor coordinates (only written when ``return_points``).
+    """
+    sq = wp.tid()
+    flat_q = q_orig[sq]
+    qx = qp_xyz4[sq, 0]
+    qy = qp_xyz4[sq, 1]
+    qz = qp_xyz4[sq, 2]
+    b = qcell_b[sq]
+    cx = qcell_cx[sq]
+    cy = qcell_cy[sq]
+    cz = qcell_cz[sq]
+
+    count = wp.int32(0)
+    for k in range(K):
+        if count >= max_points:
+            break
+        ncx = cx + offsets[k, 0]
+        ncy = cy + offsets[k, 1]
+        ncz = cz + offsets[k, 2]
+        if ncx < 0 or ncx > max_coord or ncy < 0 or ncy > max_coord or ncz < 0 or ncz > max_coord:
+            continue
+        nkey = pack_key(b, ncx, ncy, ncz, bits, morton_bits)
+        c = lookup_cell(nkey, hash_slot, cell_key, hash_cap)
+        if c < 0:
+            continue
+        s = cell_start[c]
+        e = cell_end[c]
+        for si in range(s, e):
+            px = pc_xyz4[si, 0]
+            py = pc_xyz4[si, 1]
+            pz = pc_xyz4[si, 2]
+            dx = px - qx
+            dy = py - qy
+            dz = pz - qz
+            d2 = dx * dx + dy * dy + dz * dz
+            if d2 <= radius2:
+                out_idx[flat_q, count] = pc_orig[si]
+                if return_dists:
+                    out_dist[flat_q, count] = wp.sqrt(d2)
+                if return_points:
+                    out_pts[flat_q, count] = wp.vec3(px, py, pz)
+                count += 1
+                if count >= max_points:
+                    break
+    out_count[flat_q] = count
+
+
+# ---------------------------------------------------------------------------
+# Function B1: tiled direct-FMA search
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def tiled_fma_kernel(
+    task_q_begin: wp.array(dtype=wp.int32),
+    task_q_count: wp.array(dtype=wp.int32),
+    task_p_begin: wp.array(dtype=wp.int32),
+    task_p_count: wp.array(dtype=wp.int32),
+    qp_xyz4: wp.array2d(dtype=wp.float32),
+    q_orig: wp.array(dtype=wp.int32),
+    pc_xyz4: wp.array2d(dtype=wp.float32),
+    pc_orig: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """
+    Tiled direct-FMA radius search (Function B1).
+
+    Launched with a 2D ``wp.launch(dim=(num_tasks, TILE_P))``: the first index is
+    the task and the second is the lane (one candidate point per lane). Each lane
+    computes its candidate's direct squared distance to every query in the task's
+    ``TILE_Q`` tile and appends in-radius hits via an atomic per-query slot
+    counter (``out_count``, which may overshoot ``max_points``; the host clamps it
+    afterward). Queries are read from global memory (same-address broadcast across
+    lanes), so no cooperative tile load is needed; this keeps the design's
+    one-thread-per-candidate, loop-over-``TILE_Q`` mapping while staying robust.
+
+    Args:
+        task_q_begin: Per-task query-tile start index.
+        task_q_count: Per-task query count (``<= TILE_Q``).
+        task_p_begin: Per-task point-chunk start index.
+        task_p_count: Per-task point-chunk length (``<= TILE_P``).
+        qp_xyz4: Sorted query coordinates ``(x, y, z, 0)``.
+        q_orig: Original flat query id per sorted query.
+        pc_xyz4: Sorted point coordinates ``(x, y, z, 0)``.
+        pc_orig: Local point index per sorted point.
+        radius2: Squared search radius.
+        max_points: Maximum neighbors to record per query.
+        return_dists: Whether to write distances.
+        return_points: Whether to write neighbor coordinates.
+        out_idx: Output neighbor indices, shape ``(B * Q, max_points)``.
+        out_count: Atomic per-query slot counter / neighbor count.
+        out_dist: Output distances (only written when ``return_dists``).
+        out_pts: Output neighbor coordinates (only written when ``return_points``).
+    """
+    task_id, lane = wp.tid()
+    pcount = task_p_count[task_id]
+    if lane >= pcount:
+        return
+
+    qb = task_q_begin[task_id]
+    qc = task_q_count[task_id]
+
+    # Early out: skip the whole task if every query in its tile already has
+    # max_points neighbors. These are cheap non-atomic reads; the atomic below
+    # still guarantees correctness. For large radii (dense cells) this lets later
+    # task waves stop scanning once queries fill, avoiding near-brute-force cost.
+    all_full = True
+    for iq in range(TILE_Q):
+        if iq < qc:
+            if out_count[q_orig[qb + iq]] < max_points:
+                all_full = False
+    if all_full:
+        return
+
+    pb = task_p_begin[task_id]
+    sp = pb + lane
+
+    px = pc_xyz4[sp, 0]
+    py = pc_xyz4[sp, 1]
+    pz = pc_xyz4[sp, 2]
+    porig = pc_orig[sp]
+
+    for iq in range(TILE_Q):
+        if iq < qc:
+            flat_q = q_orig[qb + iq]
+            # Per-query early out: don't compute distances for a full query.
+            if out_count[flat_q] < max_points:
+                qx = qp_xyz4[qb + iq, 0]
+                qy = qp_xyz4[qb + iq, 1]
+                qz = qp_xyz4[qb + iq, 2]
+                dx = px - qx
+                dy = py - qy
+                dz = pz - qz
+                d2 = dx * dx + dy * dy + dz * dz
+                if d2 <= radius2:
+                    slot = wp.atomic_add(out_count, flat_q, 1)
+                    if slot < max_points:
+                        out_idx[flat_q, slot] = porig
+                        if return_dists:
+                            out_dist[flat_q, slot] = wp.sqrt(d2)
+                        if return_points:
+                            out_pts[flat_q, slot] = wp.vec3(px, py, pz)
+
+
+# ---------------------------------------------------------------------------
+# Function B2: tiled GEMM search
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def tiled_gemm_kernel(
+    task_q_begin: wp.array(dtype=wp.int32),
+    task_q_count: wp.array(dtype=wp.int32),
+    task_p_begin: wp.array(dtype=wp.int32),
+    task_p_count: wp.array(dtype=wp.int32),
+    lane_iota: wp.array(dtype=wp.int32),
+    qp_xyz4: wp.array2d(dtype=wp.float32),
+    qp_norm: wp.array(dtype=wp.float32),
+    q_orig: wp.array(dtype=wp.int32),
+    pc_xyz4: wp.array2d(dtype=wp.float32),
+    pc_norm: wp.array(dtype=wp.float32),
+    pc_orig: wp.array(dtype=wp.int32),
+    radius2: wp.float32,
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """
+    Tiled GEMM radius search (Function B2).
+
+    Launched with ``wp.launch_tiled(dim=num_tasks, block_dim=TILE_P)``: one block
+    per task, one lane per candidate point. Distances use the expansion
+    :math:`D^2 = \\lVert Q \\rVert^2 + \\lVert P \\rVert^2 - 2 Q P^T`. The ``Q``
+    and ``P`` tiles (padded to width 4) are multiplied with ``wp.tile_matmul``
+    into a ``(TILE_Q, TILE_P)`` tile; ``wp.untile`` then hands each lane (point)
+    the ``TILE_Q`` dot products for its candidate, which are combined with the
+    cached norms. In-radius hits append via the atomic per-query slot counter.
+
+    Args:
+        task_q_begin: Per-task query-tile start index.
+        task_q_count: Per-task query count (``<= TILE_Q``).
+        task_p_begin: Per-task point-chunk start index.
+        task_p_count: Per-task point-chunk length (``<= TILE_P``).
+        lane_iota: Constant ``[0, 1, ..., TILE_P - 1]`` used to derive lane ids.
+        qp_xyz4: Sorted query coordinates ``(x, y, z, 0)``.
+        qp_norm: Squared norm per sorted query.
+        q_orig: Original flat query id per sorted query.
+        pc_xyz4: Sorted point coordinates ``(x, y, z, 0)``.
+        pc_norm: Squared norm per sorted point.
+        pc_orig: Local point index per sorted point.
+        radius2: Squared search radius.
+        max_points: Maximum neighbors to record per query.
+        return_dists: Whether to write distances.
+        return_points: Whether to write neighbor coordinates.
+        out_idx: Output neighbor indices, shape ``(B * Q, max_points)``.
+        out_count: Atomic per-query slot counter / neighbor count.
+        out_dist: Output distances (only written when ``return_dists``).
+        out_pts: Output neighbor coordinates (only written when ``return_points``).
+    """
+    task_id = wp.tid()
+    qb = task_q_begin[task_id]
+    qc = task_q_count[task_id]
+    pb = task_p_begin[task_id]
+    pcount = task_p_count[task_id]
+
+    # Collective tile ops first (no divergence): load Q/P tiles, compute the
+    # query-by-point dot-product tile, and distribute one point's column per lane.
+    # Shared storage is used for the matmul operands per the design, and the
+    # output uses the 3-arg accumulating tile_matmul into a zero-initialized tile.
+    q_tile = wp.tile_load(qp_xyz4, shape=(TILE_Q, 4), offset=(qb, 0), storage="shared")
+    p_tile = wp.tile_load(pc_xyz4, shape=(TILE_P, 4), offset=(pb, 0), storage="shared")
+    pt_tile = wp.tile_transpose(p_tile)  # (4, TILE_P)
+    dot_tile = wp.tile_zeros(shape=(TILE_Q, TILE_P), dtype=wp.float32)
+    wp.tile_matmul(q_tile, pt_tile, dot_tile)  # dot_tile = q_tile @ pt_tile
+    # untile distributes the last tile dimension (TILE_P == block_dim) across
+    # lanes, so each lane (one candidate point) receives its TILE_Q dot products.
+    dot = wp.untile(dot_tile)
+    lane = wp.untile(wp.tile_load(lane_iota, shape=(TILE_P,)))
+
+    valid = lane < pcount
+    sp = pb + lane
+    p_norm = float(0.0)
+    porig = wp.int32(-1)
+    px = float(0.0)
+    py = float(0.0)
+    pz = float(0.0)
+    if valid:
+        p_norm = pc_norm[sp]
+        porig = pc_orig[sp]
+        if return_points:
+            px = pc_xyz4[sp, 0]
+            py = pc_xyz4[sp, 1]
+            pz = pc_xyz4[sp, 2]
+
+    for iq in range(TILE_Q):
+        if iq < qc:
+            if valid:
+                flat_q = q_orig[qb + iq]
+                # Per-query early out: skip already-full queries (trims atomics).
+                # Note the tile_matmul above still runs for every task, so GEMM
+                # cannot early-terminate the scan like the scalar/FMA paths.
+                if out_count[flat_q] < max_points:
+                    q_norm = qp_norm[qb + iq]
+                    d2 = q_norm + p_norm - 2.0 * dot[iq]
+                    if d2 <= radius2:
+                        slot = wp.atomic_add(out_count, flat_q, 1)
+                        if slot < max_points:
+                            out_idx[flat_q, slot] = porig
+                            if return_dists:
+                                out_dist[flat_q, slot] = wp.sqrt(wp.max(d2, 0.0))
+                            if return_points:
+                                out_pts[flat_q, slot] = wp.vec3(px, py, pz)

--- a/physicsnemo/nn/functional/neighbors/radius_search/_sparse_hash_impl.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_sparse_hash_impl.py
@@ -1,0 +1,389 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Torch <-> Warp host glue for the ``sparse_fma_e2e`` radius-search backend.
+
+This backend hashes *only occupied* cells (no dense per-batch grid, no
+``total_cells``, no Morton sort, no query sort/gather, no host ``.item()``).
+The build is count -> exclusive-scan -> scatter; the scan is the three-phase
+async tile scan from ``_morton_dense_kernels.py`` (``wp.utils.array_scan``
+injects a device sync, which this backend must avoid). Search reuses the
+one-warp-per-query coalesced FMA loop.
+
+Assumptions (current experimental scope):
+* CUDA-only.
+* ``Np = B * P < 200000`` so ``H = next_pow2(2 * Np) <= 2**19 < SCAN_BLOCK**2``
+  and the two-level tile scan never overflows.
+
+Entry point: :func:`radius_search_sparse_fma_e2e`, matching the
+``(indices, points, distances, num_neighbors)`` contract of the other
+``max_points`` backends.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import warp as wp
+
+from physicsnemo.core.function_spec import FunctionSpec
+
+from . import _morton_dense_kernels as mk
+from . import _sparse_hash_kernels as sk
+from ._morton_dense_impl import (
+    _alloc_outputs,
+    _empty_outputs,
+    _wp_outputs,
+)
+from .utils import validate_inputs
+
+# Load factor <= 0.5: hash table has at least 2x as many slots as points.
+_HASH_LOAD_FACTOR_INV = 2
+
+
+def _nvtx_push(label: str) -> None:
+    """Push an NVTX range when ``PROFILE_RUN=1`` (matches the dense e2e path)."""
+    if os.environ.get("PROFILE_RUN", "0") == "1":
+        torch.cuda.nvtx.range_push(label)
+
+
+def _nvtx_pop() -> None:
+    """Pop an NVTX range when ``PROFILE_RUN=1``."""
+    if os.environ.get("PROFILE_RUN", "0") == "1":
+        torch.cuda.nvtx.range_pop()
+
+
+def _dbg(tag: str, tensor=None) -> None:
+    """Sync + print a build-phase checkpoint when ``PHYSICSNEMO_SPARSE_DEBUG=1``.
+
+    Temporary diagnostic to localise a hang/OOB to a specific kernel: the sync
+    forces the just-launched kernel to complete before the next print, so the
+    last tag printed names the stage that is stuck.
+    """
+    if os.environ.get("PHYSICSNEMO_SPARSE_DEBUG", "0") != "1":
+        return
+    import warp as _wp
+
+    _wp.synchronize()
+    msg = f"[sparse_fma_e2e] {tag}"
+    if tensor is not None:
+        t = tensor.detach()
+        msg += (
+            f"  shape={tuple(t.shape)} min={int(t.min())} "
+            f"max={int(t.max())} sum={int(t.sum())}"
+        )
+    print(msg, flush=True)
+
+
+def _next_power_of_two(n: int) -> int:
+    """Smallest power of two >= max(1, n)."""
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+def _warp_scan_exclusive(
+    counts_wp,
+    out_wp,
+    n: int,
+    device,
+    wp_device,
+    wp_stream,
+) -> None:
+    """Async exclusive prefix scan of ``counts_wp[:n]`` into ``out_wp[:n]``.
+
+    Recursive, tile-free (no ``cudaDeviceSynchronize``, no CUB scratch, all
+    launches on ``wp_stream``). Uses only scalar array ops -- ``wp.tile_scan_*``
+    was observed to scan only a fraction of a block on this Warp build:
+
+      1) sparse_block_reduce      block_sums[b] = sum(arr[block b])
+      2) recurse                  exclusive-scan block_sums -> block_offsets
+      3) sparse_block_scan_write  exclusive prefix within block b, seeded by
+                                  block_offsets[b]
+
+    Each level divides the length by ``SCAN_TILE`` (256), so any ``n`` is
+    handled with O(log_256 n) levels (H+1 for Np < 200k needs two).
+    """
+    tile = int(sk.SCAN_TILE)
+    num_blocks = (n + tile - 1) // tile
+
+    block_sums = torch.zeros(num_blocks, dtype=torch.int32, device=device)
+    block_offsets = torch.zeros(num_blocks, dtype=torch.int32, device=device)
+    block_sums_wp = wp.from_torch(block_sums)
+    block_offsets_wp = wp.from_torch(block_offsets)
+
+    # 1) Per-block totals.
+    wp.launch(
+        sk.sparse_block_reduce,
+        dim=num_blocks,
+        inputs=[counts_wp, wp.int32(n), block_sums_wp],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+    # 2) Exclusive scan of the per-block totals -> block_offsets. Base case
+    #    (num_blocks == 1) needs no scan: the single block's offset is 0.
+    if num_blocks > 1:
+        _warp_scan_exclusive(
+            block_sums_wp, block_offsets_wp, num_blocks, device, wp_device, wp_stream
+        )
+
+    # 3) Write exclusive prefixes within each block, seeded by block_offsets.
+    wp.launch(
+        sk.sparse_block_scan_write,
+        dim=num_blocks,
+        inputs=[counts_wp, block_offsets_wp, out_wp, wp.int32(n)],
+        device=wp_device,
+        stream=wp_stream,
+    )
+
+
+def radius_search_sparse_fma_e2e(
+    points: torch.Tensor,
+    queries: torch.Tensor,
+    radius: float,
+    max_points: int,
+    return_dists: bool = False,
+    return_points: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Sparse-hash-to-CSR radius search (CUDA-only, ``max_points`` path).
+
+    Args:
+        points: Reference points, ``(N, 3)`` or ``(B, N, 3)``.
+        queries: Query points, ``(M, 3)`` or ``(B, M, 3)``.
+        radius: Search radius.
+        max_points: Maximum neighbours returned per query.
+        return_dists: Whether to return neighbour distances.
+        return_points: Whether to return neighbour coordinates.
+
+    Returns:
+        ``(indices, points, distances, num_neighbors)`` -- the shared
+        ``max_points`` contract, with the batch dim squeezed for unbatched
+        inputs and float outputs cast back to the input dtype.
+    """
+    input_dtype = points.dtype
+
+    _nvtx_push("RADIUS SEARCH SPARSE FMA E2E")
+
+    points, queries, was_unbatched = validate_inputs(points, queries)
+
+    if points.dtype != torch.float32:
+        points = points.to(torch.float32)
+    if queries.dtype != torch.float32:
+        queries = queries.to(torch.float32)
+    _nvtx_push("points contiguous")
+    points = points.contiguous()
+    queries = queries.contiguous()
+    _nvtx_pop()
+
+    B, P, _ = points.shape
+    Q = queries.shape[1]
+    device = points.device
+
+    if P == 0 or Q == 0:
+        _nvtx_pop()  # RADIUS SEARCH SPARSE FMA E2E
+        return _empty_outputs(
+            B, Q, max_points, return_dists, return_points, was_unbatched,
+            input_dtype, device,
+        )
+
+    Np = B * P
+    Nq = B * Q
+    H = _next_power_of_two(_HASH_LOAD_FACTOR_INV * Np)
+
+    # Cell size strictly >= radius so the 27-neighbour stencil is exhaustive.
+    cell_size = float(radius) * (1.0 + 1e-3)
+    inv_cell = 1.0 / cell_size
+    radius2 = float(radius) * float(radius)
+
+    wp_device, wp_stream = FunctionSpec.warp_launch_context(points)
+
+    # -- Workspace (int32) -------------------------------------------------
+    # cell_rep_plus1 doubles as the occupancy sentinel (flat+1) and is cleared
+    # together with cell_count in a single zeroed allocation.
+    _nvtx_push("alloc workspace")
+    cell_rep_plus1 = torch.zeros(H, dtype=torch.int32, device=device)
+    cell_count = torch.zeros(H + 1, dtype=torch.int32, device=device)  # [H]=0 pad
+    cell_offsets = torch.empty(H + 1, dtype=torch.int32, device=device)
+    cell_coords = torch.empty((H, 4), dtype=torch.int32, device=device)
+    point_slot = torch.empty(Np, dtype=torch.int32, device=device)
+    point_rank = torch.empty(Np, dtype=torch.int32, device=device)
+
+    # Compact cell-contiguous point SoA.
+    pc_x = torch.empty(Np, dtype=torch.float32, device=device)
+    pc_y = torch.empty(Np, dtype=torch.float32, device=device)
+    pc_z = torch.empty(Np, dtype=torch.float32, device=device)
+    pc_orig = torch.empty(Np, dtype=torch.int32, device=device)
+
+    out_idx, out_count, out_dist, out_pts = _alloc_outputs(
+        B, Q, max_points, return_dists, return_points, device
+    )
+
+    # -- Warp views --------------------------------------------------------
+    points_wp = wp.from_torch(points, dtype=wp.vec3)
+    queries_wp = wp.from_torch(queries, dtype=wp.vec3)
+    cell_rep_plus1_wp = wp.from_torch(cell_rep_plus1)
+    cell_count_wp = wp.from_torch(cell_count)
+    cell_coords_wp = wp.from_torch(cell_coords, dtype=wp.vec4i)
+    point_slot_wp = wp.from_torch(point_slot)
+    point_rank_wp = wp.from_torch(point_rank)
+    pc_x_wp = wp.from_torch(pc_x)
+    pc_y_wp = wp.from_torch(pc_y)
+    pc_z_wp = wp.from_torch(pc_z)
+    pc_orig_wp = wp.from_torch(pc_orig)
+    cell_offsets_wp = wp.from_torch(cell_offsets)
+
+    idx_wp, count_wp, dist_wp, pts_wp = _wp_outputs(
+        out_idx, out_count, out_dist, out_pts, Nq, max_points
+    )
+    # _wp_outputs returns None for disabled optional outputs; the kernel still
+    # needs valid arrays to bind, so wire zero-length placeholders.
+    if dist_wp is None:
+        dist_wp = wp.from_torch(
+            torch.empty((Nq, 0), dtype=torch.float32, device=device)
+        )
+    if pts_wp is None:
+        pts_wp = wp.from_torch(
+            torch.empty((Nq, 0, 3), dtype=torch.float32, device=device),
+            dtype=wp.vec3,
+        )
+    _nvtx_pop()  # alloc workspace
+
+    
+    
+    _nvtx_push("SCOPED STREAM")
+    with wp.ScopedStream(wp_stream, sync_enter=False, sync_exit=False):
+        # 1) Count points per occupied cell + build the hash table.
+        _nvtx_push("COUNT CELLS + BUILD HASH")
+        wp.launch(
+            sk.sparse_count_cells_kernel,
+            dim=Np,
+            inputs=[
+                points_wp,
+                wp.float32(inv_cell),
+                wp.int32(P),
+                wp.int32(H),
+                cell_rep_plus1_wp,
+                cell_count_wp,
+                cell_coords_wp,
+                point_slot_wp,
+                point_rank_wp,
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+        _nvtx_pop()  # COUNT CELLS + BUILD HASH
+        # _dbg("after count: cell_count", cell_count)
+        # _dbg("after count: point_slot", point_slot)
+
+        # 2) Exclusive scan of per-cell counts -> exclusive cell starts.
+        #    Two-level Warp tile scan: three kernel launches on wp_stream, no
+        #    cudaDeviceSynchronize and no CUB scratch (torch.cumsum was confirmed
+        #    to sync on this build). Scanning all H+1 entries (cell_count[H]==0)
+        #    yields cell_offsets[H] == Np, so the cell_offsets[slot + 1] read for
+        #    the last occupied slot is valid.
+        _nvtx_push("Array Scan")
+        # _dbg("before scan: cell_count", cell_count)
+        # _warp_scan_exclusive(
+        #     cell_count_wp, cell_offsets_wp, H + 1, device, wp_device, wp_stream
+        # )
+        wp.utils.array_scan(cell_count_wp[: H + 1], cell_offsets_wp[: H + 1], inclusive=False)
+
+        _nvtx_pop()  # Array Scan
+        # cell_offsets must be non-decreasing, offsets[0]==0, offsets[H]==Np.
+        # _dbg("after scan: cell_offsets", cell_offsets)
+
+        # 3) Scatter points into cell-contiguous slots. Each point's destination
+        #    is cell_offsets[slot] + its precomputed intra-cell rank, so no write
+        #    cursor and no cell_offsets clone are needed; cell_offsets stays the
+        #    immutable CSR start array for search.
+        _nvtx_push("Scatter Points to cells")
+        wp.launch(
+            sk.sparse_scatter_points_kernel,
+            dim=Np,
+            inputs=[
+                points_wp,
+                wp.int32(P),
+                point_slot_wp,
+                point_rank_wp,
+                cell_offsets_wp,
+                pc_x_wp,
+                pc_y_wp,
+                pc_z_wp,
+                pc_orig_wp,
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+        _nvtx_pop()  # Scatter Points to cells
+        # _dbg("after scatter: pc_orig", pc_orig)
+
+        # 4) One warp per query radius search (output padding fused in-kernel).
+        # _dbg("before search (launching radius_search_sparse_fma_kernel)")
+        _nvtx_push("RAD SEARCH KERNEL")
+        wp.launch_tiled(
+            sk.radius_search_sparse_fma_kernel,
+            dim=Nq,
+            block_dim=int(sk.FMA_WARP_SIZE),
+            inputs=[
+                queries_wp,
+                wp.int32(Q),
+                wp.float32(inv_cell),
+                wp.float32(radius2),
+                wp.int32(H),
+                cell_rep_plus1_wp,
+                cell_coords_wp,
+                cell_offsets_wp,
+                pc_x_wp,
+                pc_y_wp,
+                pc_z_wp,
+                pc_orig_wp,
+                wp.int32(max_points),
+                return_dists,
+                return_points,
+                idx_wp,
+                count_wp,
+                dist_wp,
+                pts_wp,
+            ],
+            device=wp_device,
+            stream=wp_stream,
+        )
+        _nvtx_pop()  # RAD SEARCH KERNEL
+
+
+    _nvtx_pop()
+    
+    num = out_count.view(B, Q)
+    if out_pts is None:
+        out_pts = torch.empty((0, max_points, 3), dtype=torch.float32, device=device)
+    if out_dist is None:
+        out_dist = torch.empty(0, dtype=torch.float32, device=device)
+
+    if was_unbatched:
+        out_idx = out_idx.squeeze(0)
+        num = num.squeeze(0)
+        if return_points:
+            out_pts = out_pts.squeeze(0)
+        if return_dists:
+            out_dist = out_dist.squeeze(0)
+
+    out_pts = out_pts.to(input_dtype)
+    out_dist = out_dist.to(input_dtype)
+    _nvtx_pop()  # RADIUS SEARCH SPARSE FMA E2E
+    return out_idx, out_pts, out_dist, num

--- a/physicsnemo/nn/functional/neighbors/radius_search/_sparse_hash_kernels.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_sparse_hash_kernels.py
@@ -1,0 +1,487 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Warp kernels for the ``sparse_fma_e2e`` radius-search backend.
+
+Unlike the dense-grid backend (``_morton_dense_*``), this backend never
+materialises a dense per-batch cell grid. It hashes *only the occupied* cells
+into an open-addressed table sized ``H >= 2 * Np`` (load factor <= 0.5) and
+compacts the points into cell-contiguous ranges via a count -> exclusive-scan
+-> scatter build. Search reuses the one-warp-per-query, all-lanes-per-cell
+coalesced loop of the dense v2 kernel; only the dense-row cell lookup is
+replaced by a lane-zero hash probe broadcast to the warp.
+
+The three-phase async prefix scan (no ``cudaDeviceSynchronize``) lives in
+``_morton_dense_kernels.py`` and is reused verbatim by the host orchestration.
+"""
+
+import warp as wp
+
+from ._morton_dense_kernels import (
+    _NEIGHBOR_X_2BIT,
+    _NEIGHBOR_Y_2BIT,
+    _NEIGHBOR_Z_2BIT,
+)
+
+# One full warp per query. Every query launches exactly 32 lanes so the ballot
+# / shuffle helpers below can use the full 0xffffffff mask (see design note).
+FMA_WARP_SIZE = wp.constant(32)
+
+# Elements processed serially per thread in the block-reduce / block-scan
+# kernels. This is a plain grid-stride chunk size, NOT a tile/warp width: the
+# scan below uses only scalar array ops and wp.tid(), never wp.tile*, because
+# wp.tile_scan_exclusive / wp.tile_sum were observed to scan only a fraction of
+# a block on this Warp build. Larger SCAN_TILE => fewer blocks but more serial
+# work per thread; 256 keeps num_blocks small while staying cheap.
+SCAN_TILE = wp.constant(256)
+
+
+# ---------------------------------------------------------------------------
+# Async exclusive prefix scan (no cudaDeviceSynchronize, no CUB, no tiles).
+#
+# Block-decomposed, tile-free. Each "block" owns SCAN_TILE contiguous elements
+# and is handled by ONE thread that loops serially. The host recurses on the
+# per-block totals (see _warp_scan_exclusive), so any length is supported.
+#
+#   phase1  dim=num_blocks, 1 thread/block: block_sums[b] = sum(arr[block b])
+#   (recurse) exclusive-scan block_sums -> block_offsets
+#   phase3  dim=num_blocks, 1 thread/block: write exclusive prefixes within the
+#           block, seeded by block_offsets[b]
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def sparse_block_reduce(
+    arr: wp.array(dtype=wp.int32),
+    n_pad: wp.int32,
+    block_sums: wp.array(dtype=wp.int32),
+):
+    """One thread per block: serial sum of its SCAN_TILE-element chunk."""
+    b = wp.tid()
+    start = b * SCAN_TILE
+    total = wp.int32(0)
+    j = wp.int32(0)
+    while j < SCAN_TILE:
+        idx = start + j
+        if idx < n_pad:
+            total += arr[idx]
+        j += 1
+    block_sums[b] = total
+
+
+@wp.kernel(enable_backward=False)
+def sparse_block_scan_write(
+    arr: wp.array(dtype=wp.int32),
+    block_offsets: wp.array(dtype=wp.int32),
+    out: wp.array(dtype=wp.int32),
+    n: wp.int32,
+):
+    """One thread per block: exclusive prefix within the block + block base."""
+    b = wp.tid()
+    start = b * SCAN_TILE
+    running = block_offsets[b]
+    j = wp.int32(0)
+    while j < SCAN_TILE:
+        idx = start + j
+        if idx < n:
+            out[idx] = running
+            running += arr[idx]
+        j += 1
+
+
+# ---------------------------------------------------------------------------
+# Quantization and hashing
+# ---------------------------------------------------------------------------
+
+
+@wp.func
+def _quantize_cell(p: wp.vec3, inv_cell: wp.float32) -> wp.vec3i:
+    """Absolute signed integer cell of a point (no per-batch min offset)."""
+    return wp.vec3i(
+        wp.int32(wp.floor(p[0] * inv_cell)),
+        wp.int32(wp.floor(p[1] * inv_cell)),
+        wp.int32(wp.floor(p[2] * inv_cell)),
+    )
+
+
+@wp.func
+def _mix64(x: wp.uint64) -> wp.uint64:
+    """splitmix64-style finalizer; good avalanche for spatial cell keys."""
+    x = x ^ (x >> wp.uint64(33))
+    x = x * wp.uint64(0xFF51AFD7ED558CCD)
+    x = x ^ (x >> wp.uint64(33))
+    x = x * wp.uint64(0xC4CEB9FE1A85EC53)
+    x = x ^ (x >> wp.uint64(33))
+    return x
+
+
+@wp.func
+def _hash_sparse_cell(batch: wp.int32, cell: wp.vec3i) -> wp.uint64:
+    """Hash a ``(batch, cx, cy, cz)`` cell key to 64 bits.
+
+    The hash is *not* the cell identity: every insert/lookup compares the exact
+    tuple, so hash collisions stay correct (they only cost extra probes).
+    """
+    xy = wp.uint64(wp.uint32(cell[0])) | (
+        wp.uint64(wp.uint32(cell[1])) << wp.uint64(32)
+    )
+    zb = wp.uint64(wp.uint32(cell[2])) | (
+        wp.uint64(wp.uint32(batch)) << wp.uint64(32)
+    )
+    return _mix64(xy ^ _mix64(zb))
+
+
+@wp.func
+def _decode_neighbor_offset_27(neighbor: wp.int32) -> wp.vec3i:
+    """Decode one standard near-to-far 27-cell offset without a memory load."""
+    shift = wp.int64(2 * neighbor)
+    mask = wp.int64(3)
+    offset_x = wp.int32((_NEIGHBOR_X_2BIT >> shift) & mask) - 1
+    offset_y = wp.int32((_NEIGHBOR_Y_2BIT >> shift) & mask) - 1
+    offset_z = wp.int32((_NEIGHBOR_Z_2BIT >> shift) & mask) - 1
+    return wp.vec3i(offset_x, offset_y, offset_z)
+
+
+# ---------------------------------------------------------------------------
+# Native warp helpers (ballot compaction + int32 broadcast)
+# ---------------------------------------------------------------------------
+
+
+@wp.func_native(
+    """
+#if defined(__CUDA_ARCH__)
+    const unsigned hit_mask = __ballot_sync(0xffffffffu, hit != 0);
+    const unsigned lower_lane_mask =
+        (1u << static_cast<unsigned>(lane)) - 1u;
+    return wp::vec2i(
+        __popc(hit_mask & lower_lane_mask),
+        __popc(hit_mask)
+    );
+#else
+    return wp::vec2i(0, hit != 0 ? 1 : 0);
+#endif
+    """
+)
+def _warp_hit_prefix_and_count(hit: wp.int32, lane: wp.int32) -> wp.vec2i:
+    """Return ``(exclusive hit prefix, total warp hits)`` for one lane."""
+    ...
+
+
+@wp.func_native(
+    """
+#if defined(__CUDA_ARCH__)
+    return __shfl_sync(0xffffffffu, value, source_lane);
+#else
+    return value;
+#endif
+    """
+)
+def _warp_broadcast_i32(value: wp.int32, source_lane: wp.int32) -> wp.int32:
+    """Broadcast ``value`` from ``source_lane`` to all lanes in the warp."""
+    ...
+
+
+# ---------------------------------------------------------------------------
+# Search-time hash lookup
+# ---------------------------------------------------------------------------
+
+
+@wp.func
+def _lookup_sparse_cell(
+    batch: wp.int32,
+    cell: wp.vec3i,
+    hash_capacity: wp.int32,
+    cell_rep_plus1: wp.array(dtype=wp.int32),
+    cell_coords: wp.array(dtype=wp.vec4i),
+) -> wp.int32:
+    """Open-addressed probe for an occupied cell; ``-1`` if absent.
+
+    ``cell_rep_plus1[slot] == 0`` marks an empty slot and terminates the probe
+    (linear probing keeps a cell's whole run contiguous, so the first empty
+    slot proves the cell was never inserted).
+    """
+    mask = hash_capacity - 1
+    slot = wp.int32(_hash_sparse_cell(batch, cell) & wp.uint64(mask))
+
+    probe = wp.int32(0)
+    while probe < hash_capacity:
+        if cell_rep_plus1[slot] == 0:
+            return wp.int32(-1)
+
+        stored = cell_coords[slot]
+        if (
+            stored[0] == batch
+            and stored[1] == cell[0]
+            and stored[2] == cell[1]
+            and stored[3] == cell[2]
+        ):
+            return slot
+
+        slot = (slot + 1) & mask
+        probe += 1
+
+    return wp.int32(-1)
+
+
+# ---------------------------------------------------------------------------
+# Build: count + hash construction
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def sparse_count_cells_kernel(
+    points: wp.array2d(dtype=wp.vec3),
+    inv_cell: wp.float32,
+    P: wp.int32,
+    hash_capacity: wp.int32,
+    cell_rep_plus1: wp.array(dtype=wp.int32),
+    cell_count: wp.array(dtype=wp.int32),
+    cell_coords: wp.array(dtype=wp.vec4i),
+    point_slot: wp.array(dtype=wp.int32),
+    point_rank: wp.array(dtype=wp.int32),
+):
+    """Insert each point's cell into the hash table and count per-slot points.
+
+    Lock-free insert: a thread claims an empty slot with ``atomic_cas`` writing
+    ``flat + 1`` (a nonzero sentinel that shares the zero-cleared allocation).
+    On a CAS miss it re-derives the incumbent's cell from ``points[]`` -- never
+    from ``cell_coords`` (which the winner may not have published yet) -- and
+    compares the exact tuple, so the insert is race-safe without a fence.
+    """
+    flat = wp.tid()
+    batch = flat // P
+    local_point = flat - batch * P
+
+    point = points[batch, local_point]
+    cell = _quantize_cell(point, inv_cell)
+
+    mask = hash_capacity - 1
+    slot = wp.int32(_hash_sparse_cell(batch, cell) & wp.uint64(mask))
+
+    resolved_slot = wp.int32(-1)
+    probe = wp.int32(0)
+    while probe < hash_capacity:
+        old_plus1 = wp.atomic_cas(cell_rep_plus1, slot, wp.int32(0), flat + 1)
+
+        if old_plus1 == 0:
+            # This thread created the cell; publish its coordinates.
+            cell_coords[slot] = wp.vec4i(batch, cell[0], cell[1], cell[2])
+            resolved_slot = slot
+            break
+
+        # Re-derive the incumbent's cell from points[] (its cell_coords write may
+        # not be visible yet). This makes the insert correct without a fence.
+        representative = old_plus1 - 1
+        rep_batch = representative // P
+        rep_local = representative - rep_batch * P
+        rep_point = points[rep_batch, rep_local]
+        rep_cell = _quantize_cell(rep_point, inv_cell)
+
+        if (
+            rep_batch == batch
+            and rep_cell[0] == cell[0]
+            and rep_cell[1] == cell[1]
+            and rep_cell[2] == cell[2]
+        ):
+            resolved_slot = slot
+            break
+
+        slot = (slot + 1) & mask
+        probe += 1
+
+    # H >= 2*Np guarantees a free slot is always found before probe exhausts,
+    # so resolved_slot is always in [0, H). The guard keeps a hypothetical
+    # table-full case a well-defined no-op instead of a cell_count[-1] OOB.
+    point_slot[flat] = resolved_slot
+    if resolved_slot >= 0:
+        # Capture the intra-cell rank handed out by this atomic so scatter can
+        # compute its destination as cell_offsets[slot] + rank directly, with no
+        # second write-cursor atomic and no cell_offsets clone.
+        rank = wp.atomic_add(cell_count, resolved_slot, wp.int32(1))
+        point_rank[flat] = rank
+
+
+# ---------------------------------------------------------------------------
+# Build: scatter points into cell-contiguous SoA
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def sparse_scatter_points_kernel(
+    points: wp.array2d(dtype=wp.vec3),
+    P: wp.int32,
+    point_slot: wp.array(dtype=wp.int32),
+    point_rank: wp.array(dtype=wp.int32),
+    cell_offsets: wp.array(dtype=wp.int32),
+    pc_x: wp.array(dtype=wp.float32),
+    pc_y: wp.array(dtype=wp.float32),
+    pc_z: wp.array(dtype=wp.float32),
+    pc_orig: wp.array(dtype=wp.int32),
+):
+    """Compact points into cell-contiguous order using precomputed intra-cell ranks.
+
+    ``point_rank[flat]`` is the rank the count kernel handed out for this point
+    within its cell, and ``cell_offsets[slot]`` is that cell's exclusive CSR
+    start. Their sum is the point's unique destination -- no scatter-phase
+    atomic and no ``cell_offsets`` clone. ``cell_offsets`` stays immutable so it
+    serves directly as the CSR start array (``cell_offsets[slot] ..
+    cell_offsets[slot + 1]``) at search time.
+    """
+    flat = wp.tid()
+    batch = flat // P
+    local_point = flat - batch * P
+
+    slot = point_slot[flat]
+    if slot < 0:
+        return
+
+    destination = cell_offsets[slot] + point_rank[flat]
+
+    point = points[batch, local_point]
+    pc_x[destination] = point[0]
+    pc_y[destination] = point[1]
+    pc_z[destination] = point[2]
+    pc_orig[destination] = local_point
+
+
+# ---------------------------------------------------------------------------
+# Search: one warp per query
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False, launch_bounds=FMA_WARP_SIZE)
+def radius_search_sparse_fma_kernel(
+    queries: wp.array2d(dtype=wp.vec3),
+    Q: wp.int32,
+    inv_cell: wp.float32,
+    radius2: wp.float32,
+    hash_capacity: wp.int32,
+    cell_rep_plus1: wp.array(dtype=wp.int32),
+    cell_coords: wp.array(dtype=wp.vec4i),
+    cell_offsets: wp.array(dtype=wp.int32),
+    pc_x: wp.array(dtype=wp.float32),
+    pc_y: wp.array(dtype=wp.float32),
+    pc_z: wp.array(dtype=wp.float32),
+    pc_orig: wp.array(dtype=wp.int32),
+    max_points: wp.int32,
+    return_dists: wp.bool,
+    return_points: wp.bool,
+    out_idx: wp.array2d(dtype=wp.int32),
+    out_count: wp.array(dtype=wp.int32),
+    out_dist: wp.array2d(dtype=wp.float32),
+    out_pts: wp.array2d(dtype=wp.vec3),
+):
+    """One 32-lane warp per query; lane-0 hash probe, all lanes scan the cell.
+
+    Mirrors the dense v2 FMA search (coalesced unit-stride point loads, native
+    ballot compaction, ``max_points`` check every 32 candidates). The only
+    change is that the neighbour cell's point range comes from a lane-0 hash
+    probe broadcast to the warp instead of a dense-row lookup. Output padding
+    is fused into this kernel so no separate memset launch is needed.
+    """
+    flat_query, lane = wp.tid()
+
+    batch = flat_query // Q
+    local_query = flat_query - batch * Q
+    query = queries[batch, local_query]
+
+    query_cell = _quantize_cell(query, inv_cell)
+
+    # Fuse output-padding initialisation (strided across the warp).
+    output_slot = lane
+    while output_slot < max_points:
+        out_idx[flat_query, output_slot] = 0
+        if return_dists:
+            out_dist[flat_query, output_slot] = 0.0
+        if return_points:
+            out_pts[flat_query, output_slot] = wp.vec3(0.0)
+        output_slot += FMA_WARP_SIZE
+
+    found = wp.int32(0)
+
+    for neighbor in range(27):
+        offset = _decode_neighbor_offset_27(neighbor)
+        neighbor_cell = wp.vec3i(
+            query_cell[0] + offset[0],
+            query_cell[1] + offset[1],
+            query_cell[2] + offset[2],
+        )
+
+        # Only lane zero walks the probe sequence; broadcast the result.
+        cell_slot = wp.int32(-1)
+        if lane == 0:
+            cell_slot = _lookup_sparse_cell(
+                batch, neighbor_cell, hash_capacity, cell_rep_plus1, cell_coords
+            )
+        cell_slot = _warp_broadcast_i32(cell_slot, wp.int32(0))
+
+        if cell_slot >= 0:
+            point_begin = wp.int32(0)
+            point_end = wp.int32(0)
+            if lane == 0:
+                point_begin = cell_offsets[cell_slot]
+                point_end = cell_offsets[cell_slot + 1]
+            point_begin = _warp_broadcast_i32(point_begin, wp.int32(0))
+            point_end = _warp_broadcast_i32(point_end, wp.int32(0))
+
+            chunk_begin = point_begin
+            while chunk_begin < point_end:
+                point_index = chunk_begin + lane
+                point_valid = point_index < point_end
+
+                hit = wp.int32(0)
+                distance2 = wp.float32(0.0)
+                point_x = wp.float32(0.0)
+                point_y = wp.float32(0.0)
+                point_z = wp.float32(0.0)
+
+                if point_valid:
+                    point_x = pc_x[point_index]
+                    point_y = pc_y[point_index]
+                    point_z = pc_z[point_index]
+                    dx = point_x - query[0]
+                    dy = point_y - query[1]
+                    dz = point_z - query[2]
+                    distance2 = dx * dx + dy * dy + dz * dz
+                    if distance2 <= radius2:
+                        hit = wp.int32(1)
+
+                compact = _warp_hit_prefix_and_count(hit, lane)
+                hit_prefix = compact[0]
+                chunk_hits = compact[1]
+                accepted_hits = wp.min(chunk_hits, max_points - found)
+
+                if hit == 1 and hit_prefix < accepted_hits:
+                    destination = found + hit_prefix
+                    out_idx[flat_query, destination] = pc_orig[point_index]
+                    if return_dists:
+                        out_dist[flat_query, destination] = wp.sqrt(distance2)
+                    if return_points:
+                        out_pts[flat_query, destination] = wp.vec3(
+                            point_x, point_y, point_z
+                        )
+
+                found += accepted_hits
+                if found >= max_points:
+                    break
+                chunk_begin += FMA_WARP_SIZE
+
+        if found >= max_points:
+            break
+
+    if lane == 0:
+        out_count[flat_query] = found

--- a/physicsnemo/nn/functional/neighbors/radius_search/_warp_impl.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/_warp_impl.py
@@ -23,6 +23,7 @@ and not warp.  So, tensor creation and allocation is driven by torch, and
 passed to warp for computation.
 """
 
+import os
 from typing import List
 
 import torch
@@ -31,11 +32,13 @@ import warp as wp
 from physicsnemo.core.function_spec import FunctionSpec
 
 from .kernels import (
+    compute_morton_codes,
     radius_search_count,
     radius_search_limited_select_batched,
     radius_search_unlimited_select,
     scatter_add_batched,
     scatter_add_unlimited,
+    tiled_bvh_radius_search,
 )
 from .utils import format_returns, validate_inputs
 
@@ -44,6 +47,90 @@ wp.config.log_level = wp.LOG_WARNING
 wp.init()
 
 BLOCK_DIM = 32
+
+# Threads per block for the cooperative (tiled) BVH ball-query kernel. Each
+# thread block handles one (batch, query) pair and its TILE_DIM lanes traverse
+# the BVH together. compute-sanitizer traced an out-of-bounds __shared__ read in
+# Warp's tiled BVH machinery from the upper lanes of a 64-wide block on real
+# (clustered) geometry, so we use 32 here.
+TILE_DIM = 32
+
+
+def _use_bvh_radius_search() -> bool:
+    """Whether the Morton-ordered tiled-BVH backend is enabled.
+
+    Controlled by the ``PHYSICSNEMO_RADIUS_SEARCH_BVH`` environment variable
+    (default off). When enabled, the warp ``max_points`` path runs the tiled
+    BVH kernel on CUDA inputs instead of the hash-grid kernel; CPU inputs and
+    the ``max_points=None`` path always use the hash-grid implementation.
+    """
+    return os.environ.get("PHYSICSNEMO_RADIUS_SEARCH_BVH", "0").strip().lower() not in (
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+_MORTON_VARIANTS = (
+    "scalar",
+    "fma",
+    "gemm",
+    "dense_fma",
+    "dense_fma_e2e",
+    "dense_fma_store_opt",
+    "dense_fma_mem_opt",
+    "dense_fma_mm",
+    "dense_gemm",
+    "custom_grid_cell",
+    "custom_grid_cell_2",
+    "sparse_fma_e2e",
+)
+_MORTON_DENSE_VARIANTS = (
+    "dense_fma",
+    "dense_fma_e2e",
+    "dense_fma_store_opt",
+    "dense_fma_mem_opt",
+    "dense_fma_mm",
+    "dense_gemm",
+    "custom_grid_cell",
+    "custom_grid_cell_2",
+)
+
+# All backend variants that ``radius_search(implementation=...)`` can select
+# which are routed through this Warp custom op (so they share its registered
+# autograd backward): every Morton variant plus the tiled-BVH backend.
+# Used by the dispatch layer to translate an ``implementation`` name into an
+# explicit ``variant`` argument for the custom op.
+_WARP_VARIANTS = _MORTON_VARIANTS + ("bvh",)
+
+
+def _morton_variant() -> str | None:
+    """Selected Morton radius-search variant, or ``None`` when disabled.
+
+    Controlled by the ``PHYSICSNEMO_RADIUS_SEARCH_MORTON`` environment variable.
+    Hash-based variants are ``scalar`` (Function A), ``fma`` (Function B1), and
+    ``gemm`` (Function B2). Dense-cell variants are ``dense_fma`` (one warp per
+    query) and ``dense_gemm`` (tiled matmul benchmark). ``dense_fma_e2e`` is the
+    sort-free ``dense_fma`` (row-major cell bins + unsorted queries, no radix
+    sort). ``sparse_fma_e2e`` is the sparse-hash-grid counterpart of
+    ``dense_fma_e2e``: cells are stored in an open-addressed hash table instead of
+    a dense grid, so memory scales with occupied cells rather than the bounding
+    box. Anything else (including unset) disables the Morton path.
+    """
+    value = os.environ.get("PHYSICSNEMO_RADIUS_SEARCH_MORTON", "").strip().lower()
+    return value if value in _MORTON_VARIANTS else None
+
+
+def _use_morton_radius_search() -> bool:
+    """Whether the Morton-grid radius-search backend is enabled (env-gated).
+
+    When enabled, the warp ``max_points`` path on CUDA inputs runs the selected
+    Morton variant instead of the hash-grid kernel; CPU inputs and the
+    ``max_points=None`` path always use the hash-grid implementation.
+    """
+    return _morton_variant() is not None
 
 
 def count_neighbors(
@@ -67,14 +154,12 @@ def count_neighbors(
         wp_launch_stream (wp.Stream | None): The stream to launch the kernel on.
         radius (float): The radius that bounds the search.
         N_queries (int): Total number of query points.
-        sync (bool): If True, copies count to CPU and returns
-            ``(int, torch_offset)``. If False, returns
-            ``(gpu_count_tensor, torch_offset)`` for batched sync.
+        sync (bool): If True, copies count to CPU and returns (int, wp_offset).
+            If False, returns (gpu_count_tensor, wp_offset) for batched sync.
 
     Returns:
-        When sync=True: tuple[int, torch.Tensor] -- total count and int64 offsets.
-        When sync=False: tuple[torch.Tensor, torch.Tensor] -- GPU-side count
-        tensor and int64 offsets.
+        When sync=True: tuple[int, wp.array] -- total count and offset array.
+        When sync=False: tuple[torch.Tensor, wp.array] -- GPU-side count tensor and offset array.
     """
     wp_result_count = wp.zeros(N_queries, device=wp_points.device, dtype=wp.int32)
 
@@ -88,26 +173,19 @@ def count_neighbors(
         block_dim=BLOCK_DIM,
     )
 
+    wp_offset = wp.zeros(N_queries + 1, device=wp_points.device, dtype=wp.int32)
+    torch_offset = wp.to_torch(wp_offset)
     torch_result_count = wp.to_torch(wp_result_count)
-    torch_offset_64 = torch.empty(
-        N_queries + 1, device=torch_result_count.device, dtype=torch.int64
-    )
-    torch_offset_64[0] = 0
-    torch.cumsum(
-        torch_result_count,
-        dim=0,
-        dtype=torch.int64,
-        out=torch_offset_64[1:],
-    )
+    torch.cumsum(torch_result_count, dim=0, out=torch_offset[1:])
 
     if sync:
         pin_memory = torch.cuda.is_available()
-        pinned_buffer = torch.zeros(1, dtype=torch.int64, pin_memory=pin_memory)
-        pinned_buffer.copy_(torch_offset_64[-1:])
-        return pinned_buffer.item(), torch_offset_64
+        pinned_buffer = torch.zeros(1, dtype=torch.int32, pin_memory=pin_memory)
+        pinned_buffer.copy_(torch_offset[-1:])
+        return pinned_buffer.item(), wp_offset
 
     # Return the last element as a 1-element GPU tensor for batch-sync later
-    return torch_offset_64[-1:], torch_offset_64
+    return torch_offset[-1:], wp_offset
 
 
 def gather_neighbors(
@@ -192,6 +270,7 @@ def radius_search_impl(
     max_points: int | None = None,
     return_dists: bool = False,
     return_points: bool = False,
+    variant: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Find and return the nearest neighbors in `points` using locations from `queries`.
@@ -209,6 +288,11 @@ def radius_search_impl(
         max_points (int | None, optional): The maximum number of points to return per query. If None, unlimited.
         return_dists (bool, optional): Whether to return the distances of the neighbors.
         return_points (bool, optional): Whether to return the points of the neighbors.
+        variant (str | None, optional): Explicit backend variant to run on the CUDA
+            ``max_points`` path (one of :data:`_WARP_VARIANTS`: the Morton
+            variants or ``"bvh"``). When None, falls back to the
+            ``PHYSICSNEMO_RADIUS_SEARCH_MORTON`` / ``PHYSICSNEMO_RADIUS_SEARCH_BVH``
+            env vars, else the default hash-grid kernel.
 
     Returns:
         tuple[torch.Tensor, ...]: (indices, points, distances, num_neighbors)
@@ -216,6 +300,69 @@ def radius_search_impl(
 
     if points.device != queries.device:
         raise ValueError("points and queries must be on the same device")
+
+    # Optional fast paths (CUDA-only, deterministic max_points path). An explicit
+    # ``variant`` argument -- threaded from ``radius_search(implementation=...)``
+    # -- selects the backend and takes precedence over the
+    # ``PHYSICSNEMO_RADIUS_SEARCH_*`` env-var fallbacks. Each helper below handles
+    # validation/casting/batch-squeezing and returns the same
+    # (indices, points, distances, num_neighbors) tuple, so the registered
+    # autograd backward and the fake (torch.compile) path are unaffected.
+    if max_points is not None and points.is_cuda:
+        # ``_morton_variant()`` only ever returns a value in ``_MORTON_VARIANTS``,
+        # so the env fallback stays within the hash/dense Morton family; an
+        # explicit ``variant`` may additionally be ``"bvh"``, which is handled by
+        # the tiled-BVH branch below. Morton is checked before BVH so it takes
+        # precedence when both env flags are set.
+        morton_variant = variant if variant is not None else _morton_variant()
+
+        if morton_variant == "sparse_fma_e2e":
+            from ._sparse_hash_impl import radius_search_sparse_fma_e2e
+
+            return radius_search_sparse_fma_e2e(
+                points,
+                queries,
+                radius,
+                max_points,
+                return_dists,
+                return_points,
+            )
+
+        if morton_variant in _MORTON_DENSE_VARIANTS:
+            from ._morton_dense_impl import radius_search_morton_dense
+
+            return radius_search_morton_dense(
+                points,
+                queries,
+                radius,
+                max_points,
+                return_dists,
+                return_points,
+                variant=morton_variant,
+            )
+
+        if morton_variant in _MORTON_VARIANTS:
+            from ._morton_impl import radius_search_morton
+
+            return radius_search_morton(
+                points,
+                queries,
+                radius,
+                max_points,
+                return_dists,
+                return_points,
+                variant=morton_variant,
+            )
+
+        # Morton-ordered tiled-BVH ball query. Explicit ``variant="bvh"`` wins;
+        # otherwise fall back to the ``PHYSICSNEMO_RADIUS_SEARCH_BVH`` env flag.
+        use_bvh = (
+            (variant == "bvh") if variant is not None else _use_bvh_radius_search()
+        )
+        if use_bvh:
+            return radius_search_bvh(
+                points, queries, radius, max_points, return_dists, return_points
+            )
 
     points, queries, was_unbatched = validate_inputs(points, queries)
     B = points.shape[0]
@@ -232,7 +379,7 @@ def radius_search_impl(
     # Compute follows data.
     wp_launch_device, wp_launch_stream = FunctionSpec.warp_launch_context(points)
 
-    with FunctionSpec.warp_stream_scope(wp_launch_stream):
+    with wp.ScopedStream(wp_launch_stream):
         # Build one hash grid per batch element (Python loop)
         grids = []
         wp_points_per_b = []
@@ -242,9 +389,13 @@ def radius_search_impl(
             qrs_b = queries[b].contiguous()
             wp_pts_b = wp.from_torch(pts_b, dtype=wp.vec3)
             wp_qrs_b = wp.from_torch(qrs_b, dtype=wp.vec3, return_ctype=True)
+            torch.cuda.nvtx.range_push('HASH GRID')
             grid = wp.HashGrid(dim_x=128, dim_y=128, dim_z=128, device=wp_pts_b.device)
+            torch.cuda.nvtx.range_pop()
             grid.reserve(N_queries)
-            grid.build(points=wp_pts_b, radius=0.5 * radius)
+            torch.cuda.nvtx.range_push('grid build')
+            grid.build(points=wp_pts_b, radius=radius)
+            torch.cuda.nvtx.range_pop()
             grids.append(grid)
             wp_points_per_b.append(wp_pts_b)
             wp_queries_per_b.append(wp_qrs_b)
@@ -256,9 +407,10 @@ def radius_search_impl(
 
             # Count pass: collect all counts without syncing individually
             count_tensors = []
-            offset_tensors = []
+            wp_offsets = []
             for b in range(B):
-                count_t, offsets = count_neighbors(
+                torch.cuda.nvtx.range_push(f'COUNT NEIGHBOURS_{b}')
+                count_t, wp_off = count_neighbors(
                     grids[b],
                     wp_points_per_b[b],
                     wp_queries_per_b[b],
@@ -268,8 +420,9 @@ def radius_search_impl(
                     N_queries,
                     sync=(B == 1),
                 )
+                torch.cuda.nvtx.range_pop()
                 count_tensors.append(count_t)
-                offset_tensors.append(offsets)
+                wp_offsets.append(wp_off)
 
             # Sync: for B==1 count_tensors[0] is already an int;
             # for B>1 we batch-sync all GPU tensors at once
@@ -278,30 +431,22 @@ def radius_search_impl(
             else:
                 gpu_counts = torch.cat(count_tensors, dim=0)
                 pin_memory = torch.cuda.is_available()
-                cpu_counts = torch.zeros(B, dtype=torch.int64, pin_memory=pin_memory)
+                cpu_counts = torch.zeros(B, dtype=torch.int32, pin_memory=pin_memory)
                 cpu_counts.copy_(gpu_counts)
                 total_counts = cpu_counts.tolist()
 
             for tc in total_counts:
-                if tc >= torch.iinfo(torch.int32).max:
+                if not tc < 2**31 - 1:
                     raise RuntimeError(
                         f"Total found neighbors is too large: {tc} >= 2**31 - 1"
                     )
-
-            # The kernels use int32 offsets. Cast only after every int64 total
-            # has passed the range check above.
-            offset_tensors_i32 = [
-                offsets.to(dtype=torch.int32) for offsets in offset_tensors
-            ]
-            wp_offsets = [
-                wp.from_torch(offsets, dtype=wp.int32) for offsets in offset_tensors_i32
-            ]
 
             # Gather per batch element, concatenate with batch indices
             all_indices = []
             all_pts = []
             all_dists = []
             for b in range(B):
+                torch.cuda.nvtx.range_push(f'Gather NEIGHBOURS_{b}')
                 idx_b, pts_b, dist_b, _ = gather_neighbors(
                     grids[b],
                     points.device,
@@ -316,6 +461,7 @@ def radius_search_impl(
                     return_points,
                     total_counts[b],
                 )
+                torch.cuda.nvtx.range_pop()
                 # idx_b: (2, count_b); prepend batch-index row
                 batch_row = torch.full(
                     (1, idx_b.shape[1]),
@@ -341,15 +487,10 @@ def radius_search_impl(
             # Deterministic output path: always use batched 2D kernel launch
             # ---------------------------------------------------------------
 
-            # Build warp array of grid IDs.
-            # Construct in pinned host memory first so the H2D copy is
-            # stream-ordered (non_blocking) rather than a blocking cudaMemcpy.
-            _grid_ids_cpu = torch.tensor(
-                [g.id for g in grids],
-                dtype=torch.int64,
-                pin_memory=torch.cuda.is_available(),
+            # Build warp array of grid IDs
+            grid_ids_tensor = torch.tensor(
+                [g.id for g in grids], dtype=torch.int64, device=points.device
             )
-            grid_ids_tensor = _grid_ids_cpu.to(points.device, non_blocking=True)
             wp_grid_ids = wp.from_torch(
                 grid_ids_tensor, dtype=wp.uint64, return_ctype=True
             )
@@ -398,7 +539,7 @@ def radius_search_impl(
                     dtype=torch.float32,
                     device=points.device,
                 )
-
+            torch.cuda.nvtx.range_push(f'radius search nvtx push')
             wp.launch(
                 kernel=radius_search_limited_select_batched,
                 dim=(B, N_queries),
@@ -418,8 +559,9 @@ def radius_search_impl(
                     else None,
                 ],
                 stream=wp_launch_stream,
-                device=wp_launch_device,
+                device=wp_launch_device
             )
+            torch.cuda.nvtx.range_pop()
 
             if was_unbatched:
                 indices = indices.squeeze(0)
@@ -444,10 +586,14 @@ def radius_search_impl_fake(
     max_points: int | None = None,
     return_dists: bool = False,
     return_points: bool = False,
+    variant: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Fake implementation for torch.compile/fake tensor support.
     Handles both unbatched (N, 3) and batched (B, N, 3) inputs.
+
+    ``variant`` only affects the concrete kernel chosen at runtime, not output
+    shapes/dtypes, so it is accepted for signature parity and otherwise ignored.
     """
 
     if max_points is not None:
@@ -509,7 +655,7 @@ def setup_radius_search_context(
         inputs (tuple): The input arguments to the forward function.
         output (tuple): The output tensors from the forward function.
     """
-    points, queries, radius, max_points, return_dists, return_points = inputs
+    points, queries, radius, max_points, return_dists, return_points, variant = inputs
 
     indexes, ret_points, distances, num_neighbors = output
 
@@ -559,7 +705,9 @@ def backward_radius_search(
     else:
         point_grads = None
 
-    return point_grads, None, None, None, None, None
+    # One grad per forward input: points, queries, radius, max_points,
+    # return_dists, return_points, variant.
+    return point_grads, None, None, None, None, None, None
 
 
 @torch.library.custom_op(
@@ -604,85 +752,82 @@ def apply_grad_to_points(
     if max_points is not None and not num_neighbors.is_contiguous():
         num_neighbors = num_neighbors.contiguous()
 
-    with FunctionSpec.warp_stream_scope(wp_launch_stream):
-        if max_points is None:
-            # Dynamic path: indexes is (2, total) unbatched or (3, total) batched.
-            # scatter_add_unlimited works on flat (N, 3) grad tensors, so we loop
-            # over batch elements (trivially 1 iteration for unbatched).
-            if indexes.shape[-1] > 0:
-                if indexes.shape[0] == 3:
-                    # Batched: row 0 is batch index, rows 1-2 are query/point indices
-                    B = point_grads.shape[0]
-                    for b_idx in range(B):
-                        mask = indexes[0] == b_idx
-                        b_indexes = indexes[1:, mask]
-                        b_grad_out = grad_points_out[mask]
-                        if b_indexes.shape[1] > 0:
-                            wp.launch(
-                                kernel=scatter_add_unlimited,
-                                dim=b_indexes.shape[1],
-                                inputs=[
-                                    wp.from_torch(
-                                        b_indexes, dtype=wp.int32, return_ctype=True
-                                    ),
-                                    wp.from_torch(
-                                        b_grad_out, dtype=wp.vec3, return_ctype=True
-                                    ),
-                                    wp.from_torch(
-                                        point_grads[b_idx],
-                                        dtype=wp.vec3,
-                                        return_ctype=True,
-                                    ),
-                                ],
-                                device=wp_launch_device,
-                                stream=wp_launch_stream,
-                                block_dim=BLOCK_DIM,
-                            )
-                else:
-                    # Unbatched: rows 0-1 are query/point indices
-                    wp.launch(
-                        kernel=scatter_add_unlimited,
-                        dim=indexes.shape[1],
-                        inputs=[
-                            wp.from_torch(indexes, dtype=wp.int32, return_ctype=True),
-                            wp.from_torch(
-                                grad_points_out, dtype=wp.vec3, return_ctype=True
-                            ),
-                            wp.from_torch(
-                                point_grads, dtype=wp.vec3, return_ctype=True
-                            ),
-                        ],
-                        device=wp_launch_device,
-                        stream=wp_launch_stream,
-                        block_dim=BLOCK_DIM,
-                    )
+    if max_points is None:
+        # Dynamic path: indexes is (2, total) unbatched or (3, total) batched.
+        # scatter_add_unlimited works on flat (N, 3) grad tensors, so we loop
+        # over batch elements (trivially 1 iteration for unbatched).
+        if indexes.shape[-1] > 0:
+            if indexes.shape[0] == 3:
+                # Batched: row 0 is batch index, rows 1-2 are query/point indices
+                B = point_grads.shape[0]
+                for b_idx in range(B):
+                    mask = indexes[0] == b_idx
+                    b_indexes = indexes[1:, mask]
+                    b_grad_out = grad_points_out[mask]
+                    if b_indexes.shape[1] > 0:
+                        wp.launch(
+                            kernel=scatter_add_unlimited,
+                            dim=b_indexes.shape[1],
+                            inputs=[
+                                wp.from_torch(
+                                    b_indexes, dtype=wp.int32, return_ctype=True
+                                ),
+                                wp.from_torch(
+                                    b_grad_out, dtype=wp.vec3, return_ctype=True
+                                ),
+                                wp.from_torch(
+                                    point_grads[b_idx],
+                                    dtype=wp.vec3,
+                                    return_ctype=True,
+                                ),
+                            ],
+                            device=wp_launch_device,
+                            stream=wp_launch_stream,
+                            block_dim=BLOCK_DIM,
+                        )
+            else:
+                # Unbatched: rows 0-1 are query/point indices
+                wp.launch(
+                    kernel=scatter_add_unlimited,
+                    dim=indexes.shape[1],
+                    inputs=[
+                        wp.from_torch(indexes, dtype=wp.int32, return_ctype=True),
+                        wp.from_torch(
+                            grad_points_out, dtype=wp.vec3, return_ctype=True
+                        ),
+                        wp.from_torch(point_grads, dtype=wp.vec3, return_ctype=True),
+                    ],
+                    device=wp_launch_device,
+                    stream=wp_launch_stream,
+                    block_dim=BLOCK_DIM,
+                )
 
-        else:
-            # Deterministic path: always use batched kernel.
-            # Unsqueeze 2D tensors to 3D so we can use a single kernel variant.
-            if indexes.ndim == 2:
-                indexes = indexes.unsqueeze(0)
-                num_neighbors = num_neighbors.unsqueeze(0)
-                grad_points_out = grad_points_out.unsqueeze(0)
-                point_grads = point_grads.unsqueeze(0)
+    else:
+        # Deterministic path: always use batched kernel.
+        # Unsqueeze 2D tensors to 3D so we can use a single kernel variant.
+        if indexes.ndim == 2:
+            indexes = indexes.unsqueeze(0)
+            num_neighbors = num_neighbors.unsqueeze(0)
+            grad_points_out = grad_points_out.unsqueeze(0)
+            point_grads = point_grads.unsqueeze(0)
 
-            B = indexes.shape[0]
-            wp.launch(
-                kernel=scatter_add_batched,
-                dim=(B, indexes.shape[1]),
-                inputs=[
-                    wp.from_torch(indexes, dtype=wp.int32, return_ctype=True),
-                    wp.from_torch(num_neighbors, dtype=wp.int32, return_ctype=True),
-                    wp.from_torch(grad_points_out, dtype=wp.vec3, return_ctype=True),
-                    wp.from_torch(point_grads, dtype=wp.vec3, return_ctype=True),
-                ],
-                device=wp_launch_device,
-                stream=wp_launch_stream,
-                block_dim=BLOCK_DIM,
-            )
+        B = indexes.shape[0]
+        wp.launch(
+            kernel=scatter_add_batched,
+            dim=(B, indexes.shape[1]),
+            inputs=[
+                wp.from_torch(indexes, dtype=wp.int32, return_ctype=True),
+                wp.from_torch(num_neighbors, dtype=wp.int32, return_ctype=True),
+                wp.from_torch(grad_points_out, dtype=wp.vec3, return_ctype=True),
+                wp.from_torch(point_grads, dtype=wp.vec3, return_ctype=True),
+            ],
+            device=wp_launch_device,
+            stream=wp_launch_stream,
+            block_dim=BLOCK_DIM,
+        )
 
-            if point_grads.shape[0] == 1 and len(points_shape) == 2:
-                point_grads = point_grads.squeeze(0)
+        if point_grads.shape[0] == 1 and len(points_shape) == 2:
+            point_grads = point_grads.squeeze(0)
 
     return point_grads
 
@@ -727,6 +872,7 @@ def radius_search(
     max_points: int | None = None,
     return_dists: bool = False,
     return_points: bool = False,
+    variant: str | None = None,
 ):
     """
     Perform a radius search between points and queries.
@@ -742,12 +888,281 @@ def radius_search(
         return_dists (bool): Whether to return distances between query and
             neighbor points.
         return_points (bool): Whether to return the neighbor points themselves.
+        variant (str | None): Explicit backend variant for the CUDA ``max_points``
+            path (see :data:`_WARP_VARIANTS`). When None, the
+            ``PHYSICSNEMO_RADIUS_SEARCH_*`` env vars are used as a fallback, else
+            the default hash-grid kernel runs.
 
     Returns:
         The formatted radius search results, whose contents depend on
         ``return_dists`` and ``return_points``.
     """
     indices, points_out, distances, _ = radius_search_impl(
-        points, queries, radius, max_points, return_dists, return_points
+        points, queries, radius, max_points, return_dists, return_points, variant
     )
     return format_returns(indices, points_out, distances, return_dists, return_points)
+
+
+def _morton_permutation(
+    coords: torch.Tensor,
+    bbox_min_wp: wp.array,
+    inv_extent_wp: wp.array,
+    wp_launch_device: wp.Device | None,
+    wp_launch_stream: wp.Stream | None,
+) -> torch.Tensor:
+    """
+    Compute a per-batch Morton-order permutation for a set of coordinates.
+
+    Args:
+        coords (torch.Tensor): Contiguous fp32 coordinates of shape (B, M, 3).
+        bbox_min_wp (wp.array): Per-batch bbox lower corner, warp vec3 array (B,).
+        inv_extent_wp (wp.array): Per-batch reciprocal bbox extent, warp vec3 array (B,).
+        wp_launch_device (wp.Device | None): Device to launch the kernel on.
+        wp_launch_stream (wp.Stream | None): Stream to launch the kernel on.
+
+    Returns:
+        torch.Tensor: Int64 permutation of shape (B, M) sorting each batch by Morton code.
+    """
+    B, M = coords.shape[0], coords.shape[1]
+    codes = torch.empty((B, M), dtype=torch.int32, device=coords.device)
+    wp.launch(
+        kernel=compute_morton_codes,
+        dim=(B, M),
+        inputs=[
+            wp.from_torch(coords, dtype=wp.vec3, return_ctype=True),
+            bbox_min_wp,
+            inv_extent_wp,
+            wp.from_torch(codes, return_ctype=True),
+        ],
+        device=wp_launch_device,
+        stream=wp_launch_stream,
+    )
+    return torch.argsort(codes, dim=1)
+
+
+def radius_search_bvh(
+    points: torch.Tensor,
+    queries: torch.Tensor,
+    radius: float,
+    max_points: int,
+    return_dists: bool = False,
+    return_points: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Morton-ordered, tiled-BVH radius search (standalone; not wired into dispatch).
+
+    This is a drop-in alternative to the ``max_points`` path of
+    :func:`radius_search_impl` intended for testing and benchmarking. It Morton-
+    orders both point clouds and queries for locality, builds one LBVH per batch
+    element, and launches :func:`tiled_bvh_radius_search` as a flattened 1D tile
+    grid so each query is served cooperatively by a thread block via
+    ``wp.tile_bvh_query_aabb``.
+
+    Semantics match :func:`radius_search_limited_select_batched`: up to
+    ``max_points`` first-found neighbors within ``radius`` per query (filtered by
+    exact L2 distance). Outputs are returned in the original (un-permuted) point
+    and query order, with unused slots filled with ``0``.
+
+    Args:
+        points (torch.Tensor): Reference points, (N, 3) or (B, N, 3).
+        queries (torch.Tensor): Query points, (M, 3) or (B, M, 3).
+        radius (float): The search radius.
+        max_points (int): Maximum number of neighbors per query. Must not be None.
+        return_dists (bool, optional): Whether to return neighbor distances.
+        return_points (bool, optional): Whether to return neighbor coordinates.
+
+    Returns:
+        tuple[torch.Tensor, ...]: (indices, points, distances, num_neighbors),
+        mirroring the return contract of :func:`radius_search_impl`.
+    """
+    if points.device != queries.device:
+        raise ValueError("points and queries must be on the same device")
+    if max_points is None:
+        raise ValueError("radius_search_bvh requires max_points to be set (not None)")
+    if points.device.type != "cuda":
+        raise ValueError(
+            "radius_search_bvh requires CUDA tensors; tiled BVH queries are GPU-only"
+        )
+
+    points, queries, was_unbatched = validate_inputs(points, queries)
+    B = points.shape[0]
+    N = points.shape[1]
+    Q = queries.shape[1]
+
+    input_dtype = points.dtype
+
+    # Warp supports only fp32, so we have to cast:
+    if points.dtype != torch.float32:
+        points = points.to(torch.float32)
+    if queries.dtype != torch.float32:
+        queries = queries.to(torch.float32)
+    points = points.contiguous()
+    queries = queries.contiguous()
+
+    # Debug hook: dump the (validated, fp32) inputs of the first call so the exact
+    # failing case can be replayed standalone under compute-sanitizer. The .cpu()
+    # copy forces a sync, so if an *earlier* kernel already faulted the error
+    # surfaces here (attributing it upstream of this op) rather than at the next
+    # warp launch. Enable with PHYSICSNEMO_RADIUS_SEARCH_DUMP=/path/to/inputs.pt.
+    _dump_path = os.environ.get("PHYSICSNEMO_RADIUS_SEARCH_DUMP")
+    if _dump_path and not os.path.exists(_dump_path):
+        torch.save(
+            {
+                "points": points.detach().cpu(),
+                "queries": queries.detach().cpu(),
+                "radius": float(radius),
+                "max_points": int(max_points),
+                "return_dists": bool(return_dists),
+                "return_points": bool(return_points),
+            },
+            _dump_path,
+        )
+        print(f"[radius_search_bvh] dumped inputs -> {_dump_path}", flush=True)
+
+    # Compute follows data.
+    wp_launch_device, wp_launch_stream = FunctionSpec.warp_launch_context(points)
+
+    # Keep references to warp arrays / BVHs alive until after the launch.
+    keep_alive: List[object] = []
+
+    with wp.ScopedStream(wp_launch_stream):
+        # ------------------------------------------------------------------
+        # Morton ordering of points and queries (shared per-batch bbox)
+        # ------------------------------------------------------------------
+        both = torch.cat([points, queries], dim=1)
+        bbox_min = both.amin(dim=1).contiguous()
+        bbox_max = both.amax(dim=1)
+        inv_extent = (1.0 / (bbox_max - bbox_min).clamp_min(1e-12)).contiguous()
+
+        bbox_min_wp = wp.from_torch(bbox_min, dtype=wp.vec3, return_ctype=True)
+        inv_extent_wp = wp.from_torch(inv_extent, dtype=wp.vec3, return_ctype=True)
+
+        point_perm = _morton_permutation(
+            points, bbox_min_wp, inv_extent_wp, wp_launch_device, wp_launch_stream
+        )
+        query_perm = _morton_permutation(
+            queries, bbox_min_wp, inv_extent_wp, wp_launch_device, wp_launch_stream
+        )
+
+        points_sorted = torch.gather(
+            points, 1, point_perm.unsqueeze(-1).expand(B, N, 3)
+        ).contiguous()
+        queries_sorted = torch.gather(
+            queries, 1, query_perm.unsqueeze(-1).expand(B, Q, 3)
+        ).contiguous()
+
+        # ------------------------------------------------------------------
+        # Build one BVH per batch element from degenerate point AABBs
+        # ------------------------------------------------------------------
+        bvhs = []
+        for b in range(B):
+            lower_t = points_sorted[b].contiguous()
+            upper_t = lower_t.clone()
+            lowers = wp.from_torch(lower_t, dtype=wp.vec3)
+            uppers = wp.from_torch(upper_t, dtype=wp.vec3)
+            bvh = wp.Bvh(lowers, uppers, constructor="lbvh")
+            bvhs.append(bvh)
+            keep_alive.extend([lower_t, upper_t, lowers, uppers, bvh])
+
+        bvh_ids_tensor = torch.tensor(
+            [bvh.id for bvh in bvhs], dtype=torch.int64, device=points.device
+        )
+        wp_bvh_ids = wp.from_torch(bvh_ids_tensor, dtype=wp.uint64, return_ctype=True)
+
+        # ------------------------------------------------------------------
+        # Allocate outputs (sorted-query order, holding sorted-point indices)
+        # ------------------------------------------------------------------
+        mapping = torch.zeros(
+            (B, Q, max_points), dtype=torch.int32, device=points.device
+        )
+        num_neighbors = torch.zeros((B, Q), dtype=torch.int32, device=points.device)
+        if return_dists:
+            dists_out = torch.zeros(
+                (B, Q, max_points), dtype=torch.float32, device=points.device
+            )
+        else:
+            dists_out = torch.empty(0, dtype=torch.float32, device=points.device)
+        if return_points:
+            pts_out = torch.zeros(
+                (B, Q, max_points, 3), dtype=torch.float32, device=points.device
+            )
+        else:
+            pts_out = torch.empty(
+                (0, max_points, 3), dtype=torch.float32, device=points.device
+            )
+
+        # Flattened 1D tile grid (B * Q tiles), one thread block per query. A 2D
+        # dim=(B, Q) tiled launch triggers illegal memory accesses; the 1D shape
+        # matches the only tiled-launch form used by Warp's own BVH tests.
+        wp.launch_tiled(
+            kernel=tiled_bvh_radius_search,
+            dim=B * Q,
+            inputs=[
+                wp_bvh_ids,
+                wp.from_torch(points_sorted, dtype=wp.vec3, return_ctype=True),
+                wp.from_torch(queries_sorted, dtype=wp.vec3, return_ctype=True),
+                max_points,
+                radius,
+                wp.from_torch(mapping, return_ctype=True),
+                wp.from_torch(num_neighbors, return_ctype=True),
+                return_dists,
+                wp.from_torch(dists_out, return_ctype=True),
+                return_points,
+                wp.from_torch(pts_out, dtype=wp.vec3, return_ctype=True)
+                if return_points
+                else None,
+            ],
+            block_dim=16,
+            device=wp_launch_device,
+            stream=wp_launch_stream,
+        )
+
+    # ----------------------------------------------------------------------
+    # Remap outputs back to the original point / query ordering
+    # ----------------------------------------------------------------------
+    # The kernel uses an atomic counter, so num_neighbors can exceed max_points
+    # when more candidates fall within radius than there are output slots; clamp
+    # it to the cap (slots past max_points were not written).
+    num_neighbors = num_neighbors.clamp(max=max_points)
+
+    # Sorted-point indices -> original point indices; keep 0 sentinel for unused
+    # slots (those at or beyond num_neighbors).
+    valid_mask = torch.arange(max_points, device=points.device).view(
+        1, 1, max_points
+    ) < num_neighbors.unsqueeze(-1)
+    mapping_orig = (
+        torch.gather(point_perm, 1, mapping.long().reshape(B, Q * max_points))
+        .reshape(B, Q, max_points)
+        .to(torch.int32)
+    )
+    mapping_orig = mapping_orig.masked_fill(~valid_mask, 0)
+
+    # Un-permute query rows (sorted-query order -> original order).
+    inv_query_perm = torch.argsort(query_perm, dim=1)
+
+    def _unsort_queries(x: torch.Tensor) -> torch.Tensor:
+        idx = inv_query_perm.view(B, Q, *([1] * (x.ndim - 2))).expand_as(x)
+        return torch.gather(x, 1, idx)
+
+    indices = _unsort_queries(mapping_orig)
+    num_neighbors = torch.gather(num_neighbors, 1, inv_query_perm)
+    if return_points:
+        pts_out = _unsort_queries(pts_out)
+    if return_dists:
+        dists_out = _unsort_queries(dists_out)
+
+    if was_unbatched:
+        indices = indices.squeeze(0)
+        num_neighbors = num_neighbors.squeeze(0)
+        if return_dists:
+            dists_out = dists_out.squeeze(0)
+        if return_points:
+            pts_out = pts_out.squeeze(0)
+
+    pts_out = pts_out.to(input_dtype)
+    dists_out = dists_out.to(input_dtype)
+
+    # NOTE: ``keep_alive`` (BVHs and their bound arrays) is intentionally held
+    # in scope until the function returns. Warp frees are stream-ordered on the
+    # same stream as the launch, so the BVH memory stays valid for the kernel.
+    return indices, pts_out, dists_out, num_neighbors

--- a/physicsnemo/nn/functional/neighbors/radius_search/kernels.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/kernels.py
@@ -196,6 +196,7 @@ def radius_search_limited_select_batched(
     using the pre-built hash grid for its batch element.
     """
     b, tid = wp.tid()
+    
     grid_id = hash_grids[b]
 
     pos = queries[b, tid]
@@ -244,3 +245,168 @@ def scatter_add_batched(
         idx = indexes[b, tid, j]
         grad = grad_outputs[b, tid, j]
         wp.atomic_add(grad_inputs, b, idx, grad)
+
+
+# ---------------------------------------------------------------------------
+# Morton ordering + tiled BVH ball query
+# ---------------------------------------------------------------------------
+
+
+@wp.func
+def expand_bits(v: wp.uint32) -> wp.uint32:
+    """
+    Spread the 10 low bits of ``v`` so that each bit is separated by two zeros.
+
+    This is the standard "magic bits" expansion used to build 30-bit 3D Morton
+    codes from three 10-bit integer coordinates.
+    """
+    v = (v | (v << wp.uint32(16))) & wp.uint32(0x030000FF)
+    v = (v | (v << wp.uint32(8))) & wp.uint32(0x0300F00F)
+    v = (v | (v << wp.uint32(4))) & wp.uint32(0x030C30C3)
+    v = (v | (v << wp.uint32(2))) & wp.uint32(0x09249249)
+    return v
+
+
+@wp.func
+def morton3D(x: wp.int32, y: wp.int32, z: wp.int32) -> wp.int32:
+    """
+    Interleave three 10-bit integer coordinates into a 30-bit Morton code.
+
+    The result fits in a non-negative ``int32`` so it can be sorted directly
+    (e.g. with ``torch.argsort``) to order points along a Z-order curve.
+    """
+    xx = expand_bits(wp.uint32(x))
+    yy = expand_bits(wp.uint32(y))
+    zz = expand_bits(wp.uint32(z))
+    code = (xx << wp.uint32(2)) | (yy << wp.uint32(1)) | zz
+    return wp.int32(code)
+
+
+@wp.kernel
+def compute_morton_codes(
+    coords: wp.array2d(dtype=wp.vec3),
+    bbox_min: wp.array(dtype=wp.vec3),
+    inv_extent: wp.array(dtype=wp.vec3),
+    codes: wp.array2d(dtype=wp.int32),
+):
+    """
+    Compute a 30-bit Morton code for each coordinate, batched over dim=(B, M).
+
+    Each coordinate is normalized into the unit cube using the per-batch
+    bounding box (``bbox_min`` and ``inv_extent = 1 / (bbox_max - bbox_min)``),
+    quantized to a 10-bit-per-axis integer lattice, and interleaved.
+
+    Args:
+        coords: Coordinates to encode, shape (B, M).
+        bbox_min: Per-batch lower corner of the bounding box, shape (B,).
+        inv_extent: Per-batch reciprocal extent of the bounding box, shape (B,).
+        codes: Output Morton codes, shape (B, M).
+    """
+    b, i = wp.tid()
+
+    p = coords[b, i]
+    mn = bbox_min[b]
+    inv = inv_extent[b]
+
+    # Normalize to the unit cube, then scale to the [0, 1023] integer lattice.
+    nx = (p[0] - mn[0]) * inv[0]
+    ny = (p[1] - mn[1]) * inv[1]
+    nz = (p[2] - mn[2]) * inv[2]
+
+    xi = wp.clamp(wp.int32(nx * 1024.0), 0, 1023)
+    yi = wp.clamp(wp.int32(ny * 1024.0), 0, 1023)
+    zi = wp.clamp(wp.int32(nz * 1024.0), 0, 1023)
+
+    codes[b, i] = morton3D(xi, yi, zi)
+
+
+@wp.kernel
+def tiled_bvh_radius_search(
+    bvhs: wp.array(dtype=wp.uint64),
+    points: wp.array2d(dtype=wp.vec3),
+    queries: wp.array2d(dtype=wp.vec3),
+    max_points: wp.int32,
+    radius: wp.float32,
+    mapping: wp.array3d(dtype=wp.int32),
+    num_neighbors: wp.array2d(dtype=wp.int32),
+    return_dists: wp.bool,
+    distances: wp.array3d(dtype=wp.float32),
+    return_points: wp.bool,
+    result_points: wp.array3d(dtype=wp.vec3),
+):
+    """
+    Tiled (block-cooperative) BVH ball query: up to max_points neighbors / query.
+
+    Launched as a flattened 1D tile grid of ``B * N_queries`` tiles with a
+    non-trivial ``block_dim`` (via ``wp.launch_tiled``). Each thread block owns
+    one (batch, query) pair -- decoded from the flat tile index so that ``(b, q)``
+    is uniform across the block -- and its lanes cooperatively traverse the
+    per-batch BVH for that query's axis-aligned bounding box :math:`[q - r, q + r]`
+    using ``wp.tile_bvh_query_aabb``. Candidates are refined with an exact L2
+    check and up to ``max_points`` first-found neighbors are recorded.
+
+    A flat 1D launch grid (rather than a 2D ``dim=(B, Q)``) is used deliberately:
+    it matches the only tiled-launch shape exercised by Warp's own BVH tests and
+    avoids illegal memory accesses observed with 2D tiled launches.
+
+    This is a drop-in analogue of :func:`radius_search_limited_select_batched`;
+    the only signature difference is that the first argument carries BVH ids
+    instead of hash-grid ids (both ``wp.array(dtype=wp.uint64)``).
+
+    Note:
+        The reference points and queries are expected to be Morton-ordered by the
+        host (see :func:`radius_search_bvh`) so that nearby queries traverse
+        similar BVH subtrees and point gathers are coalesced. ``num_neighbors`` is
+        used as an atomic slot counter and may overshoot ``max_points``; the host
+        clamps it after the launch.
+
+    Args:
+        bvhs: Per-batch BVH ids, shape (B,).
+        points: Reference points, shape (B, N).
+        queries: Query points, shape (B, Q).
+        max_points: Maximum number of neighbors to record per query.
+        radius: Search radius.
+        mapping: Output neighbor indices (into ``points``), shape (B, Q, max_points).
+        num_neighbors: Output neighbor counts per query, shape (B, Q).
+        return_dists: Whether to write distances.
+        distances: Output distances, shape (B, Q, max_points).
+        return_points: Whether to write neighbor coordinates.
+        result_points: Output neighbor coordinates, shape (B, Q, max_points).
+    """
+    # Flattened 1D tile grid: one thread block per (batch, query). Decode (b, q)
+    # from the flat tile index; both are block-uniform, so the AABB passed to
+    # wp.tile_bvh_query_aabb is identical across the block (a requirement of the
+    # tiled query).
+    tile = wp.tid()
+    n_queries = queries.shape[1]
+    b = tile // n_queries
+    q = tile % n_queries
+
+    bvh_id = bvhs[b]
+    qp = queries[b, q]
+    r = wp.vec3(radius, radius, radius)
+    low = qp - r
+    high = qp + r
+    radius_squared = radius * radius
+
+    # Cooperative traversal. The while-loop and the tile BVH-query builtins are
+    # collective, so all lanes run the traversal to completion (no early break).
+    # Each in-radius hit claims a unique output slot via an atomic counter kept
+    # in-place in num_neighbors; slots past max_points are skipped.
+    n_points = points.shape[1]
+    query = wp.tile_bvh_query_aabb(bvh_id, low, high)
+    while wp.tile_query_valid(query):
+        # Each lane receives one candidate point index (or -1) this round.
+        result_idx = wp.untile(wp.tile_bvh_query_next(query))
+        # Guard the upper bound too: defends the points[] gather against any
+        # out-of-range index the tiled traversal might hand back.
+        if result_idx >= 0 and result_idx < n_points:
+            pos2 = points[b, result_idx]
+            if check_distance(qp, pos2, radius_squared):
+                slot = wp.atomic_add(num_neighbors, b, q, wp.int32(1))
+                if slot < max_points:
+                    mapping[b, q, slot] = result_idx
+                    if return_dists:
+                        distances[b, q, slot] = wp.length(qp - pos2)
+                    if return_points:
+                        result_points[b, q, slot] = pos2

--- a/physicsnemo/nn/functional/neighbors/radius_search/radius_search.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/radius_search.py
@@ -20,7 +20,9 @@ from jaxtyping import Float
 from physicsnemo.core.function_spec import FunctionSpec
 
 from ._torch_impl import radius_search as radius_search_torch
+from ._warp_impl import _WARP_VARIANTS
 from ._warp_impl import radius_search as radius_search_warp
+from .utils import radius_search_timing_enabled, time_radius_search
 
 
 class RadiusSearch(FunctionSpec):
@@ -71,8 +73,17 @@ class RadiusSearch(FunctionSpec):
             Defaults to False.
         return_points (bool, optional): If True, returns the actual neighbor points in addition to
             their indices. Defaults to False.
-        implementation (str, optional): Explicit implementation name ("warp" or "torch").
-            Defaults to None, which selects by rank.
+        implementation (str, optional): Explicit backend selection. Base backends are
+            ``"warp"`` (Warp hash grid) and ``"torch"`` (brute force). On the CUDA
+            ``max_points`` path the Warp backend also exposes experimental variants
+            selectable directly by name: ``"scalar"`` / ``"fma"`` / ``"gemm"``
+            (Morton hash grid), ``"dense_fma"`` / ``"dense_fma_e2e"`` /
+            ``"dense_fma_store_opt"`` / ``"dense_fma_mem_opt"`` / ``"dense_fma_mm"`` /
+            ``"dense_gemm"`` / ``"custom_grid_cell"`` (Morton dense-cell;
+            ``"custom_grid_cell"`` is a WIP experimental cell-centric memory-optimized
+            launch that is not runnable yet), ``"sparse_fma_e2e"`` (sparse hash-grid
+            cells), and ``"bvh"`` (Morton-ordered tiled LBVH). Defaults to None,
+            which selects the lowest-rank available base backend.
 
     Returns:
         tuple | torch.Tensor:
@@ -109,10 +120,17 @@ class RadiusSearch(FunctionSpec):
         max_points: int | None = None,
         return_dists: bool = False,
         return_points: bool = False,
+        variant: str | None = None,
     ) -> tuple[torch.Tensor, ...]:
-        """Warp-accelerated radius search using spatial hash grids."""
+        """Warp-accelerated radius search using spatial hash grids.
+
+        ``variant`` selects a Morton/BVH sub-variant on the CUDA
+        ``max_points`` path (injected by :meth:`RadiusSearch.dispatch` when the
+        user requests one via ``implementation=``). When None, the hash-grid
+        kernel runs unless a ``PHYSICSNEMO_RADIUS_SEARCH_*`` env var is set.
+        """
         return radius_search_warp(
-            points, queries, radius, max_points, return_dists, return_points
+            points, queries, radius, max_points, return_dists, return_points, variant
         )
 
     @FunctionSpec.register(name="torch", rank=1, baseline=True)
@@ -128,6 +146,52 @@ class RadiusSearch(FunctionSpec):
         return radius_search_torch(
             points, queries, radius, max_points, return_dists, return_points
         )
+
+    @classmethod
+    def dispatch(cls, *args, **kwargs):
+        """Dispatch to a backend, translating Warp variant names.
+
+        The Morton/BVH variants are sub-variants of the ``warp`` backend rather
+        than separately registered implementations. Selecting one by name
+        (e.g. ``implementation="dense_fma"`` or ``implementation="bvh"``) rewrites
+        the request to ``implementation="warp"`` plus an explicit ``variant`` that
+        is threaded into the Warp custom op, which preserves the op's shared
+        autograd backward. The base backends ``warp`` / ``torch`` and the
+        automatic ``None`` selection are unaffected.
+
+        Parameters
+        ----------
+        *args, **kwargs
+            Arguments forwarded to the selected implementation. ``implementation``
+            may name a base backend or any value in ``_WARP_VARIANTS``.
+
+        Returns
+        -------
+        object
+            The implementation result.
+        """
+        implementation = kwargs.get("implementation")
+        if implementation in _WARP_VARIANTS:
+            kwargs["implementation"] = "warp"
+            kwargs["variant"] = implementation
+
+        # Fast path: no timing overhead unless explicitly enabled.
+        if not radius_search_timing_enabled():
+            return super().dispatch(*args, **kwargs)
+
+        # Opt-in CUDA-event timing (PHYSICSNEMO_RADIUS_SEARCH_TIMING). Label each
+        # call by the user-requested backend so a benchmark can attribute per-call
+        # GPU time to each implementation; carry radius/max_points for per-site
+        # breakdowns. ``radius`` is the 3rd positional arg of ``radius_search``.
+        label = implementation if implementation is not None else "auto"
+        radius = args[2] if len(args) >= 3 else kwargs.get("radius")
+        max_points = kwargs.get("max_points")
+        if max_points is None and len(args) >= 4:
+            max_points = args[3]
+        with time_radius_search(
+            label, meta={"radius": radius, "max_points": max_points}
+        ):
+            return super().dispatch(*args, **kwargs)
 
     @classmethod
     def make_inputs_forward(

--- a/physicsnemo/nn/functional/neighbors/radius_search/utils.py
+++ b/physicsnemo/nn/functional/neighbors/radius_search/utils.py
@@ -14,11 +14,247 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
 import torch
 
 
+_CAPTURE_LOCK = threading.Lock()
+_CAPTURE_COUNT = 0
+_TIMING_LOCK = threading.Lock()
+# Each entry: (implementation_label, meta_dict, start_event, end_event).
+_TIMING_EVENTS: list[tuple[str, dict, Any, Any]] = []
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def radius_search_timing_enabled() -> bool:
+    return _env_flag("PHYSICSNEMO_RADIUS_SEARCH_TIMING")
+
+
+class _RadiusSearchTimer:
+    def __init__(self, implementation: str, meta: dict | None = None):
+        self.implementation = implementation
+        self.meta = meta or {}
+        self.start_event: Any | None = None
+        self.end_event: Any | None = None
+
+    def __enter__(self):
+        if not radius_search_timing_enabled():
+            return self
+        if not torch.cuda.is_available():
+            return self
+        if getattr(torch.compiler, "is_compiling", lambda: False)():
+            return self
+
+        self.start_event = torch.cuda.Event(enable_timing=True)
+        self.end_event = torch.cuda.Event(enable_timing=True)
+        self.start_event.record()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.start_event is not None and self.end_event is not None:
+            self.end_event.record()
+            with _TIMING_LOCK:
+                _TIMING_EVENTS.append(
+                    (self.implementation, self.meta, self.start_event, self.end_event)
+                )
+        return False
+
+
+def time_radius_search(
+    implementation: str, meta: dict | None = None
+) -> _RadiusSearchTimer:
+    """Context manager that CUDA-event-times an enclosed radius-search call.
+
+    Recording is a no-op unless ``PHYSICSNEMO_RADIUS_SEARCH_TIMING`` is set and
+    CUDA is available. ``meta`` (e.g. ``{"radius": ..., "max_points": ...}``) is
+    stored alongside the timing so per-call-site breakdowns are possible.
+    """
+    return _RadiusSearchTimer(implementation, meta)
+
+
+def reset_radius_search_timing() -> None:
+    with _TIMING_LOCK:
+        _TIMING_EVENTS.clear()
+
+
+def radius_search_timing_records(reset: bool = False) -> list[dict[str, Any]]:
+    """Return the individual CUDA-event timings recorded since the last reset.
+
+    Each record is a dict with keys ``implementation``, ``radius``,
+    ``max_points`` and ``elapsed_ms``. The recorded events are synchronized
+    before their elapsed time is read. Unlike
+    :func:`summarize_radius_search_timing`, this preserves every per-call sample
+    so callers can compute their own statistics (mean/median/std/var). When
+    ``reset`` is True the internal buffer is cleared after reading.
+    """
+    with _TIMING_LOCK:
+        events = list(_TIMING_EVENTS)
+        if reset:
+            _TIMING_EVENTS.clear()
+
+    for _, _, _, end_event in events:
+        end_event.synchronize()
+
+    records: list[dict[str, Any]] = []
+    for implementation, meta, start_event, end_event in events:
+        meta = meta or {}
+        records.append(
+            {
+                "implementation": implementation,
+                "radius": meta.get("radius"),
+                "max_points": meta.get("max_points"),
+                "elapsed_ms": float(start_event.elapsed_time(end_event)),
+            }
+        )
+    return records
+
+
+def summarize_radius_search_timing() -> dict[str, float | int]:
+    with _TIMING_LOCK:
+        events = list(_TIMING_EVENTS)
+        _TIMING_EVENTS.clear()
+
+    summary: dict[str, float | int] = {
+        "neighbor_search_ms": 0.0,
+        "neighbor_search_calls": 0,
+    }
+    if not events:
+        return summary
+
+    for _, _, _, end_event in events:
+        end_event.synchronize()
+
+    by_impl_ms: dict[str, float] = {}
+    by_impl_calls: dict[str, int] = {}
+    total_ms = 0.0
+    for implementation, _meta, start_event, end_event in events:
+        elapsed_ms = float(start_event.elapsed_time(end_event))
+        total_ms += elapsed_ms
+        by_impl_ms[implementation] = by_impl_ms.get(implementation, 0.0) + elapsed_ms
+        by_impl_calls[implementation] = by_impl_calls.get(implementation, 0) + 1
+
+    summary["neighbor_search_ms"] = total_ms
+    summary["neighbor_search_calls"] = len(events)
+    for implementation, elapsed_ms in sorted(by_impl_ms.items()):
+        key = implementation.replace("-", "_")
+        summary[f"neighbor_search_{key}_ms"] = elapsed_ms
+        summary[f"neighbor_search_{key}_calls"] = by_impl_calls[implementation]
+    return summary
+
+
+def _capture_enabled_for(implementation: str) -> bool:
+    capture_dir = os.getenv("PHYSICSNEMO_RADIUS_SEARCH_CAPTURE_DIR")
+    if not capture_dir:
+        return False
+
+    allowed = os.getenv("PHYSICSNEMO_RADIUS_SEARCH_CAPTURE_IMPLS")
+    if not allowed:
+        return True
+    return implementation in {item.strip() for item in allowed.split(",") if item.strip()}
+
+
+def maybe_capture_radius_search(
+    implementation: str,
+    points: torch.Tensor,
+    queries: torch.Tensor,
+    radius: float,
+    max_points: int | None,
+    return_dists: bool,
+    return_points: bool,
+    *,
+    num_neighbors: torch.Tensor | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> None:
+    """Optionally save radius-search inputs for standalone replay/benchmarking.
+
+    Capture is disabled unless ``PHYSICSNEMO_RADIUS_SEARCH_CAPTURE_DIR`` is set.
+    ``PHYSICSNEMO_RADIUS_SEARCH_CAPTURE_LIMIT`` limits files per process; the
+    default is 1 to avoid accidentally filling disks during long training runs.
+    Set the limit to 0 for unlimited capture.
+    """
+    if not _capture_enabled_for(implementation):
+        return
+    if getattr(torch.compiler, "is_compiling", lambda: False)():
+        return
+
+    global _CAPTURE_COUNT
+    limit = _env_int("PHYSICSNEMO_RADIUS_SEARCH_CAPTURE_LIMIT", 1)
+    with _CAPTURE_LOCK:
+        if limit > 0 and _CAPTURE_COUNT >= limit:
+            return
+        capture_id = _CAPTURE_COUNT
+        _CAPTURE_COUNT += 1
+
+    capture_dir = Path(os.environ["PHYSICSNEMO_RADIUS_SEARCH_CAPTURE_DIR"])
+    capture_dir.mkdir(parents=True, exist_ok=True)
+    rank = _env_int("RANK", 0)
+    filename = f"rank{rank:03d}_{capture_id:06d}_{implementation}.pt"
+    path = capture_dir / filename
+
+    metadata: dict[str, Any] = {
+        "implementation": implementation,
+        "radius": float(radius),
+        "max_points": max_points,
+        "return_dists": bool(return_dists),
+        "return_points": bool(return_points),
+        "points_shape": tuple(points.shape),
+        "queries_shape": tuple(queries.shape),
+        "points_dtype": str(points.dtype),
+        "queries_dtype": str(queries.dtype),
+        "points_device": str(points.device),
+        "queries_device": str(queries.device),
+        "rank": rank,
+        "capture_id": capture_id,
+        "path": str(path),
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    payload: dict[str, Any] = {
+        "metadata": metadata,
+        "points": points.detach().cpu(),
+        "queries": queries.detach().cpu(),
+        "radius": float(radius),
+        "max_points": max_points,
+        "return_dists": bool(return_dists),
+        "return_points": bool(return_points),
+    }
+    if num_neighbors is not None and num_neighbors.numel() > 0:
+        payload["num_neighbors"] = num_neighbors.detach().cpu()
+
+    torch.save(payload, path)
+    with (capture_dir / "manifest.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(metadata, sort_keys=True) + "\n")
+
+
 def validate_inputs(points: torch.Tensor, queries: torch.Tensor):
-    """Validate and normalize inputs to (B, N, 3) shape. Returns (points, queries, was_unbatched)."""
+    """Validate and normalize inputs to (B, N, 3) shape.
+
+    Returns ``(points, queries, was_unbatched)``.
+    """
     if points.ndim == 2 and queries.ndim == 2:
         return points.unsqueeze(0), queries.unsqueeze(0), True
     elif points.ndim == 3 and queries.ndim == 3:

--- a/physicsnemo/nn/module/ball_query.py
+++ b/physicsnemo/nn/module/ball_query.py
@@ -22,6 +22,8 @@ By default, it will project a grid of points to a 1D set of points.
 Supports arbitrary batch sizes.
 """
 
+import os
+
 import torch
 import torch.nn as nn
 from einops import rearrange
@@ -43,6 +45,7 @@ class BQWarp(nn.Module):
         self,
         radius: float = 0.25,
         neighbors_in_radius: int | None = 10,
+        implementation: str | None = None,
     ):
         """
         Initialize the BQWarp layer.
@@ -50,14 +53,17 @@ class BQWarp(nn.Module):
         Args:
             radius: Radius for ball query operation
             neighbors_in_radius: Maximum number of neighbors to return within radius. If None, all neighbors will be returned.
+            implementation: Radius-search implementation to use. If None, the
+                implementation is selected automatically.
         """
         super().__init__()
 
         self.radius = radius
         self.neighbors_in_radius = neighbors_in_radius
+        self.implementation = implementation
 
     def forward(
-        self, x: torch.Tensor, p_grid: torch.Tensor, reverse_mapping: bool = True
+        self, x: torch.Tensor, p_grid: torch.Tensor, reverse_mapping: bool = True, cfg= None
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Performs ball query operation to find neighboring points and their features.
@@ -93,22 +99,33 @@ class BQWarp(nn.Module):
                 p_grid = rearrange(p_grid, "b nx ny nz c -> b (nx ny nz) c")
             else:
                 raise ValueError("p_grid must be 3D, 4D, 5D only")
+        
+        if os.environ.get("PROFILE_RUN") == "1" or os.environ.get("PROFILE_RUN_DEEP") == "1":
+            torch.cuda.nvtx.range_push('bq_warp')
+       
+        radius_search_kwargs = {
+            "max_points": self.neighbors_in_radius,
+            "return_points": True,
+            "implementation": self.implementation,
+        }
 
         if reverse_mapping:
+            
             mapping, outputs = radius_search(
                 x,
                 p_grid,
                 self.radius,
-                self.neighbors_in_radius,
-                return_points=True,
+                **radius_search_kwargs,
             )
+
         else:
             mapping, outputs = radius_search(
                 p_grid,
                 x,
                 self.radius,
-                self.neighbors_in_radius,
-                return_points=True,
+                **radius_search_kwargs,
             )
+        if os.environ.get("PROFILE_RUN") == "1" or os.environ.get("PROFILE_RUN_DEEP") == "1":
+            torch.cuda.nvtx.range_pop()
 
         return mapping, outputs

--- a/physicsnemo/nn/module/physics_attention.py
+++ b/physicsnemo/nn/module/physics_attention.py
@@ -43,7 +43,7 @@ from einops import rearrange
 from jaxtyping import Float
 from torch.autograd.profiler import record_function
 from torch.distributed.tensor.placement_types import Replicate
-
+import os
 from physicsnemo.core.version_check import OptionalImport
 from physicsnemo.nn import gumbel_softmax
 
@@ -166,25 +166,35 @@ def _compute_slices_from_projections(
         # Transolver++ uses learned per-token temperature
         temp = temperature + proj_temperature(fx)
         clamped_temp = torch.clamp(temp, min=0.01).to(slice_projections.dtype)
+        
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_push("Grumbel Softmax")
+        
         slice_weights = gumbel_softmax(slice_projections, clamped_temp)  # (B, N, H, S)
+        
+        if os.environ.get("PROFILE_RUN") == "1":
+            torch.cuda.nvtx.range_pop()
     else:
         # Standard Transolver uses global temperature
         clamped_temp = torch.clamp(temperature, min=0.5, max=5).to(
             slice_projections.dtype
         )
         slice_weights = nn.functional.softmax(
-            slice_projections / clamped_temp, dim=-1
+            slice_projections / clamped_temp, dim=-1,
+            dtype = slice_projections.dtype,
         )  # (B, N, H, S)
 
     # Cast to the computation type (since the parameter is probably fp32)
     slice_weights = slice_weights.to(slice_projections.dtype)
 
+
+    # ----------CHANGED ---------------
     # Computing the slice tokens is a matmul followed by a normalization.
     # It can, unfortunately, overflow in reduced precision, so normalize first:
-    slice_norm = slice_weights.sum(1) + 1e-2  # (B, H, S)
+    # slice_norm = slice_weights.sum(1) + 1e-2  # (B, H, S)
     # Sharded note: slice_norm will be a partial sum at this point.
     # That's because the we're summing over the tokens, which are distributed
-    normed_weights = slice_weights / (slice_norm[:, None, :, :])
+    # normed_weights = slice_weights / (slice_norm[:, None, :, :]).to(slice_projections.dtype)
     # Normed weights has shape (B, N, H, S)
 
     # Sharded note: normed_weights will resolve the partial slice_norm
@@ -195,11 +205,82 @@ def _compute_slices_from_projections(
 
     # Like the weight norm, this sum is a **partial** sum since we are summing
     # over the tokens
-
+    # if os.environ.get("PROFILE_RUN") == "1":
+    #     torch.cuda.nvtx.range_push("slice token matmul")
+    
     # Aggregate features: (B, N, H, S)^T @ (B, N, H, D) -> (B, H, S, D)
-    slice_token = torch.matmul(
-        normed_weights.permute(0, 2, 3, 1), fx.permute(0, 2, 1, 3)
+    # slice_token = torch.matmul(
+    #     normed_weights.permute(0, 2, 3, 1), fx.permute(0, 2, 1, 3)
+    # )
+
+    # ----------------CHANGED-------------------------
+
+    # slice_norm = slice_weights.sum(dim=1, dtype=torch.float32) + 1e-2
+    # import ipdb; ipdb.set_trace()
+    # numerator = torch.matmul(slice_weights.permute(0, 2, 3, 1), fx.permute(0, 2, 1, 3)).to(torch.float32)#, out_dtype=torch.float32)
+    # slice_token = (numerator / slice_norm[..., None]).to(slice_weights.dtype)
+
+    # slice_weights: (B, N, H, S)
+# fx:            (B, N, H, D)
+    B, N, H, S = slice_weights.shape
+    D = fx.shape[-1]
+
+    # Sum over tokens. Accumulate in FP32 for BF16/FP16.
+    acc_dtype = (
+        torch.float32
+        if slice_weights.dtype in (torch.float16, torch.bfloat16)
+        else slice_weights.dtype
     )
+    slice_norm = slice_weights.sum(dim=1, dtype=acc_dtype) + 1e-2  # (B, H, S)
+
+    # Convert to batched head-major matrices:
+    # weights_bh:  (B*H, N, S)
+    # features_bh: (B*H, N, D)
+    weights_bh = (
+        slice_weights.permute(0, 2, 1, 3)
+        .reshape(B * H, N, S)
+    )
+    features_bh = (
+        fx.permute(0, 2, 1, 3)
+        .reshape(B * H, N, D)
+    )
+
+    if os.environ.get("PROFILE_RUN") == "1":
+        torch.cuda.nvtx.range_push("slice token matmul")
+
+    # if (
+    #     weights_bh.is_cuda
+    #     and weights_bh.dtype in (torch.float16, torch.bfloat16)
+    # ):
+    #     numerator = torch.bmm(
+    #         weights_bh.transpose(1, 2),  # (B*H, S, N)
+    #         features_bh,                 # (B*H, N, D)
+    #     )
+    # elif weights_bh.dtype in (torch.float16, torch.bfloat16):
+    #     # CPU/testing fallback
+    #     numerator = torch.bmm(
+    #         weights_bh.transpose(1, 2).float(),
+    #         features_bh.float(),
+    #     )
+    # else:
+    #     numerator = torch.bmm(
+    #         weights_bh.transpose(1, 2),
+    #         features_bh,
+    #     )
+    # import ipdb; ipdb.set_trace()
+    numerator = torch.bmm(weights_bh.transpose(1, 2),features_bh,).reshape(B, H, S, D)
+    # numerator = numerator.reshape(B, H, S, D)
+
+    # Divide only the small (B,H,S,D) result.
+    slice_token = (
+        numerator / slice_norm.unsqueeze(-1)
+    ).to(fx.dtype)
+
+    if os.environ.get("PROFILE_RUN") == "1":
+        torch.cuda.nvtx.range_pop()
+
+    # if os.environ.get("PROFILE_RUN") == "1":
+    #     torch.cuda.nvtx.range_pop()
 
     # Return the original weights, not the normed weights:
     return slice_weights, slice_token

--- a/test/models/geotransolver/test_geotransolver.py
+++ b/test/models/geotransolver/test_geotransolver.py
@@ -190,6 +190,30 @@ def test_geotransolver_forward_with_local_features(device, pytestconfig):
     assert not torch.isnan(outputs).any()
 
 
+def test_geotransolver_propagates_radius_search_implementation():
+    """GeoTransolver should configure every local-feature BQWarp instance."""
+    model = GeoTransolver(
+        functional_dim=8,
+        out_dim=2,
+        geometry_dim=3,
+        n_layers=1,
+        n_hidden=16,
+        n_head=2,
+        slice_num=4,
+        use_te=False,
+        include_local_features=True,
+        radii=[0.1, 0.2],
+        neighbors_in_radius=[4, 8],
+        n_hidden_local=8,
+        radius_search_implementation="torch",
+    )
+
+    assert model.context_builder.local_extractors is not None
+    for extractor in model.context_builder.local_extractors:
+        for processor in extractor.processors:
+            assert processor.bq_warp.implementation == "torch"
+
+
 # =============================================================================
 # Forward Accuracy Tests (reproducibility)
 # =============================================================================

--- a/test/nn/functional/neighbors/test_radius_search.py
+++ b/test/nn/functional/neighbors/test_radius_search.py
@@ -20,8 +20,18 @@ import torch
 from physicsnemo.nn.functional import radius_search
 from physicsnemo.nn.functional.neighbors import RadiusSearch
 from physicsnemo.nn.functional.neighbors.radius_search._warp_impl import (
+    radius_search_bvh,
+)
+from physicsnemo.nn.functional.neighbors.radius_search._warp_impl import (
     radius_search_impl as radius_search_warp,
 )
+from physicsnemo.nn.functional.neighbors.radius_search._morton_impl import (
+    radius_search_morton,
+)
+from physicsnemo.nn.functional.neighbors.radius_search._morton_dense_impl import (
+    radius_search_morton_dense,
+)
+from physicsnemo.nn.functional.neighbors.radius_search.utils import format_returns
 from test.conftest import requires_module
 
 
@@ -643,3 +653,844 @@ def test_radius_search_batched_opcheck(device: str):
         radius_search_warp,
         args=(points, queries, 1.5, 8, True, True),
     )
+
+
+_EXACT_BACKENDS = ("torch", "warp")
+
+
+def _skip_unavailable_backend(implementation: str, device: str) -> None:
+    if implementation == "warp":
+        pytest.importorskip("warp")
+
+
+def _assert_static_neighbors_match_brute_force(
+    points: torch.Tensor,
+    queries: torch.Tensor,
+    radius: float,
+    implementation: str,
+) -> None:
+    """Check an untruncated static result without assuming neighbor order."""
+    max_points = max(1, points.shape[-2])
+    indices, selected_points, distances = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation=implementation,
+    )
+
+    was_unbatched = points.ndim == 2
+    points_b = points.unsqueeze(0) if was_unbatched else points
+    queries_b = queries.unsqueeze(0) if was_unbatched else queries
+    indices_b = indices.unsqueeze(0) if was_unbatched else indices
+    selected_points_b = (
+        selected_points.unsqueeze(0) if was_unbatched else selected_points
+    )
+    distances_b = distances.unsqueeze(0) if was_unbatched else distances
+    expected_distances = torch.cdist(
+        queries_b.float(),
+        points_b.float(),
+        compute_mode="donot_use_mm_for_euclid_dist",
+    )
+
+    for batch_idx in range(points_b.shape[0]):
+        for query_idx in range(queries_b.shape[1]):
+            expected_ids = torch.nonzero(
+                expected_distances[batch_idx, query_idx] <= radius,
+                as_tuple=False,
+            ).flatten()
+            count = expected_ids.numel()
+            actual_ids = indices_b[batch_idx, query_idx, :count].long()
+            torch.testing.assert_close(
+                actual_ids.sort().values,
+                expected_ids.sort().values,
+            )
+            torch.testing.assert_close(
+                selected_points_b[batch_idx, query_idx, :count],
+                points_b[batch_idx, actual_ids],
+            )
+            torch.testing.assert_close(
+                distances_b[batch_idx, query_idx, :count].float(),
+                expected_distances[batch_idx, query_idx, actual_ids],
+                atol=1e-5,
+                rtol=1e-5,
+            )
+            assert (indices_b[batch_idx, query_idx, count:] == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Tiled-BVH radius-search tests (Morton-ordered, CUDA-only)
+# ---------------------------------------------------------------------------
+
+
+def _assert_neighbor_sets_match_bruteforce(
+    points: torch.Tensor,
+    queries: torch.Tensor,
+    radius: float,
+    indices: torch.Tensor,
+    num_neighbors: torch.Tensor,
+    distances: torch.Tensor | None,
+    selected_points: torch.Tensor | None,
+) -> None:
+    """Compare per-query neighbor sets against a brute-force cdist reference.
+
+    Assumes the test was set up so no query exceeds ``max_points`` neighbors,
+    i.e. every backend returns the complete (un-truncated) neighbor set, which
+    makes the comparison order-invariant and exact.
+    """
+    dist_matrix = torch.cdist(
+        queries.float(), points.float(), compute_mode="donot_use_mm_for_euclid_dist"
+    )
+    within = dist_matrix <= radius
+
+    expected_counts = within.sum(dim=1)
+    torch.testing.assert_close(
+        num_neighbors.to(torch.int64), expected_counts.to(torch.int64)
+    )
+
+    for q in range(queries.shape[0]):
+        k = int(num_neighbors[q])
+        expected_idx = set(within[q].nonzero().flatten().tolist())
+        got_idx = set(indices[q, :k].tolist())
+        assert got_idx == expected_idx, f"neighbor index set mismatch at query {q}"
+
+        if distances is not None:
+            got_d = torch.sort(distances[q, :k].float())[0]
+            exp_d = torch.sort(dist_matrix[q][within[q]])[0]
+            torch.testing.assert_close(got_d, exp_d, atol=1e-4, rtol=1e-4)
+
+        if selected_points is not None:
+            ref_pts = points[indices[q, :k].long()].float()
+            torch.testing.assert_close(
+                selected_points[q, :k].float(), ref_pts, atol=1e-5, rtol=1e-5
+            )
+
+
+# Validate tiled-BVH radius search against a brute-force reference (unbatched).
+@requires_module("warp")
+@pytest.mark.parametrize("return_dists", [True, False])
+@pytest.mark.parametrize("return_points", [True, False])
+def test_radius_search_bvh_matches_reference(
+    device: str,
+    return_dists: bool,
+    return_points: bool,
+):
+    if device == "cpu":
+        pytest.skip("radius_search_bvh is CUDA-only (tiled BVH queries are GPU-only)")
+
+    torch.manual_seed(0)
+    n_points, n_queries, max_points = 256, 64, 64
+    points = torch.rand(n_points, 3, device=device)
+    queries = torch.rand(n_queries, 3, device=device)
+    radius = 0.1  # small enough that no query exceeds max_points neighbors
+
+    indices, sel_points, distances, num_neighbors = radius_search_bvh(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=return_dists,
+        return_points=return_points,
+    )
+
+    assert indices.shape == (n_queries, max_points)
+    assert num_neighbors.shape == (n_queries,)
+    assert int(num_neighbors.max()) <= max_points
+
+    _assert_neighbor_sets_match_bruteforce(
+        points,
+        queries,
+        radius,
+        indices,
+        num_neighbors,
+        distances if return_dists else None,
+        sel_points if return_points else None,
+    )
+
+
+# Validate tiled-BVH radius search for batched inputs against brute force.
+@requires_module("warp")
+@pytest.mark.parametrize("batch_size", [1, 3])
+def test_radius_search_bvh_batched_matches_reference(device: str, batch_size: int):
+    if device == "cpu":
+        pytest.skip("radius_search_bvh is CUDA-only (tiled BVH queries are GPU-only)")
+
+    torch.manual_seed(1)
+    n_points, n_queries, max_points = 200, 48, 64
+    points = torch.rand(batch_size, n_points, 3, device=device)
+    queries = torch.rand(batch_size, n_queries, 3, device=device)
+    radius = 0.1
+
+    indices, sel_points, distances, num_neighbors = radius_search_bvh(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+    )
+
+    assert indices.shape == (batch_size, n_queries, max_points)
+    assert num_neighbors.shape == (batch_size, n_queries)
+
+    # Validate shapes/bounds with the shared helper using the formatted return.
+    results = format_returns(
+        indices, sel_points, distances, return_dists=True, return_points=True
+    )
+    _assert_batched_radius_outputs(
+        batch_size,
+        n_points,
+        n_queries,
+        radius,
+        max_points,
+        True,
+        True,
+        results,
+    )
+
+    # Per-(batch, query) neighbor sets must match brute force.
+    for b in range(batch_size):
+        _assert_neighbor_sets_match_bruteforce(
+            points[b],
+            queries[b],
+            radius,
+            indices[b],
+            num_neighbors[b],
+            distances[b],
+            sel_points[b],
+        )
+
+
+# Verify 2D input == batched[0] for the tiled-BVH path.
+@requires_module("warp")
+def test_radius_search_bvh_2d_3d_equivalence(device: str):
+    if device == "cpu":
+        pytest.skip("radius_search_bvh is CUDA-only (tiled BVH queries are GPU-only)")
+
+    torch.manual_seed(7)
+    pts_2d = torch.rand(128, 3, device=device)
+    qs_2d = torch.rand(40, 3, device=device)
+    radius, max_points = 0.12, 64
+
+    idx_2d, _, _, num_2d = radius_search_bvh(
+        pts_2d, qs_2d, radius=radius, max_points=max_points
+    )
+    idx_3d, _, _, num_3d = radius_search_bvh(
+        pts_2d.unsqueeze(0), qs_2d.unsqueeze(0), radius=radius, max_points=max_points
+    )
+
+    assert idx_2d.shape == (40, max_points)
+    assert idx_3d.shape == (1, 40, max_points)
+    torch.testing.assert_close(num_2d, num_3d[0])
+    # Counts and per-query neighbor sets are order-invariant; compare as sets.
+    for q in range(40):
+        k = int(num_2d[q])
+        assert set(idx_2d[q, :k].tolist()) == set(idx_3d[0, q, :k].tolist())
+
+
+# Optional benchmark: time tiled-BVH vs the hash-grid warp backend and
+# cross-check correctness on a medium case (marked slow so it is opt-in).
+@pytest.mark.slow
+@requires_module("warp")
+def test_radius_search_bvh_benchmark(device: str):
+    if device == "cpu":
+        pytest.skip("radius_search_bvh is CUDA-only (tiled BVH queries are GPU-only)")
+
+    import time
+
+    torch.manual_seed(0)
+    n_points, n_queries, max_points = 8192, 4096, 32
+    points = torch.rand(n_points, 3, device=device)
+    queries = torch.rand(n_queries, 3, device=device)
+    radius = 0.05
+
+    def _run(fn):
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        out = fn()
+        torch.cuda.synchronize()
+        return out, time.perf_counter() - start
+
+    # Warm up both backends (JIT/codegen, BVH build paths).
+    radius_search_bvh(points, queries, radius, max_points, True, True)
+    radius_search_warp(points, queries, radius, max_points, True, True)
+
+    (bvh_idx, _, _, bvh_num), bvh_t = _run(
+        lambda: radius_search_bvh(points, queries, radius, max_points, True, True)
+    )
+    (_, _, _, _), hash_t = _run(
+        lambda: radius_search_warp(points, queries, radius, max_points, True, True)
+    )
+
+    print(
+        f"\n[radius_search] tiled-BVH={bvh_t * 1e3:.2f} ms  "
+        f"hash-grid={hash_t * 1e3:.2f} ms  "
+        f"(N={n_points}, Q={n_queries}, r={radius}, max_points={max_points})"
+    )
+
+    # Correctness cross-check against brute force (radius small -> no truncation).
+    assert int(bvh_num.max()) <= max_points
+    _assert_neighbor_sets_match_bruteforce(
+        points, queries, radius, bvh_idx, bvh_num, None, None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Morton-grid radius-search tests (scalar / fma / gemm; Morton-ordered, CUDA-only)
+# ---------------------------------------------------------------------------
+
+
+# Validate each Morton variant against a brute-force reference (unbatched).
+@requires_module("warp")
+@pytest.mark.parametrize("variant", ["scalar", "fma", "gemm"])
+@pytest.mark.parametrize("return_dists", [True, False])
+@pytest.mark.parametrize("return_points", [True, False])
+def test_radius_search_morton_matches_reference(
+    device: str,
+    variant: str,
+    return_dists: bool,
+    return_points: bool,
+):
+    if device == "cpu":
+        pytest.skip("radius_search_morton is CUDA-only")
+
+    torch.manual_seed(0)
+    n_points, n_queries, max_points = 256, 64, 64
+    points = torch.rand(n_points, 3, device=device)
+    queries = torch.rand(n_queries, 3, device=device)
+    radius = 0.1  # small enough that no query exceeds max_points neighbors
+
+    indices, sel_points, distances, num_neighbors = radius_search_morton(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=return_dists,
+        return_points=return_points,
+        variant=variant,
+    )
+
+    assert indices.shape == (n_queries, max_points)
+    assert num_neighbors.shape == (n_queries,)
+    assert int(num_neighbors.max()) <= max_points
+
+    _assert_neighbor_sets_match_bruteforce(
+        points,
+        queries,
+        radius,
+        indices,
+        num_neighbors,
+        distances if return_dists else None,
+        sel_points if return_points else None,
+    )
+
+
+# Validate each Morton variant for batched inputs against brute force.
+@requires_module("warp")
+@pytest.mark.parametrize("variant", ["scalar", "fma", "gemm"])
+@pytest.mark.parametrize("batch_size", [1, 3])
+def test_radius_search_morton_batched_matches_reference(
+    device: str, variant: str, batch_size: int
+):
+    if device == "cpu":
+        pytest.skip("radius_search_morton is CUDA-only")
+
+    torch.manual_seed(1)
+    n_points, n_queries, max_points = 200, 48, 64
+    points = torch.rand(batch_size, n_points, 3, device=device)
+    queries = torch.rand(batch_size, n_queries, 3, device=device)
+    radius = 0.1
+
+    indices, sel_points, distances, num_neighbors = radius_search_morton(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        variant=variant,
+    )
+
+    assert indices.shape == (batch_size, n_queries, max_points)
+    assert num_neighbors.shape == (batch_size, n_queries)
+
+    for b in range(batch_size):
+        _assert_neighbor_sets_match_bruteforce(
+            points[b],
+            queries[b],
+            radius,
+            indices[b],
+            num_neighbors[b],
+            distances[b],
+            sel_points[b],
+        )
+
+
+# Verify 2D input == batched[0] for a Morton variant.
+@requires_module("warp")
+@pytest.mark.parametrize("variant", ["scalar", "fma", "gemm"])
+def test_radius_search_morton_2d_3d_equivalence(device: str, variant: str):
+    if device == "cpu":
+        pytest.skip("radius_search_morton is CUDA-only")
+
+    torch.manual_seed(7)
+    pts_2d = torch.rand(128, 3, device=device)
+    qs_2d = torch.rand(40, 3, device=device)
+    radius, max_points = 0.12, 64
+
+    idx_2d, _, _, num_2d = radius_search_morton(
+        pts_2d, qs_2d, radius=radius, max_points=max_points, variant=variant
+    )
+    idx_3d, _, _, num_3d = radius_search_morton(
+        pts_2d.unsqueeze(0),
+        qs_2d.unsqueeze(0),
+        radius=radius,
+        max_points=max_points,
+        variant=variant,
+    )
+
+    assert idx_2d.shape == (40, max_points)
+    assert idx_3d.shape == (1, 40, max_points)
+    torch.testing.assert_close(num_2d, num_3d[0])
+    # Per-query neighbor sets are order-invariant; compare as sets.
+    for q in range(40):
+        k = int(num_2d[q])
+        assert set(idx_2d[q, :k].tolist()) == set(idx_3d[0, q, :k].tolist())
+
+
+# Verify the env-var dispatch routes radius_search(implementation="warp") through
+# the Morton path and matches the torch backend (order-invariant, no truncation).
+@requires_module("warp")
+@pytest.mark.parametrize("variant", ["scalar", "fma", "gemm"])
+def test_radius_search_morton_dispatch_parity(
+    device: str, variant: str, monkeypatch
+):
+    if device == "cpu":
+        pytest.skip("radius_search_morton is CUDA-only")
+
+    torch.manual_seed(2)
+    points = torch.rand(512, 3, device=device)
+    queries = torch.rand(64, 3, device=device)
+    radius, max_points = 0.1, 128  # large max_points -> no truncation
+
+    monkeypatch.setenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", variant)
+    warp_out = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation="warp",
+    )
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", raising=False)
+    torch_out = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation="torch",
+    )
+
+    RadiusSearch.compare_forward(warp_out, torch_out)
+
+
+# dense_fma_e2e is the sort-free twin of dense_fma (row-major cell bins + unsorted
+# queries, no radix sort). Verify it (a) matches a brute-force reference and (b)
+# returns the exact same neighbor sets/counts as dense_fma, for unbatched and
+# batched inputs. max_points is large enough that no query is truncated.
+@requires_module("warp")
+@pytest.mark.parametrize("batch_size", [1, 3])
+def test_radius_search_morton_dense_fma_e2e_parity(device: str, batch_size: int):
+    if device == "cpu":
+        pytest.skip("radius_search_morton_dense is CUDA-only")
+
+    torch.manual_seed(3)
+    n_points, n_queries, max_points = 300, 80, 128
+    points = torch.rand(batch_size, n_points, 3, device=device)
+    queries = torch.rand(batch_size, n_queries, 3, device=device)
+    radius = 0.1  # small enough that no query exceeds max_points neighbors
+
+    idx_base, _, _, num_base = radius_search_morton_dense(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        variant="dense_fma",
+    )
+    idx_e2e, sel_e2e, dist_e2e, num_e2e = radius_search_morton_dense(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        variant="dense_fma_e2e",
+    )
+
+    assert idx_e2e.shape == (batch_size, n_queries, max_points)
+    assert num_e2e.shape == (batch_size, n_queries)
+
+    for b in range(batch_size):
+        # (a) dense_fma_e2e matches the brute-force reference.
+        _assert_neighbor_sets_match_bruteforce(
+            points[b],
+            queries[b],
+            radius,
+            idx_e2e[b],
+            num_e2e[b],
+            dist_e2e[b],
+            sel_e2e[b],
+        )
+        # (b) identical per-query counts and neighbor sets as dense_fma.
+        torch.testing.assert_close(num_e2e[b], num_base[b])
+        for q in range(n_queries):
+            k = int(num_base[b, q])
+            assert (
+                set(idx_e2e[b, q, :k].tolist()) == set(idx_base[b, q, :k].tolist())
+            ), f"neighbor set mismatch (batch {b}, query {q})"
+
+
+# Confirm the env-var dispatch recognizes and routes the new dense_fma_e2e variant
+# end to end through radius_search(implementation="warp"), matching the torch backend.
+@requires_module("warp")
+def test_radius_search_dense_fma_e2e_dispatch_parity(device: str, monkeypatch):
+    if device == "cpu":
+        pytest.skip("radius_search_morton_dense is CUDA-only")
+
+    torch.manual_seed(2)
+    points = torch.rand(512, 3, device=device)
+    queries = torch.rand(64, 3, device=device)
+    radius, max_points = 0.1, 128  # large max_points -> no truncation
+
+    monkeypatch.setenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", "dense_fma_e2e")
+    warp_out = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation="warp",
+    )
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", raising=False)
+    torch_out = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation="torch",
+    )
+
+    RadiusSearch.compare_forward(warp_out, torch_out)
+
+
+# dense_fma_store_opt is the store-optimized twin of dense_fma (shared-memory
+# staged flush + host-gathered points, no in-kernel vec3 scatter). Verify it (a)
+# matches a brute-force reference and (b) returns the exact same neighbor
+# sets/counts as dense_fma, for unbatched and batched inputs. max_points is large
+# enough that no query is truncated, but stays within FMA_STAGE_CAP.
+@requires_module("warp")
+@pytest.mark.parametrize("batch_size", [1, 3])
+def test_radius_search_morton_dense_fma_store_opt_parity(device: str, batch_size: int):
+    if device == "cpu":
+        pytest.skip("radius_search_morton_dense is CUDA-only")
+
+    torch.manual_seed(3)
+    n_points, n_queries, max_points = 300, 80, 128
+    points = torch.rand(batch_size, n_points, 3, device=device)
+    queries = torch.rand(batch_size, n_queries, 3, device=device)
+    radius = 0.1  # small enough that no query exceeds max_points neighbors
+
+    idx_base, _, _, num_base = radius_search_morton_dense(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        variant="dense_fma",
+    )
+    idx_opt, sel_opt, dist_opt, num_opt = radius_search_morton_dense(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        variant="dense_fma_store_opt",
+    )
+
+    assert idx_opt.shape == (batch_size, n_queries, max_points)
+    assert num_opt.shape == (batch_size, n_queries)
+
+    for b in range(batch_size):
+        # (a) dense_fma_store_opt matches the brute-force reference (this also
+        # checks the host-gathered points equal points[indices]).
+        _assert_neighbor_sets_match_bruteforce(
+            points[b],
+            queries[b],
+            radius,
+            idx_opt[b],
+            num_opt[b],
+            dist_opt[b],
+            sel_opt[b],
+        )
+        # (b) identical per-query counts and neighbor sets as dense_fma.
+        torch.testing.assert_close(num_opt[b], num_base[b])
+        for q in range(n_queries):
+            k = int(num_base[b, q])
+            assert (
+                set(idx_opt[b, q, :k].tolist()) == set(idx_base[b, q, :k].tolist())
+            ), f"neighbor set mismatch (batch {b}, query {q})"
+
+
+# Confirm the env-var dispatch recognizes and routes the new dense_fma_store_opt
+# variant end to end through radius_search(implementation="warp").
+@requires_module("warp")
+def test_radius_search_dense_fma_store_opt_dispatch_parity(device: str, monkeypatch):
+    if device == "cpu":
+        pytest.skip("radius_search_morton_dense is CUDA-only")
+
+    torch.manual_seed(2)
+    points = torch.rand(512, 3, device=device)
+    queries = torch.rand(64, 3, device=device)
+    radius, max_points = 0.1, 128  # large max_points -> no truncation
+
+    monkeypatch.setenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", "dense_fma_store_opt")
+    warp_out = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation="warp",
+    )
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", raising=False)
+    torch_out = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation="torch",
+    )
+
+    RadiusSearch.compare_forward(warp_out, torch_out)
+
+
+# ---------------------------------------------------------------------------
+# Config-driven backend selection: choosing a variant directly by name via
+# ``radius_search(implementation="<variant>")`` (no env var required). This is the
+# path exercised by GeoTransolver's ``radius_search_implementation`` config.
+# ---------------------------------------------------------------------------
+
+
+# All Warp CUDA variants selectable via ``implementation=`` and routed through the
+# Warp custom op (Morton hash/dense variants plus the tiled BVH).
+_NAME_SELECTABLE_VARIANTS = [
+    "scalar",
+    "fma",
+    "gemm",
+    "dense_fma",
+    "dense_fma_e2e",
+    "dense_fma_store_opt",
+    "dense_fma_mem_opt",
+    "dense_fma_mm",
+    "dense_gemm",
+    "sparse_fma_e2e",
+    "bvh",
+]
+
+# Subset with a verified brute-force/torch reference, used for parity-vs-torch.
+_NAME_PARITY_VARIANTS = [
+    "scalar",
+    "fma",
+    "gemm",
+    "dense_fma",
+    "dense_fma_e2e",
+    "dense_fma_store_opt",
+    "sparse_fma_e2e",
+    "bvh",
+]
+
+
+def _set_variant_env(monkeypatch, variant: str) -> None:
+    """Point the legacy env-var selectors at ``variant`` (and clear the other)."""
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", raising=False)
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_BVH", raising=False)
+    if variant == "bvh":
+        monkeypatch.setenv("PHYSICSNEMO_RADIUS_SEARCH_BVH", "1")
+    else:
+        monkeypatch.setenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", variant)
+
+
+# Selecting a variant by name must match the torch baseline (order-invariant, no
+# truncation), proving config-driven selection is correct end to end.
+@requires_module("warp")
+@pytest.mark.parametrize("variant", _NAME_PARITY_VARIANTS)
+def test_radius_search_variant_selection_matches_torch(device: str, variant: str):
+    if device == "cpu":
+        pytest.skip("radius-search variants are CUDA-only")
+
+    torch.manual_seed(2)
+    points = torch.rand(512, 3, device=device)
+    queries = torch.rand(64, 3, device=device)
+    radius, max_points = 0.1, 128  # large max_points -> no truncation
+
+    variant_out = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation=variant,
+    )
+    torch_out = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation="torch",
+    )
+
+    RadiusSearch.compare_forward(variant_out, torch_out)
+
+
+# Selecting a variant by name must route to the exact same kernel as the legacy
+# env-var mechanism. This covers every variant (including the benchmark-only
+# dense_* kernels and the BVH backend) without depending on kernel correctness.
+@requires_module("warp")
+@pytest.mark.parametrize("variant", _NAME_SELECTABLE_VARIANTS)
+def test_radius_search_variant_selection_matches_env(
+    device: str, variant: str, monkeypatch
+):
+    if device == "cpu":
+        pytest.skip("radius-search variants are CUDA-only")
+
+    torch.manual_seed(2)
+    points = torch.rand(512, 3, device=device)
+    queries = torch.rand(64, 3, device=device)
+    radius, max_points = 0.1, 128  # large max_points -> no truncation
+
+    # New path: select by name with no env var set.
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", raising=False)
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_BVH", raising=False)
+    by_name = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation=variant,
+    )
+
+    # Legacy path: same kernel selected via the env var + implementation="warp".
+    _set_variant_env(monkeypatch, variant)
+    by_env = radius_search(
+        points,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_dists=True,
+        return_points=True,
+        implementation="warp",
+    )
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", raising=False)
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_BVH", raising=False)
+
+    RadiusSearch.compare_forward(by_name, by_env)
+
+
+# Autograd must survive config-driven variant selection: variants run inside the
+# Warp custom op, so its shared backward should still populate point gradients,
+# identically to the legacy env-var path.
+@requires_module("warp")
+def test_radius_search_variant_selection_preserves_autograd(device: str, monkeypatch):
+    if device == "cpu":
+        pytest.skip("radius-search variants are CUDA-only")
+
+    torch.manual_seed(4)
+    radius, max_points = 0.1, 64
+    queries = torch.rand(48, 3, device=device)
+    base_points = torch.rand(300, 3, device=device)
+
+    # Config-driven selection (implementation="dense_fma"), env unset.
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", raising=False)
+    pts_name = base_points.clone().requires_grad_(True)
+    _, sel_name = radius_search(
+        pts_name,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_points=True,
+        implementation="dense_fma",
+    )
+    sel_name.pow(2).sum().backward()
+    assert pts_name.grad is not None
+    assert torch.isfinite(pts_name.grad).all()
+    assert pts_name.grad.abs().sum() > 0
+
+    # Legacy env-var selection of the same kernel -> identical gradients.
+    monkeypatch.setenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", "dense_fma")
+    pts_env = base_points.clone().requires_grad_(True)
+    _, sel_env = radius_search(
+        pts_env,
+        queries,
+        radius=radius,
+        max_points=max_points,
+        return_points=True,
+        implementation="warp",
+    )
+    sel_env.pow(2).sum().backward()
+    monkeypatch.delenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", raising=False)
+
+    torch.testing.assert_close(pts_name.grad, pts_env.grad)
+
+
+# An explicit variant passed via implementation= must take precedence over the
+# env-var fallback (which here points at a different kernel).
+@requires_module("warp")
+def test_radius_search_explicit_variant_overrides_env(device: str, monkeypatch):
+    if device == "cpu":
+        pytest.skip("radius-search variants are CUDA-only")
+
+    from physicsnemo.nn.functional.neighbors.radius_search import (
+        _morton_dense_impl as dense_mod,
+    )
+
+    seen: list[str | None] = []
+    original = dense_mod.radius_search_morton_dense
+
+    def _spy(*args, **kwargs):
+        seen.append(kwargs.get("variant"))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(dense_mod, "radius_search_morton_dense", _spy)
+    # Env requests the hash-scalar kernel (not a dense kernel)...
+    monkeypatch.setenv("PHYSICSNEMO_RADIUS_SEARCH_MORTON", "scalar")
+
+    torch.manual_seed(5)
+    points = torch.rand(256, 3, device=device)
+    queries = torch.rand(32, 3, device=device)
+    # ...but the explicit variant must win and route to the dense kernel.
+    radius_search(
+        points,
+        queries,
+        radius=0.1,
+        max_points=64,
+        return_points=True,
+        implementation="dense_fma",
+    )
+
+    assert seen == ["dense_fma"]

--- a/test/nn/module/test_ball_query.py
+++ b/test/nn/module/test_ball_query.py
@@ -17,8 +17,24 @@
 import pytest
 import torch
 
+import physicsnemo.nn.module.ball_query as ball_query_module
 from physicsnemo.nn.module.ball_query import BQWarp
 from test.conftest import requires_module
+
+
+def test_bqwarp_passes_radius_search_implementation(monkeypatch):
+    """BQWarp should pass its explicit implementation to radius_search."""
+    captured_kwargs = {}
+
+    def fake_radius_search(points, queries, radius, **kwargs):
+        captured_kwargs.update(kwargs)
+        return torch.empty(0, dtype=torch.long), torch.empty(0)
+
+    monkeypatch.setattr(ball_query_module, "radius_search", fake_radius_search)
+    bq = BQWarp(radius=1.5, neighbors_in_radius=5, implementation="dense_fma")
+    bq(torch.randn(1, 20, 3), torch.randn(1, 15, 3))
+
+    assert captured_kwargs["implementation"] == "dense_fma"
 
 
 @requires_module("warp")


### PR DESCRIPTION
… search

Adds experimental CUDA neighbor-search backends on the radius_search max_points path, plus the GeoTransolver-side changes that use them.

Radius search:
- Morton hash-grid variants (scalar, fma, gemm) in _morton_impl / _morton_kernels.
- Morton dense-cell variants (dense_fma, dense_fma_e2e, dense_fma_store_opt, dense_fma_mem_opt, dense_fma_mm, dense_gemm) in _morton_dense_impl / _morton_dense_kernels / _morton_dense_gemm_kernels.
- Sparse hash-grid variant (sparse_fma_e2e) in _sparse_hash_impl / _sparse_hash_kernels: the counterpart of dense_fma_e2e that stores cells in an open-addressed hash table, so memory scales with occupied cells rather than the bounding box.
- Morton-ordered tiled LBVH (bvh) in kernels.py.
- All variants route through the existing Warp custom op, so they share its registered autograd backward and torch.compile fake path. Selection is by name via radius_search(implementation=...); the PHYSICSNEMO_RADIUS_SEARCH_* env vars remain as a fallback.

GeoTransolver:
- context_projector, gale and physics_attention optimizations; ball_query and point_cloud_ops forward an explicit implementation.
- New radius_search_implementation config key wired through the unified external-aero recipe.
- Nsight capture window (profile / warmup_steps / profile_steps) in the recipe training loop.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
