### PR TITLE
Fix weighted multinomial device alias validation

### DIFF
--- a/physicsnemo/nn/functional/weighted_multinomial.py
+++ b/physicsnemo/nn/functional/weighted_multinomial.py
@@ -28,6 +28,25 @@ _SAMPLE_CHUNK_SIZE = 1 << 22
 _RANDPERM_POPULATION_LIMIT = 1 << 24
 
 
+def _devices_match(
+    first: torch.device | str,
+    second: torch.device | str,
+) -> bool:
+    """Return whether two device specifications select the same device."""
+    first = torch.device(first)
+    second = torch.device(second)
+    if first.type != second.type:
+        return False
+    if first.type == "cpu":
+        return True
+    if first.type == "cuda" and (first.index is None or second.index is None):
+        current = torch.cuda.current_device()
+        first_index = current if first.index is None else first.index
+        second_index = current if second.index is None else second.index
+        return first_index == second_index
+    return first == second
+
+
 def _sample_exact_without_replacement(
     population_size: int,
     num_samples: int,
@@ -256,7 +275,9 @@ class WeightedMultinomial(FunctionSpec):
                 raise ValueError(
                     "poisson_gap sampling requires an integer uniform population."
                 )
-            if requested_device is not None and requested_device != weights.device:
+            if requested_device is not None and not _devices_match(
+                requested_device, weights.device
+            ):
                 raise ValueError(
                     "device must match input.device when weights are supplied, got "
                     f"{requested_device} and {weights.device}."
@@ -288,7 +309,9 @@ class WeightedMultinomial(FunctionSpec):
 
         if strategy == "poisson_gap" and replacement:
             raise ValueError("poisson_gap sampling does not support replacement.")
-        if generator is not None and torch.device(generator.device) != sample_device:
+        if generator is not None and not _devices_match(
+            generator.device, sample_device
+        ):
             raise ValueError(
                 "generator.device must match the sampling device, got "
                 f"{generator.device} and {sample_device}."

--- a/test/nn/functional/test_weighted_multinomial.py
+++ b/test/nn/functional/test_weighted_multinomial.py
@@ -170,6 +170,61 @@ def test_weighted_sampling_with_replacement_matches_torch_multinomial():
     assert 0 not in indices
 
 
+@pytest.mark.parametrize("device", ["cpu:0", "cpu:1"])
+def test_accepts_equivalent_cpu_device_aliases(device):
+    indices = weighted_multinomial(
+        4,
+        2,
+        device=device,
+        generator=torch.Generator().manual_seed(0),
+    )
+
+    assert indices.device == torch.device("cpu")
+    assert torch.unique(indices).numel() == 2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_accepts_indexless_cuda_generator_on_current_device():
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    indices = weighted_multinomial(
+        4,
+        2,
+        device=device,
+        generator=torch.Generator(device="cuda").manual_seed(0),
+    )
+
+    assert indices.device == device
+    assert torch.unique(indices).numel() == 2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_accepts_indexless_cuda_device_for_indexed_weights():
+    device = torch.device("cuda", torch.cuda.current_device())
+    weights = torch.ones(4, device=device)
+
+    indices = weighted_multinomial(
+        weights,
+        2,
+        device="cuda",
+        generator=torch.Generator(device=device).manual_seed(0),
+    )
+
+    assert indices.device == device
+    assert torch.unique(indices).numel() == 2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_rejects_generator_on_different_device():
+    with pytest.raises(ValueError, match="generator.device"):
+        weighted_multinomial(
+            4,
+            2,
+            device="cuda",
+            generator=torch.Generator(),
+        )
+
+
 @pytest.mark.parametrize("population_size", [10_000, 100_000_000])
 def test_poisson_gap_sampling_is_ordered_and_unique(population_size):
     num_samples = 1_000


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

For NV folks, this is a hotfix for: https://nvbugspro.nvidia.com/bug/6594365

`weighted_multinomial` compared raw `torch.device` objects when validating the
sampling device. In the unified MultiDataset pipeline, an index-less CUDA
generator can therefore report `cuda` while mesh tensors on that same current
GPU report `cuda:0`. Although both specifications select the same device, the
raw comparison rejected them before sampling with
`generator.device must match the sampling device`.

This PR:

- compares device semantics instead of raw device descriptors, resolving an
  index-less CUDA alias to the current CUDA device and canonicalizing CPU
  aliases
- applies the same equivalence check to both generator validation and an
  explicitly supplied device alongside weighted tensor input
- preserves rejection of genuinely different device types or explicit CUDA
  indices without recreating or reseeding the caller's generator
- adds CPU and CUDA regression coverage for accepted aliases and rejected
  mismatches

This restores random mesh cell sampling in the affected unified MultiDataset
example without changing the public API or RNG sequence.

Fixes [NVBug 6594365](https://nvbugspro.nvidia.com/bug/6594365).

## Verification

- `python -m pytest test/nn/functional/test_weighted_multinomial.py -q`: 38 passed
- CUDA `SubsampleMesh` smoke regression with an index-less CUDA generator passed
- `pre-commit run --files physicsnemo/nn/functional/weighted_multinomial.py test/nn/functional/test_weighted_multinomial.py` passed
- `git diff --check` passed

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes; there is no public API change.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date; the PR title supplies the changelog entry.
- [x] An issue is linked to this pull request: [NVBug 6594365](https://nvbugspro.nvidia.com/bug/6594365).
- [x] Model implementation standards are not applicable; this PR does not modify a model.

## Dependencies

No new dependencies.

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
