### PR TITLE
Fix double optimizer step in DefaultTrainingLoop with static capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -532,6 +532,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   broke the `test_get_checkpoint_dir` CI test on Windows. The function now
   always joins with `/`, working uniformly for local paths and `fsspec`
   URIs (`msc://`, etc.) across operating systems.
+- `DefaultTrainingLoop` no longer applies two optimizer updates per minibatch
+  when `enable_static_capture=True`. `StaticCaptureTraining` steps the optimizer
+  through its grad scaler, and the loop stepped again on the same gradients,
+  doubling the effective learning rate and bypassing the grad scaler's
+  inf/nan check.
 
 ### Security
 

--- a/physicsnemo/active_learning/loop.py
+++ b/physicsnemo/active_learning/loop.py
@@ -513,10 +513,11 @@ class DefaultTrainingLoop(p.TrainingLoop):
                     model.zero_grad(set_to_none=True)
                     loss = train_step_fn(model, batch, *args, **kwargs)
                     log.log_minibatch({"train_loss": loss.detach().item()})
-                    # normally, static capture will call backward because of AMP
+                    # static capture calls backward because of AMP, and steps
+                    # the optimizer itself through its grad scaler
                     if not self.enable_static_capture:
                         loss.backward()
-                    optimizer.step()
+                        optimizer.step()
                     if lr_scheduler:
                         lr_scheduler.step()
             ########### VALIDATION STEP LOOP ###########

--- a/test/active_learning/test_loop.py
+++ b/test/active_learning/test_loop.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from unittest.mock import MagicMock
 
 import pytest
@@ -446,3 +447,51 @@ class TestDefaultTrainingLoop:
         # it won't be used directly in this implementation
         # This test verifies the loop runs without error
         assert True
+
+    def test_single_optimizer_step_per_minibatch(self, mock_module):
+        """Static capture must not add a second optimizer update per minibatch.
+
+        ``StaticCaptureTraining`` runs the backward pass and steps the optimizer
+        itself through its grad scaler, so the loop stepping again would apply the
+        same gradients twice.
+        """
+        dataset = TensorDataset(torch.randn(4, 64), torch.randn(4, 3))
+        dataloader = DataLoader(dataset, batch_size=4)
+        initial_state = deepcopy(mock_module.state_dict())
+
+        def train_step(model, batch, *args, **kwargs):
+            inputs, targets = batch
+            return (model(inputs) - targets).square().mean()
+
+        def run(enable_static_capture: bool) -> tuple[list[torch.Tensor], int]:
+            mock_module.load_state_dict(initial_state)
+            optimizer = torch.optim.SGD(mock_module.parameters(), lr=0.1)
+            optimizer.step = MagicMock(side_effect=optimizer.step)
+
+            DefaultTrainingLoop(
+                enable_static_capture=enable_static_capture,
+                use_progress_bars=False,
+                use_amp=False,
+            )(
+                mock_module,
+                optimizer,
+                dataloader,
+                max_epochs=1,
+                train_step_fn=train_step,
+                device=torch.device("cpu"),
+            )
+
+            deltas = [
+                parameter.detach() - initial_state[name]
+                for name, parameter in mock_module.named_parameters()
+            ]
+            return deltas, optimizer.step.call_count
+
+        eager_deltas, eager_steps = run(False)
+        captured_deltas, captured_steps = run(True)
+
+        # one minibatch, so exactly one update on both paths
+        assert eager_steps == 1
+        assert captured_steps == 1
+        for eager, captured in zip(eager_deltas, captured_deltas):
+            assert torch.equal(eager, captured)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

`StaticCaptureTraining` runs the backward pass and steps the optimizer through its grad scaler, but the loop skipped only `loss.backward()` and called `optimizer.step()` unconditionally. The gradients are still populated there, so with `enable_static_capture=True` every minibatch got a second update: the effective learning rate doubled, stateful optimizers advanced twice, and the update bypassed the grad scaler's inf/nan check, while the minibatch count and scheduler still recorded one.

This moves `optimizer.step()` into the eager branch, leaving the capture wrapper the sole owner of the update.

`test_single_optimizer_step_per_minibatch` runs one deterministic minibatch each way on CPU and asserts identical parameter deltas and a single `optimizer.step` call; it fails on main. Every other test in that file sets `enable_static_capture=False`, so this path had no coverage.

Unrelated and left alone: the loop's `model.zero_grad(set_to_none=True)` before each wrapped step is what `capture.py` warns can invalidate a recorded CUDA graph.

Closes #1911

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

None.

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI's assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
