### PR TITLE
Restore legacy experimental import paths for GeoTransolver and FLARE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `physicsnemo.experimental.guardrails.embedded.GuardedGeoTransolver` (or
   `attach_ood_guard`) to enable out-of-distribution guarding. PhysicsNeMo removes
   the  `guard_config` model argument. Legacy import shims keep the pre-move
-  `physicsnemo.experimental` import paths working.
+  `physicsnemo.experimental` import paths working and emit a
+  `LegacyFeatureWarning` pointing to the new locations.
 - Adds `zenith_azimuth_angles` and `zenith_azimuth_angles_from_timestamp` to
   `physicsnemo.utils.zenith_angle`, returning
   `(sin_zenith, cos_zenith, sin_azimuth, cos_azimuth)` alongside the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Wrap a constructed GeoTransolver with
   `physicsnemo.experimental.guardrails.embedded.GuardedGeoTransolver` (or
   `attach_ood_guard`) to enable out-of-distribution guarding. PhysicsNeMo removes
-  the  `guard_config` model argument.
+  the  `guard_config` model argument. Legacy import shims keep the pre-move
+  `physicsnemo.experimental` import paths working.
 - Adds `zenith_azimuth_angles` and `zenith_azimuth_angles_from_timestamp` to
   `physicsnemo.utils.zenith_angle`, returning
   `(sin_zenith, cos_zenith, sin_azimuth, cos_azimuth)` alongside the existing

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_synthetic_configs.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_synthetic_configs.py
@@ -36,10 +36,9 @@ Each test:
    output shape matches ``target_config``.
 7. Computes the dict-based loss to confirm pred / target shapes line up.
 
-Tests skip if the model class is not importable (e.g., FLARE under
-``physicsnemo.experimental`` may be gated, or DoMINO is not yet wired
-up). The test set deliberately excludes DoMINO recipes because their
-``forward_kwargs`` references fields the dataset doesn't expose
+Tests skip if the model class is not importable (for example, DoMINO
+is not yet wired up). The test set deliberately excludes DoMINO recipes
+because their ``forward_kwargs`` references fields the dataset doesn't expose
 (documented in the model template comments).
 """
 

--- a/examples/kinetic_monte_carlo/utils/nn.py
+++ b/examples/kinetic_monte_carlo/utils/nn.py
@@ -27,9 +27,7 @@ from jaxtyping import Bool, Float
 from torch import Tensor
 
 from physicsnemo.core.module import Module
-from physicsnemo.experimental.models.geotransolver.context_projector import (
-    ContextProjector,
-)
+from physicsnemo.models.geotransolver import ContextProjector
 from physicsnemo.nn.module.embedding_layers import PositionalEmbedding
 
 # Numerical floor added to a standard deviation before dividing by it.

--- a/examples/structural_mechanics/drop_test/README.md
+++ b/examples/structural_mechanics/drop_test/README.md
@@ -23,7 +23,7 @@ The implementation uses a GeoTransolver backbone with one-shot training and is c
 pip install -r requirements.txt
 ```
 
-GeoTransolver lives under `physicsnemo.experimental.models`, so a standard PhysicsNeMo install is sufficient — no extras required.
+GeoTransolver lives under `physicsnemo.models`, so a standard PhysicsNeMo install needs no extras.
 
 ## Data Preprocessing
 

--- a/physicsnemo/experimental/models/flare/__init__.py
+++ b/physicsnemo/experimental/models/flare/__init__.py
@@ -14,8 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Legacy checkpoint shim for the FLARE model."""
+r"""Legacy import shims for the FLARE model.
+
+The model now lives in :mod:`physicsnemo.models.flare`. Import it from there
+instead:
+
+.. code-block:: python
+
+    from physicsnemo.models.flare import FLARE
+
+Importing from this legacy namespace emits a
+:class:`~physicsnemo.core.warnings.LegacyFeatureWarning`; PhysicsNeMo will
+remove these shims in a future release.
+"""
+
+import warnings
+
+from physicsnemo.core.warnings import LegacyFeatureWarning
 
 from .flare import FLARE
+
+warnings.warn(
+    "Importing from 'physicsnemo.experimental.models.flare' is deprecated. "
+    "Use 'from physicsnemo.models.flare import FLARE' instead. "
+    "This backward-compatibility shim will be removed in a future release.",
+    LegacyFeatureWarning,
+    stacklevel=2,
+)
 
 __all__ = ["FLARE"]

--- a/physicsnemo/experimental/models/geotransolver/__init__.py
+++ b/physicsnemo/experimental/models/geotransolver/__init__.py
@@ -14,8 +14,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Legacy checkpoint shim for the GeoTransolver model."""
+"""Legacy import shims for the GeoTransolver model and its components."""
 
-from .geotransolver import GeoTransolver
+from physicsnemo.nn import (
+    ConcreteDropout,
+    collect_concrete_dropout_losses,
+    get_concrete_dropout_rates,
+)
 
-__all__ = ["GeoTransolver"]
+from .context_projector import (
+    ContextProjector,
+    GeometricFeatureProcessor,
+    GlobalContextBuilder,
+    MultiScaleFeatureExtractor,
+    StructuredContextProjector,
+)
+from .gale import (
+    GALE,
+    GALE_FA,
+    GALE_block,
+    GALEStructuredMesh2D,
+    GALEStructuredMesh3D,
+)
+from .geotransolver import GeoTransolver, GeoTransolverMetaData
+
+__all__ = [
+    "GeoTransolver",
+    "GeoTransolverMetaData",
+    "GALE",
+    "GALE_FA",
+    "GALE_block",
+    "GALEStructuredMesh2D",
+    "GALEStructuredMesh3D",
+    "ContextProjector",
+    "GeometricFeatureProcessor",
+    "GlobalContextBuilder",
+    "MultiScaleFeatureExtractor",
+    "StructuredContextProjector",
+    "ConcreteDropout",
+    "collect_concrete_dropout_losses",
+    "get_concrete_dropout_rates",
+]

--- a/physicsnemo/experimental/models/geotransolver/__init__.py
+++ b/physicsnemo/experimental/models/geotransolver/__init__.py
@@ -14,8 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Legacy import shims for the GeoTransolver model and its components."""
+r"""Legacy import shims for the GeoTransolver model and its components.
 
+The model, its metadata, and the context projector components now live in
+:mod:`physicsnemo.models.geotransolver`; the GALE attention layers now live in
+:mod:`physicsnemo.nn`. Import them from there instead:
+
+.. code-block:: python
+
+    from physicsnemo.models.geotransolver import ContextProjector, GeoTransolver
+    from physicsnemo.nn import GALE, GALEBlock
+
+Importing from this legacy namespace emits a
+:class:`~physicsnemo.core.warnings.LegacyFeatureWarning`; PhysicsNeMo will
+remove these shims in a future release.
+"""
+
+import warnings
+
+from physicsnemo.core.warnings import LegacyFeatureWarning
 from physicsnemo.nn import (
     ConcreteDropout,
     collect_concrete_dropout_losses,
@@ -37,6 +54,16 @@ from .gale import (
     GALEStructuredMesh3D,
 )
 from .geotransolver import GeoTransolver, GeoTransolverMetaData
+
+warnings.warn(
+    "Importing from 'physicsnemo.experimental.models.geotransolver' is deprecated. "
+    "Import GeoTransolver, its metadata, and the context projector components "
+    "from 'physicsnemo.models.geotransolver', and the GALE attention layers "
+    "(GALE_block is now named GALEBlock) from 'physicsnemo.nn' instead. "
+    "This backward-compatibility shim will be removed in a future release.",
+    LegacyFeatureWarning,
+    stacklevel=2,
+)
 
 __all__ = [
     "GeoTransolver",

--- a/physicsnemo/experimental/models/geotransolver/context_projector.py
+++ b/physicsnemo/experimental/models/geotransolver/context_projector.py
@@ -14,11 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Legacy checkpoint shim for the GeoTransolver model."""
+"""Legacy import shim for the GeoTransolver context projector components."""
 
-from physicsnemo.models.geotransolver.geotransolver import (
-    GeoTransolver,
-    GeoTransolverMetaData,
+from physicsnemo.models.geotransolver.context_projector import (
+    ContextProjector,
+    GeometricFeatureProcessor,
+    GlobalContextBuilder,
+    MultiScaleFeatureExtractor,
+    StructuredContextProjector,
 )
 
-__all__ = ["GeoTransolver", "GeoTransolverMetaData"]
+__all__ = [
+    "ContextProjector",
+    "GeometricFeatureProcessor",
+    "GlobalContextBuilder",
+    "MultiScaleFeatureExtractor",
+    "StructuredContextProjector",
+]

--- a/physicsnemo/experimental/models/geotransolver/gale.py
+++ b/physicsnemo/experimental/models/geotransolver/gale.py
@@ -14,11 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Legacy checkpoint shim for the GeoTransolver model."""
+"""Legacy import shim for the GALE attention layers."""
 
-from physicsnemo.models.geotransolver.geotransolver import (
-    GeoTransolver,
-    GeoTransolverMetaData,
+from physicsnemo.nn.module.gale import (
+    GALE,
+    GALE_FA,
+    GALEStructuredMesh2D,
+    GALEStructuredMesh3D,
 )
 
-__all__ = ["GeoTransolver", "GeoTransolverMetaData"]
+# The move out of experimental renamed GALE_block to GALEBlock.
+from physicsnemo.nn.module.gale import GALEBlock as GALE_block
+
+__all__ = [
+    "GALE",
+    "GALE_FA",
+    "GALE_block",
+    "GALEStructuredMesh2D",
+    "GALEStructuredMesh3D",
+]

--- a/physicsnemo/experimental/nn/__init__.py
+++ b/physicsnemo/experimental/nn/__init__.py
@@ -21,8 +21,11 @@ that are under active development. These components may have breaking API
 changes between releases.
 """
 
+import warnings
+
+from physicsnemo.core.warnings import LegacyFeatureWarning
+
 from .diffusion_unet_3d_blocks import Conv3D, GroupNorm3D, UNetAttention3D, UNetBlock3D
-from .flare_attention import FLARE
 from .rope import (
     build_axial_rope_cos_sin_2d_continuous,
     build_rope_cos_sin_1d_continuous,
@@ -61,3 +64,22 @@ __all__ = [
     "masked_mean",
     "unflatten_to_padded",
 ]
+
+
+def __getattr__(name):
+    # Lazy legacy re-export: FLARE moved to physicsnemo.nn, and warning only on
+    # access keeps plain 'import physicsnemo.experimental.nn' silent.
+    if name == "FLARE":
+        warnings.warn(
+            "Importing 'FLARE' from 'physicsnemo.experimental.nn' is deprecated. "
+            "Use 'from physicsnemo.nn import FLARE' instead. "
+            "This backward-compatibility shim will be removed in a future release.",
+            LegacyFeatureWarning,
+            stacklevel=2,
+        )
+        from physicsnemo.nn import FLARE
+
+        return FLARE
+    raise AttributeError(
+        f"module 'physicsnemo.experimental.nn' has no attribute {name!r}"
+    )

--- a/physicsnemo/experimental/nn/__init__.py
+++ b/physicsnemo/experimental/nn/__init__.py
@@ -22,6 +22,7 @@ changes between releases.
 """
 
 from .diffusion_unet_3d_blocks import Conv3D, GroupNorm3D, UNetAttention3D, UNetBlock3D
+from .flare_attention import FLARE
 from .rope import (
     build_axial_rope_cos_sin_2d_continuous,
     build_rope_cos_sin_1d_continuous,
@@ -41,6 +42,7 @@ from .point_utils import (
 )
 
 __all__ = [
+    "FLARE",
     "UNetBlock3D",
     "Conv3D",
     "GroupNorm3D",

--- a/physicsnemo/experimental/nn/flare_attention.py
+++ b/physicsnemo/experimental/nn/flare_attention.py
@@ -16,6 +16,17 @@
 
 """Legacy import shim for the FLARE attention layer."""
 
+import warnings
+
+from physicsnemo.core.warnings import LegacyFeatureWarning
 from physicsnemo.nn.module.flare_attention import FLARE
+
+warnings.warn(
+    "Importing from 'physicsnemo.experimental.nn.flare_attention' is deprecated. "
+    "Use 'from physicsnemo.nn import FLARE' instead. "
+    "This backward-compatibility shim will be removed in a future release.",
+    LegacyFeatureWarning,
+    stacklevel=2,
+)
 
 __all__ = ["FLARE"]

--- a/physicsnemo/experimental/nn/flare_attention.py
+++ b/physicsnemo/experimental/nn/flare_attention.py
@@ -14,11 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Legacy checkpoint shim for the GeoTransolver model."""
+"""Legacy import shim for the FLARE attention layer."""
 
-from physicsnemo.models.geotransolver.geotransolver import (
-    GeoTransolver,
-    GeoTransolverMetaData,
-)
+from physicsnemo.nn.module.flare_attention import FLARE
 
-__all__ = ["GeoTransolver", "GeoTransolverMetaData"]
+__all__ = ["FLARE"]

--- a/test/models/flare/test_flare.py
+++ b/test/models/flare/test_flare.py
@@ -15,11 +15,14 @@
 # limitations under the License.
 
 import random
+import re
+import sys
 
 import pytest
 import torch
 
 from physicsnemo.core.module import Module
+from physicsnemo.core.warnings import LegacyFeatureWarning
 from physicsnemo.models.flare import FLARE
 from test.common import (
     check_ort_version,
@@ -37,10 +40,18 @@ from test.conftest import requires_module
 
 def test_flare_legacy_checkpoint_class_path():
     """Test resolving the model class path stored by experimental checkpoints."""
-    from physicsnemo.experimental.models.flare import FLARE as LegacyPackageFLARE
-    from physicsnemo.experimental.models.flare.flare import (
-        FLARE as LegacyModuleFLARE,
-    )
+    # Drop the cached legacy modules so the shim warning fires again.
+    for module_name in list(sys.modules):
+        if module_name.startswith("physicsnemo.experimental.models.flare"):
+            del sys.modules[module_name]
+
+    with pytest.warns(
+        LegacyFeatureWarning, match=re.escape("physicsnemo.models.flare")
+    ):
+        from physicsnemo.experimental.models.flare import FLARE as LegacyPackageFLARE
+        from physicsnemo.experimental.models.flare.flare import (
+            FLARE as LegacyModuleFLARE,
+        )
 
     assert LegacyPackageFLARE is FLARE
     assert LegacyModuleFLARE is FLARE

--- a/test/models/geotransolver/test_geotransolver.py
+++ b/test/models/geotransolver/test_geotransolver.py
@@ -684,6 +684,19 @@ def test_geotransolver_legacy_checkpoint_class_path():
     assert LegacyModuleGeoTransolver is GeoTransolver
 
 
+def test_geotransolver_legacy_import_paths():
+    """Test the component import paths used before the move out of experimental."""
+    import physicsnemo.models.geotransolver as production_pkg
+    from physicsnemo.experimental.models import geotransolver as legacy_pkg
+
+    for legacy_name in legacy_pkg.__all__:
+        # The move out of experimental renamed GALE_block to GALEBlock.
+        production_name = "GALEBlock" if legacy_name == "GALE_block" else legacy_name
+        assert getattr(legacy_pkg, legacy_name) is getattr(
+            production_pkg, production_name
+        ), f"'{legacy_name}' does not resolve to production '{production_name}'"
+
+
 def test_geotransolver_checkpoint(device):
     """Test GeoTransolver checkpoint save/load."""
     torch.manual_seed(42)

--- a/test/models/geotransolver/test_geotransolver.py
+++ b/test/models/geotransolver/test_geotransolver.py
@@ -14,9 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+import re
+import sys
+
 import pytest
 import torch
 
+from physicsnemo.core.warnings import LegacyFeatureWarning
 from physicsnemo.models.geotransolver.geotransolver import (
     GeoTransolver,
 )
@@ -687,7 +692,18 @@ def test_geotransolver_legacy_checkpoint_class_path():
 def test_geotransolver_legacy_import_paths():
     """Test the component import paths used before the move out of experimental."""
     import physicsnemo.models.geotransolver as production_pkg
-    from physicsnemo.experimental.models import geotransolver as legacy_pkg
+
+    # Drop the cached legacy modules so the shim warning fires again.
+    for module_name in list(sys.modules):
+        if module_name.startswith("physicsnemo.experimental.models.geotransolver"):
+            del sys.modules[module_name]
+
+    with pytest.warns(
+        LegacyFeatureWarning, match=re.escape("physicsnemo.models.geotransolver")
+    ):
+        legacy_pkg = importlib.import_module(
+            "physicsnemo.experimental.models.geotransolver"
+        )
 
     for legacy_name in legacy_pkg.__all__:
         # The move out of experimental renamed GALE_block to GALEBlock.

--- a/test/nn/module/test_flare_attention.py
+++ b/test/nn/module/test_flare_attention.py
@@ -87,3 +87,14 @@ def test_flare_gradient_flow(device):
     loss.backward()
     assert x.grad is not None
     assert not torch.isnan(x.grad).any()
+
+
+def test_flare_attention_legacy_import_paths():
+    """Test the import paths used before the move out of experimental."""
+    from physicsnemo.experimental.nn import FLARE as LegacyPackageFLARE
+    from physicsnemo.experimental.nn.flare_attention import (
+        FLARE as LegacyModuleFLARE,
+    )
+
+    assert LegacyPackageFLARE is FLARE
+    assert LegacyModuleFLARE is FLARE

--- a/test/nn/module/test_flare_attention.py
+++ b/test/nn/module/test_flare_attention.py
@@ -16,9 +16,14 @@
 
 """Tests for FLARE attention layer."""
 
+import re
+import subprocess
+import sys
+
 import pytest
 import torch
 
+from physicsnemo.core.warnings import LegacyFeatureWarning
 from physicsnemo.nn import FLARE
 from test.conftest import requires_module
 
@@ -91,10 +96,42 @@ def test_flare_gradient_flow(device):
 
 def test_flare_attention_legacy_import_paths():
     """Test the import paths used before the move out of experimental."""
-    from physicsnemo.experimental.nn import FLARE as LegacyPackageFLARE
-    from physicsnemo.experimental.nn.flare_attention import (
-        FLARE as LegacyModuleFLARE,
-    )
+    # Drop the cached legacy module so the shim warning fires again.
+    sys.modules.pop("physicsnemo.experimental.nn.flare_attention", None)
+
+    with pytest.warns(
+        LegacyFeatureWarning, match=re.escape("from physicsnemo.nn import FLARE")
+    ):
+        from physicsnemo.experimental.nn.flare_attention import (
+            FLARE as LegacyModuleFLARE,
+        )
+    with pytest.warns(
+        LegacyFeatureWarning, match=re.escape("from physicsnemo.nn import FLARE")
+    ):
+        from physicsnemo.experimental.nn import FLARE as LegacyPackageFLARE
 
     assert LegacyPackageFLARE is FLARE
     assert LegacyModuleFLARE is FLARE
+
+
+def test_experimental_nn_import_does_not_warn():
+    """Importing physicsnemo.experimental.nn alone must not raise the FLARE shim warning.
+
+    Runs in a subprocess because a module body executes once per process: by the
+    time this test runs, the modules are already cached, so an in-process check
+    would pass regardless of what the package imports.
+    """
+    snippet = (
+        "import warnings\n"
+        "with warnings.catch_warnings(record=True) as caught:\n"
+        "    warnings.simplefilter('always')\n"
+        "    import physicsnemo.experimental.nn\n"
+        "leaked = [str(w.message) for w in caught if 'FLARE' in str(w.message)]\n"
+        "assert not leaked, leaked\n"
+    )
+    subprocess.run(  # noqa: S603 - interpreter and snippet are test constants
+        [sys.executable, "-c", snippet],
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

PR #1845 moved GeoTransolver, FLARE, and the GALE/FLARE attention layers out of `physicsnemo.experimental`, but only added legacy shims for the `GeoTransolver` and `FLARE` model classes. Code written against the pre-move paths, such as `examples/kinetic_monte_carlo/utils/nn.py`, now fails at import time with `ModuleNotFoundError: No module named 'physicsnemo.experimental.models.geotransolver.context_projector'`. This PR completes the legacy import surface: it adds shims for the `context_projector` and `gale` submodules of `physicsnemo.experimental.models.geotransolver` (including the pre-rename `GALE_block` name for `GALEBlock`), restores the full pre-move package exports in its `__init__`, and re-exposes the FLARE attention layer as `physicsnemo.experimental.nn.flare_attention.FLARE` and `physicsnemo.experimental.nn.FLARE`. The legacy import path tests are extended to cover the whole restored surface. Every legacy path (including the pre-existing model shims) emits a `LegacyFeatureWarning` that names the new import location; importing `physicsnemo.experimental.nn` alone stays silent since its `FLARE` re-export is lazy. Example code and docs now reference the production locations directly, leaving the shims to serve external user code and old checkpoints only.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [x] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
