### PR TITLE
DLESyM checkpoint compat fixes

### DIFF
--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -36,7 +36,12 @@ from physicsnemo.core.meta import ModelMetaData
 from physicsnemo.core.module import Module
 from physicsnemo.nn.module.hpx import HEALPixFoldFaces, HEALPixUnfoldFaces
 
-from .layers import _legacy_hydra_targets_warning, _remap_obj
+from .layers import (
+    _backward_compat_dlesym_v1_args,
+    _dlesym_v02_version_mismatch_warning,
+    _legacy_hydra_targets_warning,
+    _remap_obj,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -120,9 +125,10 @@ class HEALPixRecUNet(Module):
 
     """
 
-    __model_checkpoint_version__ = "0.2.0"
+    __model_checkpoint_version__ = "0.3.0"
     __supported_model_checkpoint_version__ = {
         "0.1.0": _legacy_hydra_targets_warning,
+        "0.2.0": _dlesym_v02_version_mismatch_warning,
     }
 
     @classmethod
@@ -145,10 +151,11 @@ class HEALPixRecUNet(Module):
             Updated arguments dictionary compatible with the current version.
         """
         args = super()._backward_compat_arg_mapper(version, args)
-        if version != "0.1.0":
-            return args
-
-        return _remap_obj(args)
+        if version == "0.1.0":
+            args = _remap_obj(args)
+        if version in ("0.1.0", "0.2.0"):
+            args = _backward_compat_dlesym_v1_args(args)
+        return args
 
     def __init__(
         self,

--- a/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
@@ -34,7 +34,12 @@ from physicsnemo.core.meta import ModelMetaData
 from physicsnemo.core.module import Module
 from physicsnemo.nn.module.hpx import HEALPixFoldFaces, HEALPixUnfoldFaces
 
-from .layers import _legacy_hydra_targets_warning, _remap_obj
+from .layers import (
+    _backward_compat_dlesym_v1_args,
+    _dlesym_v02_version_mismatch_warning,
+    _legacy_hydra_targets_warning,
+    _remap_obj,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -115,9 +120,10 @@ class HEALPixUNet(Module):
 
     """
 
-    __model_checkpoint_version__ = "0.2.0"
+    __model_checkpoint_version__ = "0.3.0"
     __supported_model_checkpoint_version__ = {
         "0.1.0": _legacy_hydra_targets_warning,
+        "0.2.0": _dlesym_v02_version_mismatch_warning,
     }
 
     @classmethod
@@ -140,10 +146,11 @@ class HEALPixUNet(Module):
             Updated arguments dictionary compatible with the current version.
         """
         args = super()._backward_compat_arg_mapper(version, args)
-        if version != "0.1.0":
-            return args
-
-        return _remap_obj(args)
+        if version == "0.1.0":
+            args = _remap_obj(args)
+        if version in ("0.1.0", "0.2.0"):
+            args = _backward_compat_dlesym_v1_args(args)
+        return args
 
     def __init__(
         self,

--- a/physicsnemo/models/dlwp_healpix/layers/__init__.py
+++ b/physicsnemo/models/dlwp_healpix/layers/__init__.py
@@ -16,6 +16,8 @@
 
 """DLWP HEALPix model building blocks."""
 
+import warnings
+
 from physicsnemo.nn import (
     HEALPixAvgPool,
     HEALPixLayer,
@@ -162,3 +164,95 @@ def _remap_obj(obj):
 
 
 _legacy_hydra_targets_warning = "Automatically converting legacy checkpoint with deprecated `dlwp_healpix_layers` Hydra targets. Please update by saving a new checkpoint after loading the legacy checkpoint."
+
+# Registered in __supported_model_checkpoint_version__ for "0.2.0", this fires
+# unconditionally on any version-mismatched load (that's how
+# Module.from_checkpoint's version-check hook works), including checkpoints
+# that saved a stale "0.2.0" tag despite already using the current
+# architecture (e.g. a v1.1 checkpoint saved before __model_checkpoint_version__
+# was bumped to "0.3.0"). Kept intentionally neutral so it isn't misleading in
+# that case; the specific, actionable warning is
+# `_legacy_symmetric_skip_and_diagnostic_warning` below, which only fires when
+# `_backward_compat_dlesym_v1_args` actually detects and rewrites a legacy
+# architecture.
+_dlesym_v02_version_mismatch_warning = (
+    "Loading a checkpoint tagged with model checkpoint version 0.2.0; checking "
+    "for and applying any legacy-architecture backward-compatibility fixes "
+    "needed for pre-DLESyM-v1.1 checkpoints. Please update by saving a new "
+    "checkpoint after loading the legacy checkpoint."
+)
+
+_legacy_symmetric_skip_and_diagnostic_warning = (
+    "Automatically converting legacy checkpoint predating the "
+    "`SymmetricConvNeXtBlock` skip-connection rule change and the explicit "
+    "`is_diagnostic` argument. Please update by saving a new checkpoint after "
+    "loading the legacy checkpoint."
+)
+
+
+def _inject_legacy_skip_rule(obj):
+    """
+    Recursively inject ``legacy_skip_rule=True`` into any ``SymmetricConvNeXtBlock``
+    Hydra config found within ``obj``, so reconstructed encoder/decoder conv blocks
+    use the identity-vs-conv skip rule that legacy checkpoints were actually trained
+    with (``in_channels == latent_channels``) instead of the current rule
+    (``in_channels == out_channels``).
+    """
+    from omegaconf import DictConfig, OmegaConf
+
+    if isinstance(obj, DictConfig):
+        container = OmegaConf.to_container(obj, resolve=False)
+        return OmegaConf.create(_inject_legacy_skip_rule(container))
+    if isinstance(obj, dict):
+        out = {key: _inject_legacy_skip_rule(value) for key, value in obj.items()}
+        target = out.get("_target_")
+        if isinstance(target, str) and target.split(".")[-1].endswith(
+            "SymmetricConvNeXtBlock"
+        ):
+            out["legacy_skip_rule"] = True
+        return out
+    if isinstance(obj, list):
+        return [_inject_legacy_skip_rule(value) for value in obj]
+    return obj
+
+
+def _backward_compat_dlesym_v1_args(args):
+    """
+    Backfill ``HEALPixUNet``/``HEALPixRecUNet`` arguments for checkpoints saved
+    before the DLESyM v1.1 architecture changes (commit ``94b355108``):
+
+    - inject ``legacy_skip_rule=True`` into every ``SymmetricConvNeXtBlock``
+      conv_block config in ``encoder``/``decoder``, reconstructing the actual
+      trained architecture (Issue 2).
+    - backfill ``is_diagnostic`` using the pre-explicit-arg heuristic when the
+      checkpoint predates that parameter (Issue 3).
+
+    Both bugs were introduced by the same commit, so whether a checkpoint
+    predates it is detected structurally rather than from
+    ``__model_checkpoint_version__`` alone: ``is_diagnostic`` only exists as a
+    constructor parameter starting with that commit, and ``Module.__new__``
+    always captures it (with its default applied) into a saved checkpoint's
+    ``__args__`` once it's part of the signature. So its absence here reliably
+    means "saved by code older than the commit that introduced both bugs" —
+    unlike the checkpoint version tag, which can lag behind: a checkpoint
+    saved by patched-but-not-yet-version-bumped code (e.g. an already-correct
+    v1.1 checkpoint saved before this fix landed) still carries the old
+    version tag, but it *will* have ``is_diagnostic`` in its args and must NOT
+    have ``legacy_skip_rule`` forced on, or loading breaks.
+    """
+    args = dict(args)
+    if "is_diagnostic" in args:
+        return args
+
+    warnings.warn(_legacy_symmetric_skip_and_diagnostic_warning)
+
+    if args.get("encoder") is not None:
+        args["encoder"] = _inject_legacy_skip_rule(args["encoder"])
+    if args.get("decoder") is not None:
+        args["decoder"] = _inject_legacy_skip_rule(args["decoder"])
+    output_time_dim = args.get("output_time_dim")
+    input_time_dim = args.get("input_time_dim")
+    args["is_diagnostic"] = bool(
+        output_time_dim == 1 and input_time_dim is not None and input_time_dim > 1
+    )
+    return args

--- a/physicsnemo/models/dlwp_healpix/layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix/layers/healpix_blocks.py
@@ -596,6 +596,7 @@ class Multi_SymmetricConvNeXtBlock(torch.nn.Module):
         enable_healpixpad: bool = False,
         dropout: float = 0.0,
         conditional_layer_norm: Callable = None,
+        legacy_skip_rule: bool = False,
     ):
         """
         Parameters
@@ -606,6 +607,9 @@ class Multi_SymmetricConvNeXtBlock(torch.nn.Module):
             Callable for physicsnemo.models.dlwp_healpix_layers.normalization.ConditionalLayerNorm.
             Callable can be passed in by setting _partial_ to True in hydra config. If None,
             conditional layer normalization is not applied.
+        legacy_skip_rule: bool, optional
+            Forwarded to each wrapped ``SymmetricConvNeXtBlock``; see its
+            docstring. Only intended for reconstructing legacy checkpoints.
         """
         super().__init__()
 
@@ -632,6 +636,7 @@ class Multi_SymmetricConvNeXtBlock(torch.nn.Module):
                     conditional_layer_norm=conditional_layer_norm
                     if conditional_layer_norm is not None
                     else None,
+                    legacy_skip_rule=legacy_skip_rule,
                 ),
             )
 
@@ -678,6 +683,7 @@ class SymmetricConvNeXtBlock(torch.nn.Module):
         enable_healpixpad: bool = False,
         dropout: float = 0.0,
         conditional_layer_norm: torch.nn.Module = None,
+        legacy_skip_rule: bool = False,
     ):
         """
         Parameters
@@ -709,6 +715,12 @@ class SymmetricConvNeXtBlock(torch.nn.Module):
         conditional_layer_norm: torch.nn.Module, optional
             conditional layer normalization. If None,
             no conditional layer normalization is applied.
+        legacy_skip_rule: bool, optional
+            If ``True``, use the pre-DLESyM-v1.1 identity-vs-conv skip rule
+            (``in_channels == latent_channels``) instead of the current rule
+            (``in_channels == out_channels``). Only intended for reconstructing
+            legacy checkpoints via ``_backward_compat_arg_mapper``; new models
+            should leave this ``False``.
         """
 
         super().__init__()
@@ -719,7 +731,12 @@ class SymmetricConvNeXtBlock(torch.nn.Module):
         self.cln_enabled = conditional_layer_norm is not None
 
         if use_block_skip_connection:
-            if in_channels == int(out_channels):
+            is_identity_skip = (
+                in_channels == int(latent_channels)
+                if legacy_skip_rule
+                else in_channels == int(out_channels)
+            )
+            if is_identity_skip:
                 self.skip_module = lambda x: x
             else:
                 self.skip_module = geometry_layer(
@@ -822,6 +839,41 @@ class SymmetricConvNeXtBlock(torch.nn.Module):
             convblock.append(torch.nn.Dropout2d(p=dropout))
 
         self.convblock = torch.nn.ModuleList(convblock)
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        """
+        Tolerant loading for the ``<prefix>activation.cap`` key: it is always a
+        duplicate reference to one of the ``<prefix>convblock.<i>.cap`` buffers
+        (same object, identical value), so checkpoints saved before
+        ``self.activation`` was stored as a standalone submodule reference are
+        missing it. Backfill it from the first matching convblock buffer before
+        delegating to the normal loading logic.
+        """
+        activation_cap_key = prefix + "activation.cap"
+        if activation_cap_key not in state_dict:
+            convblock_prefix = prefix + "convblock."
+            for key, value in state_dict.items():
+                if key.startswith(convblock_prefix) and key.endswith(".cap"):
+                    state_dict[activation_cap_key] = value
+                    break
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
     def forward(self, x, conditions_cln=None):
         """


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
#1827 actually broke the previous dlesym checkpoints (`dlesym-v1-era5-v1.0` and `dlesym-v0-isccp-era5`). These fixes add some backward compat shims to checkpoint load so older checkpoints of previous dlesym variants will still run.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
