### PR TITLE
Use `preadv` to load tensor data in `MeshReader` and `DomainMeshReader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,6 +482,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It was annotated optional while the constructor raised on `None`, so callers
   that already pass it by keyword are unaffected. It also gains `matern_nu`,
   which was previously hardcoded to 2.5 (still the default).
+- `MeshReader` and `DomainMeshReader` now use `preadv` to load tensor data.
+  Any tensor the reader cannot locate exactly on disk (not memory-mapped, a
+  view of a larger mapping, or a platform without `preadv`) takes the previous
+  path. Explicit reads keep the pages of already-read samples out of the
+  process resident set, and can be faster where page faults are expensive,
+  such as cold data on a network filesystem. Readers that neither subsample
+  nor pin are unaffected.
 
 ### Deprecated
 

--- a/physicsnemo/datapipes/readers/mesh.py
+++ b/physicsnemo/datapipes/readers/mesh.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import glob as _glob
 import logging
+import os
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -45,10 +46,123 @@ DEFAULT_MESH_EXTENSION = ".pmsh"
 DEFAULT_DOMAIN_MESH_EXTENSION = ".pdmsh"
 
 
+def _pread_leaf(
+    t: torch.Tensor,
+    runs: list[tuple[int, int]] | None = None,
+    *,
+    pin_memory: bool = False,
+) -> torch.Tensor | None:
+    """Materialize a memory-mapped tensor by reading it, not by faulting it in.
+
+    Reads the whole tensor, or only the rows covered by *runs*
+    (``(start, length)`` pairs), into a fresh buffer with
+    :func:`os.preadv`.  The result is identical to indexing the memory map
+    and copying, but the kernel fills the destination directly: no page
+    faults, one call per run instead of one fault per page, and no mapped
+    pages left charged to the process.
+
+    Returns ``None`` when *t* is not a whole, contiguous, memory-mapped
+    tensor, or the platform has no ``preadv``, leaving the caller to use
+    the ordinary path.
+    """
+    filename = getattr(t, "filename", None)
+    if filename is None or getattr(t, "index", None) is not None:
+        return None
+    if not hasattr(os, "preadv") or not t.is_contiguous() or t.numel() == 0:
+        return None
+    ### A view into a larger mapping would need the parent's layout to locate
+    ### its bytes on disk; only a whole tensor maps 1:1 onto its backing file.
+    if t.storage_offset() != 0 or t.untyped_storage().nbytes() != t.nbytes:
+        return None
+
+    if runs is None:
+        ranges = [(0, t.nbytes)]
+        shape = t.shape
+    else:
+        if t.ndim == 0:
+            return None
+        row_bytes = t.nbytes // t.shape[0]
+        ranges = [(start * row_bytes, length * row_bytes) for start, length in runs]
+        shape = torch.Size((sum(length for _, length in runs), *t.shape[1:]))
+
+    buf = torch.empty(
+        sum(nbytes for _, nbytes in ranges), dtype=torch.uint8, pin_memory=pin_memory
+    )
+    # os.preadv needs the buffer protocol, which Tensor does not implement.
+    view = buf.numpy()
+    fd = os.open(filename, os.O_RDONLY)
+    try:
+        pos = 0
+        for offset, nbytes in ranges:
+            if os.preadv(fd, [view[pos : pos + nbytes]], offset) != nbytes:
+                raise OSError(
+                    f"short read of {nbytes} bytes at offset {offset} in {filename}"
+                )
+            pos += nbytes
+    finally:
+        os.close(fd)
+    return buf.view(t.dtype).reshape(shape)
+
+
+def _contiguous_runs(indices: torch.Tensor) -> list[tuple[int, int]] | None:
+    """Rewrite row *indices* as ``(start, length)`` runs of consecutive rows.
+
+    Each run is one byte range, so selecting a block becomes one or two
+    reads instead of a gather over the mapping.
+    :func:`_cyclic_block_indices` produces exactly that shape: one
+    ascending run, or two when the block wraps past the end of the array.
+
+    Returns ``None`` when the indices would need more than two runs,
+    which tells the caller to fall back to ordinary indexing.  The runs
+    are read off the tensor rather than recomputed from the block's start
+    and length, so the bytes read stay in step with the indices even if
+    the sampler changes.
+    """
+    if indices.ndim != 1 or indices.numel() == 0:
+        return None
+    breaks = (indices.diff() != 1).nonzero().flatten()
+    if breaks.numel() > 1:
+        return None
+    return [
+        (int(run[0]), run.numel())
+        for run in indices.tensor_split((breaks + 1).tolist())
+    ]
+
+
+def _read_rows(
+    t: torch.Tensor,
+    indices: torch.Tensor,
+    runs: list[tuple[int, int]] | None,
+    pin_memory: bool,
+) -> torch.Tensor:
+    """Rows *indices* of *t*, read with ``pread`` when *t* is memory-mapped."""
+    if runs is not None:
+        out = _pread_leaf(t, runs, pin_memory=pin_memory)
+        if out is not None:
+            return out
+    return t[indices]
+
+
+def _pin_memory(md: Mesh | DomainMesh) -> Mesh | DomainMesh:
+    """``pin_memory()`` that reads memory-mapped leaves instead of faulting them.
+
+    Every leaf is copied either way; this only changes how the bytes reach
+    the pinned buffer.
+    """
+
+    def pin(t: torch.Tensor) -> torch.Tensor:
+        out = _pread_leaf(t, pin_memory=True)
+        return t.pin_memory() if out is None else out
+
+    return md.apply(pin)
+
+
 def _subsample_mesh_points(
     mesh: Mesh,
     n_points: int,
     generator: torch.Generator | None = None,
+    *,
+    pin_memory: bool = False,
 ) -> Mesh:
     """Subsample a Mesh to *n_points* via a cyclic contiguous block read.
 
@@ -63,6 +177,10 @@ def _subsample_mesh_points(
     measure weights: dropping points removes cells implicitly, with
     no per-cell inclusion probability to invert.  Prefer cell
     subsampling when downstream code integrates over the mesh.
+
+    ``pin_memory`` reads the selected rows of memmap-backed data straight
+    into pinned memory (see :func:`_pread_leaf`), sparing the caller's
+    later ``pin_memory()`` a second copy.
     """
     if mesh.n_points <= n_points:
         return mesh
@@ -73,10 +191,14 @@ def _subsample_mesh_points(
         device=mesh.points.device,
     )
     if mesh.n_cells == 0:
+        runs = _contiguous_runs(indices)
         return Mesh(
-            points=mesh.points[indices],
+            points=_read_rows(mesh.points, indices, runs, pin_memory),
             cells=mesh.cells,
-            point_data=mesh.point_data[indices],
+            point_data=mesh.point_data.apply(
+                lambda t: _read_rows(t, indices, runs, pin_memory),
+                batch_size=indices.shape,
+            ),
             cell_data=mesh.cell_data,
             global_data=mesh.global_data,
         )
@@ -201,6 +323,8 @@ def _subsample_mesh(
     n_cells: int | None = None,
     n_points: int | None = None,
     generator: torch.Generator | None = None,
+    *,
+    pin_memory: bool = False,
 ) -> Mesh:
     """Apply cell and/or point subsampling to a single Mesh.
 
@@ -210,7 +334,9 @@ def _subsample_mesh(
     if n_cells is not None:
         mesh = _subsample_mesh_cells(mesh, n_cells, generator=generator)
     if n_points is not None:
-        mesh = _subsample_mesh_points(mesh, n_points, generator=generator)
+        mesh = _subsample_mesh_points(
+            mesh, n_points, generator=generator, pin_memory=pin_memory
+        )
     return mesh
 
 
@@ -244,7 +370,9 @@ class MeshReader:
             Glob pattern for mesh paths under ``path``. Default matches ``**/*.pmsh``.
         pin_memory : bool, default=False
             If True, place tensors in pinned (page-locked) memory for faster
-            async CPU→GPU transfers.
+            async CPU→GPU transfers.  Memmap-backed data is read into that
+            buffer rather than faulted in through the mapping, so the
+            process keeps no mapped pages of the samples it has read.
         include_index_in_metadata : bool, default=True
             If True, include sample index in metadata.
         subsample_n_points : int, optional
@@ -373,10 +501,11 @@ class MeshReader:
             self.subsample_n_cells,
             self.subsample_n_points,
             generator=generator,
+            pin_memory=self.pin_memory,
         )
 
         if self.pin_memory:
-            mesh = mesh.pin_memory()
+            mesh = _pin_memory(mesh)
 
         metadata = self._get_sample_metadata(index)
         if self.include_index_in_metadata:
@@ -430,7 +559,9 @@ class DomainMeshReader:
             Default matches ``**/*.pdmsh``.
         pin_memory : bool, default=False
             If True, place tensors in pinned (page-locked) memory for faster
-            async CPU→GPU transfers.
+            async CPU→GPU transfers.  Memmap-backed data is read into that
+            buffer rather than faulted in through the mapping, so the
+            process keeps no mapped pages of the samples it has read.
         include_index_in_metadata : bool, default=True
             If True, include sample index in metadata.
         subsample_n_points : int, optional
@@ -634,6 +765,7 @@ class DomainMeshReader:
                 n_cells=self.subsample_n_cells,
                 n_points=self.subsample_n_points,
                 generator=generator,
+                pin_memory=self.pin_memory,
             )
             interior = _subsample_mesh(dm.interior, **sub_kw)
             boundaries = {
@@ -651,7 +783,7 @@ class DomainMeshReader:
             dm = self._load_extra_boundaries(dm, index)
 
         if self.pin_memory:
-            dm = dm.pin_memory()
+            dm = _pin_memory(dm)
 
         metadata: dict[str, Any] = {
             "source_path": str(self._paths[index]),

--- a/test/datapipes/readers/test_mesh_readers.py
+++ b/test/datapipes/readers/test_mesh_readers.py
@@ -23,6 +23,7 @@ from physicsnemo.datapipes.mesh_dataset import MeshDataset
 from physicsnemo.datapipes.readers.mesh import (
     DomainMeshReader,
     MeshReader,
+    _pread_leaf,
     _subsample_mesh_points,
 )
 from physicsnemo.datapipes.transforms.mesh import (
@@ -539,3 +540,86 @@ class TestCellSubsampleMeasureWeights:
             m, _ = reader[0]
             distinct_blocks.add(round(float(m.points[0, 0])))
         assert len(distinct_blocks) > 5
+
+
+class TestPreadMaterialization:
+    """Reading memmap-backed leaves must be indistinguishable from mapping them.
+
+    The risk in ``_pread_leaf`` is silent byte-level error (wrong offset,
+    dtype, or shape), which produces plausible garbage rather than a
+    failure, so these compare it against the mapped reads it replaces.
+    """
+
+    @staticmethod
+    def _save_point_cloud(tmp_path):
+        """A cloud (no cells) takes the contiguous-block subsample path."""
+        Mesh(
+            points=torch.rand(64, 3),
+            point_data={"f": torch.rand(64, 2), "i": torch.arange(64)},
+            global_data={"s": torch.tensor(1.5)},
+        ).save(tmp_path / "c.pmsh")
+        return Mesh.load(tmp_path / "c.pmsh")
+
+    def test_whole_tensor_matches_mapping(self, tmp_path):
+        loaded = self._save_point_cloud(tmp_path)
+        for t in (
+            loaded.points,
+            loaded.point_data["f"],
+            loaded.point_data["i"],
+            loaded.global_data["s"],  # 0-dim
+        ):
+            assert torch.equal(_pread_leaf(t), t)
+
+    @pytest.mark.parametrize("runs", [[(0, 64)], [(10, 20)], [(60, 4), (0, 6)]])
+    def test_row_runs_match_mapping(self, tmp_path, runs):
+        loaded = self._save_point_cloud(tmp_path)
+        for t in (loaded.points, loaded.point_data["f"], loaded.point_data["i"]):
+            want = torch.cat([t[start : start + length] for start, length in runs])
+            assert torch.equal(_pread_leaf(t, runs), want)
+
+    def test_declines_tensors_it_cannot_locate(self, tmp_path):
+        loaded = self._save_point_cloud(tmp_path)
+        assert _pread_leaf(torch.rand(4, 3)) is None  # never mapped
+        assert _pread_leaf(loaded.points[:4]) is None  # a view of a mapping
+
+    def test_reader_output_matches_mapped_reads(self, tmp_path, monkeypatch):
+        """Disabling pread reproduces the pre-pread path exactly."""
+        self._save_point_cloud(tmp_path)
+
+        def sample():
+            reader = MeshReader(tmp_path, pattern="*.pmsh", subsample_n_points=10)
+            reader.set_generator(torch.Generator().manual_seed(3))
+            return reader[0][0]
+
+        with_pread = sample()
+        monkeypatch.setattr(
+            "physicsnemo.datapipes.readers.mesh._pread_leaf", lambda *a, **k: None
+        )
+        mapped = sample()
+        keys = list(with_pread.keys(include_nested=True, leaves_only=True))
+        assert keys == list(mapped.keys(include_nested=True, leaves_only=True))
+        for key in keys:
+            assert torch.equal(with_pread.get(key), mapped.get(key))
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_pinned_output_matches_mapped_reads(self, tmp_path, monkeypatch):
+        """pin_memory reads every leaf, including the ones subsampling skips."""
+        self._save_point_cloud(tmp_path)
+
+        def sample():
+            reader = MeshReader(tmp_path, pattern="*.pmsh", pin_memory=True)
+            reader.set_generator(torch.Generator().manual_seed(3))
+            return reader[0][0]
+
+        with_pread = sample()
+        monkeypatch.setattr(
+            "physicsnemo.datapipes.readers.mesh._pread_leaf", lambda *a, **k: None
+        )
+        mapped = sample()
+        assert with_pread.points.is_pinned()
+        for key in with_pread.keys(include_nested=True, leaves_only=True):
+            got, want = with_pread.get(key), mapped.get(key)
+            ### Empty leaves stay unpinned on both paths: pin_memory() does not
+            ### page-lock a zero-byte allocation.
+            assert got.is_pinned() == want.is_pinned()
+            assert torch.equal(got, want)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

Update `MeshReader` and `DomainMeshReader` to use `preadv` for loading tensor data rather than indexing into the memory mapped files, which loads data through page faults. Any tensor the reader cannot locate exactly on disk (not memory-mapped, a view of a larger mapping, or a platform without `preadv`) takes the previous path. Explicit reads keep the pages of already-read samples out of the process resident set, and can be faster where page faults are expensive, such as cold data on a network filesystem. Readers that neither subsample nor pin are unaffected.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [x] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

Depends on #1872.

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
