### PR TITLE
Fix DistributedManager initialization on CPU-only hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DistributedManager` initialization on CPU-only hosts: `setup()` no
+  longer passes a CPU `torch.device` as `device_id` to
+  `torch.distributed.init_process_group` (which raises on recent PyTorch
+  versions) and no longer divides by zero when deriving `local_rank`
+  without visible accelerators; `cleanup()` no longer asserts when the
+  process group was never created (e.g. after a failed initialization).
 - `MeshReader` / `DomainMeshReader` sample discovery no longer uses
   `pathlib.Path.glob`, which can silently drop entries under filesystem
   metadata-server load (Lustre), causing training to proceed on a subset

--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -576,7 +576,9 @@ class DistributedManager(object):
             manager._rank = rank
             manager._world_size = world_size
             if local_rank is None:
-                manager._local_rank = rank % torch.cuda.device_count()
+                # On CPU-only hosts there are no devices to assign by rank
+                n_devices = torch.cuda.device_count()
+                manager._local_rank = rank % n_devices if n_devices > 0 else 0
             else:
                 manager._local_rank = local_rank
 
@@ -585,13 +587,16 @@ class DistributedManager(object):
         )
 
         if manager._distributed:
-            # Setup distributed process group
+            # Setup distributed process group. device_id must be an
+            # accelerator device: recent PyTorch versions raise when a CPU
+            # device is passed, so only bind a device on CUDA.
+            device_id = manager.device if manager.device.type == "cuda" else None
             try:
                 dist.init_process_group(
                     backend,
                     rank=manager.rank,
                     world_size=manager.world_size,
-                    device_id=manager.device,
+                    device_id=device_id,
                 )
             except TypeError:
                 # device_id only introduced in PyTorch 2.3
@@ -741,6 +746,26 @@ class DistributedManager(object):
         parent: Optional[str] = None,
         verbose: bool = False,
     ):  # pragma: no cover
+        """Create the process subgroup described by a ``ProcessGroupNode``.
+
+        Creates the subgroup for ``node`` (whose ``size`` must already be
+        populated) under the optional ``parent`` group, together with the
+        corresponding orthogonal process group.
+
+        Parameters
+        ----------
+        node : ProcessGroupNode
+            Node describing the process group to create.
+        parent : str, optional
+            Name of the parent process group, by default None.
+        verbose : bool, optional
+            Print group creation details, by default False.
+
+        Returns
+        -------
+        str
+            Name of the orthogonal process group that was created.
+        """
         if node.size is None:
             raise AssertionError(
                 "Cannot create groups from a ProcessGroupNode that is not fully"
@@ -762,6 +787,19 @@ class DistributedManager(object):
     def create_groups_from_config(
         config: ProcessGroupConfig, verbose: bool = False
     ):  # pragma: no cover
+        """Create nested process groups from a ``ProcessGroupConfig`` tree.
+
+        Traverses the config tree breadth-first, creating each group with
+        :meth:`create_group_from_node`. Deprecated on PyTorch > 2.4 in favor
+        of ``DeviceMesh`` and :meth:`initialize_mesh`.
+
+        Parameters
+        ----------
+        config : ProcessGroupConfig
+            Tree of process groups to create.
+        verbose : bool, optional
+            Print group creation details, by default False.
+        """
         if torch.__version__ > "2.4":
             warnings.warn(
                 "DistributedManager.create_groups_from_config is no longer the most simple "
@@ -814,6 +852,7 @@ class DistributedManager(object):
             and DistributedManager._shared_state["_is_initialized"]
             and "_distributed" in DistributedManager._shared_state
             and DistributedManager._shared_state["_distributed"]
+            and dist.is_initialized()
         ):
             if barrier:
                 if torch.cuda.is_available():

--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -310,15 +310,12 @@ class DistributedManager(object):
         """Setup method using generic initialization"""
         rank = int(os.environ.get("RANK"))
         world_size = int(os.environ.get("WORLD_SIZE"))
-        if "LOCAL_RANK" in os.environ:
-            local_rank = os.environ.get("LOCAL_RANK")
-            if local_rank is not None:
-                local_rank = int(local_rank)
-            else:
-                local_rank = rank % torch.cuda.device_count()
-
-        else:
-            local_rank = rank % torch.cuda.device_count()
+        local_rank = os.environ.get("LOCAL_RANK")
+        if local_rank is not None:
+            local_rank = int(local_rank)
+        # When LOCAL_RANK is not provided, leave it as None so that setup()
+        # derives it (rank modulo the accelerator count, or 0 on CPU-only
+        # hosts).
 
         # Read env variables
         addr = os.environ.get("MASTER_ADDR")

--- a/test/distributed/test_manager.py
+++ b/test/distributed/test_manager.py
@@ -74,6 +74,35 @@ def test_manager(monkeypatch):
     DistributedManager.cleanup()
 
 
+def test_manager_setup_cpu_gloo(monkeypatch):
+    """setup() must work on CPU-only hosts (gloo backend, no accelerator).
+
+    Regression test: passing a CPU torch.device as ``device_id`` to
+    ``init_process_group`` raises on recent PyTorch versions, and deriving
+    ``local_rank`` from ``torch.cuda.device_count()`` divides by zero when
+    no accelerator is present.
+    """
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+
+    DistributedManager.setup(
+        rank=0,
+        world_size=1,
+        local_rank=None,
+        addr="localhost",
+        port="12356",
+        backend="gloo",
+        method="env",
+    )
+    manager = DistributedManager()
+
+    assert manager.is_initialized()
+    assert manager.device.type == "cpu"
+    assert manager.local_rank == 0
+    assert torch.distributed.is_initialized()
+    DistributedManager.cleanup()
+
+
 def test_manager_slurm(monkeypatch):
     # Test distributed manager with Slurm variables
     monkeypatch.setenv("MASTER_ADDR", "localhost")

--- a/test/distributed/test_manager.py
+++ b/test/distributed/test_manager.py
@@ -103,6 +103,27 @@ def test_manager_setup_cpu_gloo(monkeypatch):
     DistributedManager.cleanup()
 
 
+def test_manager_initialize_env_cpu_no_local_rank(monkeypatch):
+    """initialize() via env variables must work on CPU-only hosts when
+    LOCAL_RANK is not set (local rank derivation must not divide by the
+    accelerator count)."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "1")
+    monkeypatch.setenv("MASTER_ADDR", "localhost")
+    monkeypatch.setenv("MASTER_PORT", "12357")
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+
+    DistributedManager.initialize()
+    manager = DistributedManager()
+
+    assert manager.is_initialized()
+    assert manager.device.type == "cpu"
+    assert manager.local_rank == 0
+    DistributedManager.cleanup()
+
+
 def test_manager_slurm(monkeypatch):
     # Test distributed manager with Slurm variables
     monkeypatch.setenv("MASTER_ADDR", "localhost")


### PR DESCRIPTION
## Description

`DistributedManager.setup()` failed on hosts without accelerators (e.g. laptop-scale gloo runs, CPU nodes):

- it passed the CPU `torch.device` as the `device_id` argument of `torch.distributed.init_process_group`, which recent PyTorch versions reject with `ValueError: init_process_group device_id parameter must be an accelerator with an index`;
- with `local_rank=None` (the SLURM/OpenMPI initialization paths) it derived the local rank as `rank % torch.cuda.device_count()`, a division by zero when no accelerator is present.

This PR binds a device to the process group only on CUDA (`device_id=None` otherwise, the documented default), defaults `local_rank` to 0 on CPU-only hosts, and additionally guards `cleanup()` on the process group actually existing so a failed initialization no longer cascades into `AssertionError: Process group cannot be None` from the `atexit` handler, obscuring the original error.

Verified with a two-process gloo run launched by `torchrun` on a CPU-only machine (initialize → broadcast → barrier → cleanup). Adds a regression test that forces the CPU code path via monkeypatched `torch.cuda.is_available` / `device_count`, so it exercises the fix even on GPU CI (the existing distributed-manager tests are skipped on CPU by an autouse fixture, which is how this path went unnoticed). Also adds docstrings to two pre-existing undocumented methods in `manager.py` flagged by the `interrogate` pre-commit hook.

closes #1936

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [x] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

None.
