### PR TITLE
Add amp_mode support to experimental DiffusionUNet3D and UNetBlock3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds `amp_mode` support to the experimental `DiffusionUNet3D` and
+  `UNetBlock3D`, threading the flag through their internal layers so the 3D
+  diffusion U-Net can be trained under `torch.autocast` mixed precision,
+  matching the behavior of `SongUNet` and the 2D `UNetBlock`.
 - Adds `ShardTensor` support for GeoTransolver and FLARE models.
 - Adds zarr save/load for `Mesh` and `DomainMesh` via tensordict's zarr
   storage backend: `physicsnemo.mesh.io.to_zarr` / `from_zarr`, with

--- a/physicsnemo/experimental/models/diffusion_unets/diffusion_unet_3d.py
+++ b/physicsnemo/experimental/models/diffusion_unets/diffusion_unet_3d.py
@@ -130,6 +130,11 @@ class DiffusionUNet3D(Module):
         Set to ``False`` for faster inference without bottleneck attention.
     activation : Literal["silu", "gelu"], optional, default="silu"
         Activation function used inside the 3D U-Net blocks.
+    amp_mode : bool, optional, default=False
+        A flag indicating whether mixed-precision (AMP) training is enabled.
+        Threaded through to all sub-layers; when ``False``, running the model
+        under ``torch.autocast`` raises an error, and when ``True``, dtype
+        handling is delegated to autocast.
 
     Forward
     -------
@@ -243,6 +248,7 @@ class DiffusionUNet3D(Module):
         checkpoint_level: int = 0,
         bottleneck_attention: bool = True,
         activation: Literal["silu", "gelu"] = "silu",
+        amp_mode: bool = False,
     ):
         if len(channel_mult) != num_levels:
             raise ValueError(
@@ -272,6 +278,7 @@ class DiffusionUNet3D(Module):
         self.num_levels = num_levels
         self._input_shape_mult = 2 ** (num_levels - 1)
         self.checkpoint_level = checkpoint_level
+        self.amp_mode = amp_mode
 
         emb_channels = model_channels * channel_mult_emb
         self.emb_channels = emb_channels
@@ -294,24 +301,40 @@ class DiffusionUNet3D(Module):
             init=init,
             init_zero=init_zero,
             init_attn=init_attn,
+            amp_mode=amp_mode,
         )
 
         if self.embedding_type != "zero":
             self.map_noise = (
-                PositionalEmbedding(num_channels=noise_channels, endpoint=True)
+                PositionalEmbedding(
+                    num_channels=noise_channels, endpoint=True, amp_mode=amp_mode
+                )
                 if embedding_type == "positional"
-                else FourierEmbedding(num_channels=noise_channels)
+                else FourierEmbedding(
+                    num_channels=noise_channels, amp_mode=amp_mode
+                )
             )
             self.map_condition = (
-                Linear(in_features=vec_cond_dim, out_features=noise_channels, **init)
+                Linear(
+                    in_features=vec_cond_dim,
+                    out_features=noise_channels,
+                    amp_mode=amp_mode,
+                    **init,
+                )
                 if vec_cond_dim > 0
                 else None
             )
             self.map_layer0 = Linear(
-                in_features=noise_channels, out_features=emb_channels, **init
+                in_features=noise_channels,
+                out_features=emb_channels,
+                amp_mode=amp_mode,
+                **init,
             )
             self.map_layer1 = Linear(
-                in_features=emb_channels, out_features=emb_channels, **init
+                in_features=emb_channels,
+                out_features=emb_channels,
+                amp_mode=amp_mode,
+                **init,
             )
         else:
             # FSDP-compatible zero buffer; persistent=False keeps it out of state_dict

--- a/physicsnemo/experimental/nn/diffusion_unet_3d_blocks.py
+++ b/physicsnemo/experimental/nn/diffusion_unet_3d_blocks.py
@@ -25,6 +25,7 @@ from torch.nn.functional import dropout, scaled_dot_product_attention, silu
 from physicsnemo.core.meta import ModelMetaData
 from physicsnemo.core.module import Module
 from physicsnemo.nn.module.fully_connected_layers import Linear
+from physicsnemo.nn.module.utils.utils import _validate_amp
 from physicsnemo.nn.module.utils.weight_init import _weight_init
 
 
@@ -450,6 +451,10 @@ class UNetBlock3D(Module):
     init_attn : dict or None, optional, default=None
         Weight initialization kwargs for the attention QKV projection. Defaults to
         ``init`` if ``None``.
+    amp_mode : bool, optional, default=False
+        A flag indicating whether mixed-precision (AMP) training is enabled.
+        When ``False``, running the block under ``torch.autocast`` raises an
+        error; when ``True``, dtype handling is delegated to autocast.
 
     Forward
     -------
@@ -497,6 +502,7 @@ class UNetBlock3D(Module):
         init: Dict[str, Any] = dict(),
         init_zero: Dict[str, Any] = dict(init_weight=0),
         init_attn: Any = None,
+        amp_mode: bool = False,
     ):
         super().__init__(meta=ModelMetaData())
 
@@ -507,6 +513,7 @@ class UNetBlock3D(Module):
         self.dropout = dropout
         self.skip_scale = skip_scale
         self.adaptive_scale = adaptive_scale
+        self.amp_mode = amp_mode
         self.act = silu if activation == "silu" else torch.nn.functional.gelu
 
         self.norm0 = GroupNorm3D(num_channels=in_channels, eps=eps)
@@ -522,6 +529,7 @@ class UNetBlock3D(Module):
         self.affine = Linear(
             in_features=emb_channels,
             out_features=out_channels * (2 if adaptive_scale else 1),
+            amp_mode=amp_mode,
             **init,
         )
         self.norm1 = GroupNorm3D(num_channels=out_channels, eps=eps)
@@ -563,7 +571,10 @@ class UNetBlock3D(Module):
         x = self.conv0(self.act(self.norm0(x)))
 
         # Affine conditioning from emb, broadcast over spatial dims
-        params = self.affine(emb).unsqueeze(2).unsqueeze(3).unsqueeze(4).to(x.dtype)
+        params = self.affine(emb).unsqueeze(2).unsqueeze(3).unsqueeze(4)
+        _validate_amp(self.amp_mode)
+        if not self.amp_mode and params.dtype != x.dtype:
+            params = params.to(x.dtype)
         if self.adaptive_scale:
             scale, shift = params.chunk(chunks=2, dim=1)
             x = self.act(torch.addcmul(shift, self.norm1(x), scale + 1))

--- a/test/models/diffusion/test_diffusion_unet_3d.py
+++ b/test/models/diffusion/test_diffusion_unet_3d.py
@@ -282,7 +282,8 @@ class TestArchitecture:
             DiffusionUNet3D, seed=0, amp_mode=True, **arch_kwargs
         ).to(device)
         data = _generate_batch_data(arch_kwargs, x_shape, GLOBAL_SEED, device)
-        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+        dev_type = torch.device(device).type
+        with torch.autocast(device_type=dev_type, dtype=torch.bfloat16):
             out = model(data["x"], data["t"], condition=data["condition"])
         assert out.shape == x_shape
         assert out.dtype == torch.bfloat16
@@ -296,7 +297,8 @@ class TestArchitecture:
             DiffusionUNet3D, seed=0, **arch_kwargs
         ).to(device)
         data = _generate_batch_data(arch_kwargs, x_shape, GLOBAL_SEED, device)
-        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+        dev_type = torch.device(device).type
+        with torch.autocast(device_type=dev_type, dtype=torch.bfloat16):
             with pytest.raises(RuntimeError, match="amp_mode"):
                 model(data["x"], data["t"], condition=data["condition"])
 

--- a/test/models/diffusion/test_diffusion_unet_3d.py
+++ b/test/models/diffusion/test_diffusion_unet_3d.py
@@ -276,6 +276,42 @@ class TestArchitecture:
         assert x.grad is not None
         assert not torch.isnan(x.grad).any()
 
+    def test_amp_mode_autocast_forward(self, arch_name, arch_kwargs, x_shape, device):
+        """With amp_mode=True the forward runs under torch.autocast."""
+        model = instantiate_model_deterministic(
+            DiffusionUNet3D, seed=0, amp_mode=True, **arch_kwargs
+        ).to(device)
+        data = _generate_batch_data(arch_kwargs, x_shape, GLOBAL_SEED, device)
+        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+            out = model(data["x"], data["t"], condition=data["condition"])
+        assert out.shape == x_shape
+        assert out.dtype == torch.bfloat16
+        assert not torch.isnan(out.float()).any()
+
+    def test_amp_mode_default_raises_under_autocast(
+        self, arch_name, arch_kwargs, x_shape, device
+    ):
+        """With the default amp_mode=False, autocast execution raises."""
+        model = instantiate_model_deterministic(
+            DiffusionUNet3D, seed=0, **arch_kwargs
+        ).to(device)
+        data = _generate_batch_data(arch_kwargs, x_shape, GLOBAL_SEED, device)
+        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+            with pytest.raises(RuntimeError, match="amp_mode"):
+                model(data["x"], data["t"], condition=data["condition"])
+
+    def test_amp_mode_true_without_autocast(
+        self, arch_name, arch_kwargs, x_shape, device
+    ):
+        """amp_mode=True still runs in full precision outside autocast."""
+        model = instantiate_model_deterministic(
+            DiffusionUNet3D, seed=0, amp_mode=True, **arch_kwargs
+        ).to(device)
+        data = _generate_batch_data(arch_kwargs, x_shape, GLOBAL_SEED, device)
+        out = model(data["x"], data["t"], condition=data["condition"])
+        assert out.shape == x_shape
+        assert out.dtype == data["x"].dtype
+
     @pytest.mark.usefixtures("nop_compile")
     def test_compile(
         self,

--- a/test/models/diffusion/test_layers_diffusion_unet_3d_blocks.py
+++ b/test/models/diffusion/test_layers_diffusion_unet_3d_blocks.py
@@ -541,7 +541,8 @@ class TestUNetBlock3D:
         block = UNetBlock3D(amp_mode=True, **kwargs).to(device)
         x = torch.randn(*x_shape, device=device)
         emb = torch.randn(*emb_shape, device=device)
-        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+        dev_type = torch.device(device).type
+        with torch.autocast(device_type=dev_type, dtype=torch.bfloat16):
             out = block(x, emb)
         assert not torch.isnan(out.float()).any()
 
@@ -552,7 +553,8 @@ class TestUNetBlock3D:
         block = UNetBlock3D(**kwargs).to(device)
         x = torch.randn(*x_shape, device=device)
         emb = torch.randn(*emb_shape, device=device)
-        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+        dev_type = torch.device(device).type
+        with torch.autocast(device_type=dev_type, dtype=torch.bfloat16):
             with pytest.raises(RuntimeError, match="amp_mode"):
                 block(x, emb)
 

--- a/test/models/diffusion/test_layers_diffusion_unet_3d_blocks.py
+++ b/test/models/diffusion/test_layers_diffusion_unet_3d_blocks.py
@@ -534,6 +534,28 @@ class TestUNetBlock3D:
         assert x.grad is not None
         assert not torch.isnan(x.grad).any()
 
+    def test_amp_mode_autocast_forward(
+        self, config_name, kwargs, x_shape, emb_shape, device
+    ):
+        """With amp_mode=True the block runs under torch.autocast."""
+        block = UNetBlock3D(amp_mode=True, **kwargs).to(device)
+        x = torch.randn(*x_shape, device=device)
+        emb = torch.randn(*emb_shape, device=device)
+        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+            out = block(x, emb)
+        assert not torch.isnan(out.float()).any()
+
+    def test_amp_mode_default_raises_under_autocast(
+        self, config_name, kwargs, x_shape, emb_shape, device
+    ):
+        """With the default amp_mode=False, autocast execution raises."""
+        block = UNetBlock3D(**kwargs).to(device)
+        x = torch.randn(*x_shape, device=device)
+        emb = torch.randn(*emb_shape, device=device)
+        with torch.autocast(device_type=device, dtype=torch.bfloat16):
+            with pytest.raises(RuntimeError, match="amp_mode"):
+                block(x, emb)
+
     @pytest.mark.usefixtures("nop_compile")
     def test_compile(
         self,


### PR DESCRIPTION
## Description

The experimental 3D diffusion U-Net could not run under `torch.autocast`: its internal `physicsnemo.nn` layers (`Linear`, `PositionalEmbedding`, `FourierEmbedding`) validate their `amp_mode` flag and raise when autocast is active, but neither `DiffusionUNet3D` nor `UNetBlock3D` exposed the flag, so mixed-precision training always failed with `RuntimeError: amp_mode=False but torch autocast is enabled`.

This PR threads `amp_mode` through both classes, mirroring `SongUNet` and the 2D `UNetBlock`:

- `DiffusionUNet3D` gains `amp_mode: bool = False` and passes it to the noise/condition embeddings, the map linears, and every `UNetBlock3D` (via `block_kwargs`).
- `UNetBlock3D` gains `amp_mode: bool = False`, passes it to its affine `Linear`, and applies the standard `_validate_amp` / conditional-cast pattern to the affine conditioning parameters (matching `physicsnemo/nn/module/unet_layers.py`).

Defaults preserve existing behavior (`amp_mode=False`), and previously saved checkpoints load unchanged (the existing `.mdlus` non-regression tests pass).

New tests (parametrized over all architecture configurations): autocast bf16 forward with `amp_mode=True` (shape/dtype/finiteness), error on the default `amp_mode=False` under autocast, and full-precision execution with `amp_mode=True` outside autocast; analogous tests for `UNetBlock3D`. Validated end-to-end by training an EDM-preconditioned `DiffusionUNet3D` under `torch.autocast` bf16.

closes #1935

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [x] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

None.
