### PR TITLE
Allow Python 3.14 patch releases in requires-python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,6 +405,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `requires-python` no longer excludes Python 3.14 patch releases. Under PEP 440
+  `<=3.14` means `<=3.14.0`, so `pip install` failed on 3.14.1 and later even
+  though the `cp314` wheel installs and works. The bound is now `<3.15`.
 - `MeshReader` / `DomainMeshReader` sample discovery no longer uses
   `pathlib.Path.glob`, which can silently drop entries under filesystem
   metadata-server load (Lustre), causing training to proceed on a subset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "A deep learning framework for AI-driven multi-physics systems"
 readme = "README.md"
 
 
-requires-python = ">=3.11,<=3.14"
+requires-python = ">=3.11,<3.15"
 
 license = "Apache-2.0"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <=3.14"
+requires-python = ">=3.11, <3.15"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32' and extra != 'extra-18-nvidia-physicsnemo-cu12' and extra == 'extra-18-nvidia-physicsnemo-cu13' and extra != 'extra-18-nvidia-physicsnemo-natten-cu12' and extra == 'extra-18-nvidia-physicsnemo-natten-cu13' and extra != 'extra-18-nvidia-physicsnemo-transformer-engine-cu12' and extra == 'extra-18-nvidia-physicsnemo-transformer-engine-cu13'",
     "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32' and extra != 'extra-18-nvidia-physicsnemo-cu12' and extra == 'extra-18-nvidia-physicsnemo-cu13' and extra != 'extra-18-nvidia-physicsnemo-natten-cu12' and extra == 'extra-18-nvidia-physicsnemo-natten-cu13' and extra != 'extra-18-nvidia-physicsnemo-transformer-engine-cu12' and extra == 'extra-18-nvidia-physicsnemo-transformer-engine-cu13'",


### PR DESCRIPTION
Closes #1952.

Under PEP 440 `<=3.14` is equivalent to `<=3.14.0`, so `requires-python = ">=3.11,<=3.14"` admitted 3.14.0 and rejected every patch release after it, even though the `cp314` wheel is built and installs fine. GitHub-hosted runners currently ship 3.14.6, so `pip install nvidia-physicsnemo` fails there.

Checked against the parsed metadata:

| version | `<=3.14` (before) | `<3.15` (after) |
|---|---|---|
| 3.10.5 | rejected | rejected |
| 3.11.0 | accepted | accepted |
| 3.13.2 | accepted | accepted |
| 3.14.0 | accepted | accepted |
| 3.14.1 | **rejected** | accepted |
| 3.14.6 | **rejected** | accepted |
| 3.15.0 | rejected | rejected |

An exclusive bound on the next minor is the conventional way to express "all of 3.14", and it keeps 3.15 excluded exactly as before.

`CHANGELOG.md` updated under `Fixed`.
