### PR TITLE
Fix Python 3.14 support for 2.2.1

### DIFF
--- a/.github/actions/bootstrap-cudnn-ci/action.yml
+++ b/.github/actions/bootstrap-cudnn-ci/action.yml
@@ -109,10 +109,7 @@ runs:
         set -euo pipefail
         python3 --version
         uv --version
-        # Hard-fail if the container's python3 is not the major.minor the
-        # cache key advertises -- same rationale as the uv pin check below.
-        # A container image update that changes the Python minor would
-        # otherwise silently reuse caches keyed to the old interpreter.
+        # Keep the container Python aligned with its cache key.
         actual_py="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
         if [ "$actual_py" != "$EXPECTED_PYTHON_VERSION" ]; then
           echo "::error::Python version mismatch: expected ${EXPECTED_PYTHON_VERSION}, got ${actual_py}"

--- a/.github/actions/bootstrap-cudnn-ci/action.yml
+++ b/.github/actions/bootstrap-cudnn-ci/action.yml
@@ -104,10 +104,20 @@ runs:
       shell: bash
       env:
         EXPECTED_UV_VERSION: ${{ inputs.uv-version }}
+        EXPECTED_PYTHON_VERSION: ${{ inputs.python-version }}
       run: |
         set -euo pipefail
         python3 --version
         uv --version
+        # Hard-fail if the container's python3 is not the major.minor the
+        # cache key advertises -- same rationale as the uv pin check below.
+        # A container image update that changes the Python minor would
+        # otherwise silently reuse caches keyed to the old interpreter.
+        actual_py="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+        if [ "$actual_py" != "$EXPECTED_PYTHON_VERSION" ]; then
+          echo "::error::Python version mismatch: expected ${EXPECTED_PYTHON_VERSION}, got ${actual_py}"
+          exit 1
+        fi
         # Hard-fail if the installed uv does not match the pin -- otherwise
         # the cache prefix would lie about which uv produced the wheels.
         actual_uv="$(uv --version | awk '{print $2}')"

--- a/.github/actions/setup-uv-env/action.yml
+++ b/.github/actions/setup-uv-env/action.yml
@@ -105,14 +105,15 @@ runs:
         UV_LINK_MODE: copy
         UV_FROZEN: "1"
         UV_NO_SYNC: "1"
-        # Pin uv to the container's python3 and forbid managed-CPython
-        # downloads.  Without this, uv discovers any interpreter that
-        # satisfies requires-python and can silently build the venv on a
-        # different Python than the container baseline the cache key
-        # advertises (the interpreter-swap that masked #1952).  With the
-        # pin, an incompatible requires-python bound fails the sync loudly.
+        # Pin uv to the container's python3, reject managed interpreters,
+        # and forbid downloads.  Without this, uv discovers any interpreter
+        # that satisfies requires-python and can silently build the venv on
+        # a different Python than the container baseline the cache key
+        # advertises (the interpreter-swap that masked #1952).  With these
+        # constraints, an incompatible requires-python bound fails loudly.
         UV_PYTHON: python3
         UV_PYTHON_DOWNLOADS: never
+        UV_NO_MANAGED_PYTHON: "1"
       run: |
         set -euo pipefail
         echo "::group::build venv (extras=${{ inputs.extras }})"

--- a/.github/actions/setup-uv-env/action.yml
+++ b/.github/actions/setup-uv-env/action.yml
@@ -105,6 +105,14 @@ runs:
         UV_LINK_MODE: copy
         UV_FROZEN: "1"
         UV_NO_SYNC: "1"
+        # Pin uv to the container's python3 and forbid managed-CPython
+        # downloads.  Without this, uv discovers any interpreter that
+        # satisfies requires-python and can silently build the venv on a
+        # different Python than the container baseline the cache key
+        # advertises (the interpreter-swap that masked #1952).  With the
+        # pin, an incompatible requires-python bound fails the sync loudly.
+        UV_PYTHON: python3
+        UV_PYTHON_DOWNLOADS: never
       run: |
         set -euo pipefail
         echo "::group::build venv (extras=${{ inputs.extras }})"
@@ -131,6 +139,15 @@ runs:
         set -euo pipefail
         echo "::group::verify environment"
         .venv/bin/python --version
+        # Hard-fail if the venv's interpreter is not the system python3 the
+        # sync step pinned -- same rationale as the uv version pin check:
+        # otherwise the cache key would lie about which Python built it.
+        venv_py="$(.venv/bin/python -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+        sys_py="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+        if [ "$venv_py" != "$sys_py" ]; then
+          echo "::error::venv Python ${venv_py} does not match system python3 ${sys_py}"
+          exit 1
+        fi
         .venv/bin/python -c "import torch; print(f'torch={torch.__version__} cuda={torch.version.cuda}')"
         echo "::endgroup::"
 

--- a/.github/actions/setup-uv-env/action.yml
+++ b/.github/actions/setup-uv-env/action.yml
@@ -105,12 +105,7 @@ runs:
         UV_LINK_MODE: copy
         UV_FROZEN: "1"
         UV_NO_SYNC: "1"
-        # Pin uv to the container's python3, reject managed interpreters,
-        # and forbid downloads.  Without this, uv discovers any interpreter
-        # that satisfies requires-python and can silently build the venv on
-        # a different Python than the container baseline the cache key
-        # advertises (the interpreter-swap that masked #1952).  With these
-        # constraints, an incompatible requires-python bound fails loudly.
+        # Use only the container's Python.
         UV_PYTHON: python3
         UV_PYTHON_DOWNLOADS: never
         UV_NO_MANAGED_PYTHON: "1"
@@ -140,9 +135,7 @@ runs:
         set -euo pipefail
         echo "::group::verify environment"
         .venv/bin/python --version
-        # Hard-fail if the venv's interpreter is not the system python3 the
-        # sync step pinned -- same rationale as the uv version pin check:
-        # otherwise the cache key would lie about which Python built it.
+        # Keep the venv Python aligned with the cache key.
         venv_py="$(.venv/bin/python -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
         sys_py="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
         if [ "$venv_py" != "$sys_py" ]; then

--- a/.github/workflows/github-nightly-container.yml
+++ b/.github/workflows/github-nightly-container.yml
@@ -36,11 +36,7 @@ on:
 # Note: env context not available in container.image, so we hardcode the value
 
 env:
-  # Pin uv to the NGC container's python3, reject managed interpreters,
-  # and forbid downloads.  The whole point of this workflow is testing
-  # against the container's own Python/torch stack; without these constraints,
-  # uv can silently build or run the venv on a different Python (the
-  # interpreter-swap that masked #1952).  An incompatible bound must fail.
+  # Use only the container's Python.
   UV_PYTHON: python3
   UV_PYTHON_DOWNLOADS: never
   UV_NO_MANAGED_PYTHON: "1"

--- a/.github/workflows/github-nightly-container.yml
+++ b/.github/workflows/github-nightly-container.yml
@@ -36,14 +36,14 @@ on:
 # Note: env context not available in container.image, so we hardcode the value
 
 env:
-  # Pin uv to the NGC container's python3 and forbid managed-CPython
-  # downloads.  The whole point of this workflow is testing against the
-  # container's own Python/torch stack; without the pin, uv discovers any
-  # interpreter satisfying requires-python and can silently build or run
-  # the venv on a different Python (the interpreter-swap that masked
-  # #1952).  With the pin, an incompatible bound fails loudly instead.
+  # Pin uv to the NGC container's python3, reject managed interpreters,
+  # and forbid downloads.  The whole point of this workflow is testing
+  # against the container's own Python/torch stack; without these constraints,
+  # uv can silently build or run the venv on a different Python (the
+  # interpreter-swap that masked #1952).  An incompatible bound must fail.
   UV_PYTHON: python3
   UV_PYTHON_DOWNLOADS: never
+  UV_NO_MANAGED_PYTHON: "1"
 
 jobs:
   # Stage 1: Build and cache the environment

--- a/.github/workflows/github-nightly-container.yml
+++ b/.github/workflows/github-nightly-container.yml
@@ -34,6 +34,17 @@ on:
 
 # Container image used across all jobs - update this single value to change everywhere
 # Note: env context not available in container.image, so we hardcode the value
+
+env:
+  # Pin uv to the NGC container's python3 and forbid managed-CPython
+  # downloads.  The whole point of this workflow is testing against the
+  # container's own Python/torch stack; without the pin, uv discovers any
+  # interpreter satisfying requires-python and can silently build or run
+  # the venv on a different Python (the interpreter-swap that masked
+  # #1952).  With the pin, an incompatible bound fails loudly instead.
+  UV_PYTHON: python3
+  UV_PYTHON_DOWNLOADS: never
+
 jobs:
   # Stage 1: Build and cache the environment
   build-environment:

--- a/.github/workflows/install-ci.yml
+++ b/.github/workflows/install-ci.yml
@@ -47,7 +47,7 @@ jobs:
         # Matrix varies by event type:
         #   PR/merge_group:  ubuntu × 3.12 only (1 job)
         #   push:            ubuntu × all Python versions (4 jobs)
-        #   schedule/manual: ubuntu × all versions + arm/mac/win × 3.13/3.14 (10 jobs)
+        #   schedule/manual: ubuntu × 3.12–3.14 + arm/mac/win × 3.14 (6 jobs)
         include: >-
           ${{
             (github.event_name == 'pull_request' || github.event_name == 'merge_group')
@@ -62,15 +62,11 @@ jobs:
                 {"os": "ubuntu-latest", "python-version": "3.14"}
               ]')
             || fromJSON('[
-                {"os": "ubuntu-latest",    "python-version": "3.11"},
                 {"os": "ubuntu-latest",    "python-version": "3.12"},
                 {"os": "ubuntu-latest",    "python-version": "3.13"},
                 {"os": "ubuntu-latest",    "python-version": "3.14"},
-                {"os": "ubuntu-24.04-arm", "python-version": "3.13"},
                 {"os": "ubuntu-24.04-arm", "python-version": "3.14"},
-                {"os": "macos-latest",     "python-version": "3.13"},
                 {"os": "macos-latest",     "python-version": "3.14"},
-                {"os": "windows-latest",   "python-version": "3.13"},
                 {"os": "windows-latest",   "python-version": "3.14"}
               ]')
           }}

--- a/.github/workflows/install-ci.yml
+++ b/.github/workflows/install-ci.yml
@@ -2,9 +2,9 @@ name: Install CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "*-rc"]
   pull_request:
-    branches: [main]
+    branches: [main, "*-rc"]
   schedule:
     - cron: '0 6 * * *'  # 6 AM UTC daily
   workflow_dispatch:  # Allows manual triggering from GitHub UI
@@ -45,14 +45,18 @@ jobs:
       fail-fast: false
       matrix:
         # Matrix varies by event type:
-        #   PR/merge_group:  ubuntu × 3.12 only (1 job)
-        #   push:            ubuntu × all Python versions (3 jobs)
-        #   schedule/manual: ubuntu × all versions + ubuntu-arm/mac/win × 3.13 (6 jobs)
+        #   PR/merge_group:  ubuntu × 3.12 + all platforms × 3.14 (5 jobs)
+        #   push:            ubuntu × all Python versions (4 jobs)
+        #   schedule/manual: ubuntu × all versions + arm/mac/win × 3.13/3.14 (10 jobs)
         include: >-
           ${{
             (github.event_name == 'pull_request' || github.event_name == 'merge_group')
               && fromJSON('[
-                {"os": "ubuntu-latest", "python-version": "3.12"}
+                {"os": "ubuntu-latest",    "python-version": "3.12"},
+                {"os": "ubuntu-latest",    "python-version": "3.14"},
+                {"os": "ubuntu-24.04-arm", "python-version": "3.14"},
+                {"os": "macos-latest",     "python-version": "3.14"},
+                {"os": "windows-latest",   "python-version": "3.14"}
               ]')
             || github.event_name == 'push'
               && fromJSON('[
@@ -79,6 +83,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - uses: actions/setup-python@v6
+      id: setup_python
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -102,7 +107,23 @@ jobs:
           }}
 
     - name: Install package with uv
+      env:
+        UV_PYTHON: ${{ steps.setup_python.outputs.python-path }}
+        UV_PYTHON_DOWNLOADS: never
       run: uv sync --frozen --group dev
 
+    - name: Verify Python version
+      env:
+        UV_PYTHON: ${{ steps.setup_python.outputs.python-path }}
+        UV_PYTHON_DOWNLOADS: never
+      run: >-
+        uv run --no-sync python -c
+        "import sys; expected=tuple(map(int, '${{ matrix.python-version }}'.split('.')));
+        actual=sys.version_info[:2]; assert actual == expected,
+        f'Expected Python {expected}, got {sys.version}'"
+
     - name: Run tests
-      run: uv run pytest test/
+      env:
+        UV_PYTHON: ${{ steps.setup_python.outputs.python-path }}
+        UV_PYTHON_DOWNLOADS: never
+      run: uv run --no-sync pytest test/

--- a/.github/workflows/install-ci.yml
+++ b/.github/workflows/install-ci.yml
@@ -47,7 +47,7 @@ jobs:
         # Matrix varies by event type:
         #   PR/merge_group:  ubuntu × 3.12 only (1 job)
         #   push:            ubuntu × all Python versions (4 jobs)
-        #   schedule/manual: ubuntu × 3.12–3.14 + arm/mac/win × 3.14 (6 jobs)
+        #   schedule/manual: ubuntu × all versions + arm/mac/win × 3.14 (7 jobs)
         include: >-
           ${{
             (github.event_name == 'pull_request' || github.event_name == 'merge_group')
@@ -62,6 +62,7 @@ jobs:
                 {"os": "ubuntu-latest", "python-version": "3.14"}
               ]')
             || fromJSON('[
+                {"os": "ubuntu-latest",    "python-version": "3.11"},
                 {"os": "ubuntu-latest",    "python-version": "3.12"},
                 {"os": "ubuntu-latest",    "python-version": "3.13"},
                 {"os": "ubuntu-latest",    "python-version": "3.14"},

--- a/.github/workflows/install-ci.yml
+++ b/.github/workflows/install-ci.yml
@@ -45,18 +45,14 @@ jobs:
       fail-fast: false
       matrix:
         # Matrix varies by event type:
-        #   PR/merge_group:  ubuntu × 3.12 + all platforms × 3.14 (5 jobs)
+        #   PR/merge_group:  ubuntu × 3.12 only (1 job)
         #   push:            ubuntu × all Python versions (4 jobs)
         #   schedule/manual: ubuntu × all versions + arm/mac/win × 3.13/3.14 (10 jobs)
         include: >-
           ${{
             (github.event_name == 'pull_request' || github.event_name == 'merge_group')
               && fromJSON('[
-                {"os": "ubuntu-latest",    "python-version": "3.12"},
-                {"os": "ubuntu-latest",    "python-version": "3.14"},
-                {"os": "ubuntu-24.04-arm", "python-version": "3.14"},
-                {"os": "macos-latest",     "python-version": "3.14"},
-                {"os": "windows-latest",   "python-version": "3.14"}
+                {"os": "ubuntu-latest", "python-version": "3.12"}
               ]')
             || github.event_name == 'push'
               && fromJSON('[

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-XX-YY
+
+### Fixed
+
+- Allows installation on all Python 3.14 patch releases while continuing to
+  exclude Python 3.15 and later.
+- Pins install CI to the interpreter provisioned by `setup-python` and verifies
+  the runtime version, preventing `uv` from silently selecting another Python.
+- Keeps tensorclass mesh API annotations introspectable under Python 3.14's
+  deferred annotation evaluation.
+
 ## [2.2.0] - 2026-08-27
 
 ### Added

--- a/physicsnemo/__init__.py
+++ b/physicsnemo/__init__.py
@@ -24,7 +24,7 @@ from .core.module import Module  # noqa E402
 
 wp.config.log_level = wp.LOG_WARNING
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 
 # Backwards-compatibility is opt-in. Enable with env var or via enable_compat().

--- a/physicsnemo/mesh/domain_mesh.py
+++ b/physicsnemo/mesh/domain_mesh.py
@@ -188,8 +188,8 @@ class DomainMesh:
         self,
         fn: Callable[[Mesh], Mesh],
         *,
-        interior: bool = True,
-        boundaries: bool = True,
+        interior: builtins.bool = True,
+        boundaries: builtins.bool = True,
     ) -> "DomainMesh":
         r"""Apply a Mesh-to-Mesh function to meshes in the domain.
 
@@ -378,7 +378,7 @@ class DomainMesh:
 
     def translate(
         self,
-        offset: Float[torch.Tensor, " n_spatial_dims"] | Sequence[float],
+        offset: Float[torch.Tensor, " n_spatial_dims"] | Sequence[builtins.float],
     ) -> "DomainMesh":
         r"""Translate all meshes in the domain by a constant offset.
 
@@ -399,15 +399,17 @@ class DomainMesh:
 
     def rotate(
         self,
-        angle: float,
+        angle: builtins.float,
         axis: Float[torch.Tensor, " n_spatial_dims"]
-        | Sequence[float]
+        | Sequence[builtins.float]
         | Literal["x", "y", "z"]
         | None = None,
-        center: Float[torch.Tensor, " n_spatial_dims"] | Sequence[float] | None = None,
-        transform_point_data: bool | TensorDict = False,
-        transform_cell_data: bool | TensorDict = False,
-        transform_global_data: bool | TensorDict = False,
+        center: Float[torch.Tensor, " n_spatial_dims"]
+        | Sequence[builtins.float]
+        | None = None,
+        transform_point_data: builtins.bool | TensorDict = False,
+        transform_cell_data: builtins.bool | TensorDict = False,
+        transform_global_data: builtins.bool | TensorDict = False,
     ) -> "DomainMesh":
         r"""Rotate all meshes in the domain about an axis.
 
@@ -477,12 +479,14 @@ class DomainMesh:
 
     def scale(
         self,
-        factor: float | Float[torch.Tensor, " n_spatial_dims"],
-        center: Float[torch.Tensor, " n_spatial_dims"] | Sequence[float] | None = None,
-        transform_point_data: bool | TensorDict = False,
-        transform_cell_data: bool | TensorDict = False,
-        transform_global_data: bool | TensorDict = False,
-        assume_invertible: bool | None = None,
+        factor: builtins.float | Float[torch.Tensor, " n_spatial_dims"],
+        center: Float[torch.Tensor, " n_spatial_dims"]
+        | Sequence[builtins.float]
+        | None = None,
+        transform_point_data: builtins.bool | TensorDict = False,
+        transform_cell_data: builtins.bool | TensorDict = False,
+        transform_global_data: builtins.bool | TensorDict = False,
+        assume_invertible: builtins.bool | None = None,
     ) -> "DomainMesh":
         r"""Scale all meshes in the domain by specified factor(s).
 
@@ -551,10 +555,10 @@ class DomainMesh:
     def transform(
         self,
         matrix: Float[torch.Tensor, "new_n_spatial_dims n_spatial_dims"],
-        transform_point_data: bool | TensorDict = False,
-        transform_cell_data: bool | TensorDict = False,
-        transform_global_data: bool | TensorDict = False,
-        assume_invertible: bool | None = None,
+        transform_point_data: builtins.bool | TensorDict = False,
+        transform_cell_data: builtins.bool | TensorDict = False,
+        transform_global_data: builtins.bool | TensorDict = False,
+        assume_invertible: builtins.bool | None = None,
     ) -> "DomainMesh":
         r"""Apply a linear transformation to all meshes in the domain.
 
@@ -1081,10 +1085,10 @@ class DomainMesh:
 
     def clean(
         self,
-        tolerance: float = 1e-12,
-        merge_points: bool = True,
-        remove_duplicate_cells: bool = True,
-        remove_unused_points: bool = True,
+        tolerance: builtins.float = 1e-12,
+        merge_points: builtins.bool = True,
+        remove_duplicate_cells: builtins.bool = True,
+        remove_unused_points: builtins.bool = True,
     ) -> "DomainMesh":
         r"""Clean and repair all meshes in the domain.
 
@@ -1129,7 +1133,7 @@ class DomainMesh:
 
     def subdivide(
         self,
-        levels: int = 1,
+        levels: builtins.int = 1,
         filter: Literal["linear", "butterfly", "loop"] = "linear",
     ) -> "DomainMesh":
         r"""Subdivide all meshes in the domain.
@@ -1152,7 +1156,9 @@ class DomainMesh:
 
     ### Data Operations
 
-    def cell_data_to_point_data(self, overwrite_keys: bool = False) -> "DomainMesh":
+    def cell_data_to_point_data(
+        self, overwrite_keys: builtins.bool = False
+    ) -> "DomainMesh":
         r"""Convert cell data to point data on all meshes in the domain.
 
         Delegates to :meth:`Mesh.cell_data_to_point_data` for each mesh.
@@ -1171,7 +1177,9 @@ class DomainMesh:
             lambda m: m.cell_data_to_point_data(overwrite_keys=overwrite_keys)
         )
 
-    def point_data_to_cell_data(self, overwrite_keys: bool = False) -> "DomainMesh":
+    def point_data_to_cell_data(
+        self, overwrite_keys: builtins.bool = False
+    ) -> "DomainMesh":
         r"""Convert point data to cell data on all meshes in the domain.
 
         Delegates to :meth:`Mesh.point_data_to_cell_data` for each mesh.
@@ -1254,15 +1262,15 @@ class DomainMesh:
 
     def validate(
         self,
-        check_degenerate_cells: bool = True,
-        check_duplicate_vertices: bool = True,
-        check_inverted_cells: bool = False,
-        check_out_of_bounds: bool = True,
-        check_manifoldness: bool = False,
-        tolerance: float | None = None,
-        raise_on_error: bool = False,
+        check_degenerate_cells: builtins.bool = True,
+        check_duplicate_vertices: builtins.bool = True,
+        check_inverted_cells: builtins.bool = False,
+        check_out_of_bounds: builtins.bool = True,
+        check_manifoldness: builtins.bool = False,
+        tolerance: builtins.float | None = None,
+        raise_on_error: builtins.bool = False,
         *,
-        check_self_intersection: bool = False,
+        check_self_intersection: builtins.bool = False,
     ) -> dict[str, Any]:
         r"""Validate all meshes in the domain and aggregate results.
 
@@ -1345,7 +1353,7 @@ class DomainMesh:
         return sorted(self.boundaries.keys())
 
     @property
-    def n_boundaries(self) -> int:
+    def n_boundaries(self) -> builtins.int:
         """Number of boundary meshes.
 
         Returns
@@ -1399,7 +1407,7 @@ class DomainMesh:
         """
         yield from self.all_meshes()
 
-    def merge_boundaries(self, preserve_data: bool = False) -> Mesh:
+    def merge_boundaries(self, preserve_data: builtins.bool = False) -> Mesh:
         """Merge all boundary meshes into a single :class:`Mesh`.
 
         Produces a mesh containing the concatenated points and cells from
@@ -1442,7 +1450,7 @@ class DomainMesh:
         geometry_only = [Mesh(points=b.points, cells=b.cells) for b in boundaries]
         return Mesh.merge(geometry_only)
 
-    def is_boundary_watertight(self, tolerance: float = 1e-6) -> bool:
+    def is_boundary_watertight(self, tolerance: builtins.float = 1e-6) -> builtins.bool:
         r"""Check whether the merged boundary meshes form a watertight surface.
 
         Merges all boundary meshes via :meth:`merge_boundaries`, deduplicates
@@ -1485,16 +1493,16 @@ class DomainMesh:
         self,
         *,
         backend: Literal["matplotlib", "pyvista", "auto"] = "auto",
-        show: bool = True,
+        show: builtins.bool = True,
         point_scalars: None | torch.Tensor | str | tuple[str, ...] = None,
         cell_scalars: None | torch.Tensor | str | tuple[str, ...] = None,
         cmap: str = "viridis",
-        vmin: float | None = None,
-        vmax: float | None = None,
-        alpha_points: float = 1.0,
-        alpha_cells: float = 1.0,
-        alpha_edges: float = 1.0,
-        show_edges: bool = False,
+        vmin: builtins.float | None = None,
+        vmax: builtins.float | None = None,
+        alpha_points: builtins.float = 1.0,
+        alpha_cells: builtins.float = 1.0,
+        alpha_edges: builtins.float = 1.0,
+        show_edges: builtins.bool = False,
         boundary_kwargs: dict[str, Any] | None = None,
         ax: "matplotlib.axes.Axes | pyvista.Plotter | None" = None,
         backend_options: dict[str, Any] | None = None,

--- a/physicsnemo/mesh/mesh.py
+++ b/physicsnemo/mesh/mesh.py
@@ -454,7 +454,7 @@ class Mesh:
         point_data: TensorDict | dict[str, torch.Tensor] | None = None,
         cell_data: TensorDict | dict[str, torch.Tensor] | None = None,
         global_data: TensorDict | dict[str, torch.Tensor] | None = None,
-        assume_convex: bool = False,
+        assume_convex: builtins.bool = False,
     ) -> Self:
         r"""Build a triangulated surface :class:`Mesh` from a polygon soup.
 
@@ -538,7 +538,7 @@ class Mesh:
         )
 
     @classmethod
-    def __class_getitem__(cls, params: tuple) -> type:
+    def __class_getitem__(cls, params: tuple) -> builtins.type:
         r"""Parametrize Mesh by manifold and spatial dimensions.
 
         Returns a synthetic type usable in type annotations and ``isinstance``
@@ -729,27 +729,27 @@ class Mesh:
             ...
 
     @property
-    def n_points(self) -> int:
+    def n_points(self) -> builtins.int:
         """Number of points in the mesh."""
         return self.points.shape[0]
 
     @property
-    def n_spatial_dims(self) -> int:
+    def n_spatial_dims(self) -> builtins.int:
         """Dimension of the ambient coordinate space."""
         return self.points.shape[-1]
 
     @property
-    def n_cells(self) -> int:
+    def n_cells(self) -> builtins.int:
         """Number of cells in the mesh."""
         return self.cells.shape[0]
 
     @property
-    def n_manifold_dims(self) -> int:
+    def n_manifold_dims(self) -> builtins.int:
         """Intrinsic dimension of each simplicial cell."""
         return self.cells.shape[-1] - 1
 
     @property
-    def codimension(self) -> int:
+    def codimension(self) -> builtins.int:
         """Compute the codimension of the mesh.
 
         The codimension is the difference between the spatial dimension and the
@@ -1319,12 +1319,12 @@ class Mesh:
 
     def slice_points(
         self,
-        indices: int
+        indices: builtins.int
         | slice
         | types.EllipsisType
         | None
         | torch.Tensor
-        | Sequence[int | bool],
+        | Sequence[builtins.int | builtins.bool],
     ) -> "Mesh":
         """Returns a new Mesh with a subset of the points.
 
@@ -1423,12 +1423,12 @@ class Mesh:
 
     def slice_cells(
         self,
-        indices: int
+        indices: builtins.int
         | slice
         | types.EllipsisType
         | None
         | torch.Tensor
-        | Sequence[int | bool | slice],
+        | Sequence[builtins.int | builtins.bool | slice],
     ) -> "Mesh":
         """Returns a new Mesh with a subset of the cells.
 
@@ -1491,8 +1491,8 @@ class Mesh:
 
     def sample_random_points_on_cells(
         self,
-        cell_indices: Sequence[int] | torch.Tensor | None = None,
-        alpha: float = 1.0,
+        cell_indices: Sequence[builtins.int] | torch.Tensor | None = None,
+        alpha: builtins.float = 1.0,
     ) -> torch.Tensor:
         """Sample random points on specified cells of the mesh.
 
@@ -1554,8 +1554,8 @@ class Mesh:
         query_points: torch.Tensor,
         data_source: Literal["cells", "points"] = "cells",
         multiple_cells_strategy: Literal["mean", "nan"] = "mean",
-        project_onto_nearest_cell: bool = False,
-        tolerance: float = 1e-6,
+        project_onto_nearest_cell: builtins.bool = False,
+        tolerance: builtins.float = 1e-6,
         bvh: Any = None,
     ) -> "TensorDict":
         """Extract or interpolate mesh data at specified query points.
@@ -1685,7 +1685,7 @@ class Mesh:
             _cache=self._cache.copy(),
         )
 
-    def cell_data_to_point_data(self, overwrite_keys: bool = False) -> "Mesh":
+    def cell_data_to_point_data(self, overwrite_keys: builtins.bool = False) -> "Mesh":
         """Convert cell data to point data by averaging.
 
         For each point, computes the average of the cell data values from all cells
@@ -1774,7 +1774,7 @@ class Mesh:
             _cache=self._cache.copy(),
         )
 
-    def point_data_to_cell_data(self, overwrite_keys: bool = False) -> "Mesh":
+    def point_data_to_cell_data(self, overwrite_keys: builtins.bool = False) -> "Mesh":
         """Convert point data to cell data by averaging.
 
         For each cell, computes the average of the point data values from all points
@@ -1838,10 +1838,10 @@ class Mesh:
 
     def get_facet_mesh(
         self,
-        manifold_codimension: int = 1,
+        manifold_codimension: builtins.int = 1,
         data_source: Literal["points", "cells"] = "cells",
         data_aggregation: Literal["mean", "area_weighted", "inverse_distance"] = "mean",
-        target_counts: list[int]
+        target_counts: list[builtins.int]
         | Literal["boundary", "shared", "interior", "all"] = "all",
     ) -> "Mesh":
         """Extract k-codimension facet mesh from this n-dimensional mesh.
@@ -2215,7 +2215,7 @@ class Mesh:
 
         return self._cached_adjacency("point_to_points", get_point_to_points_adjacency)
 
-    def get_cell_to_cells_adjacency(self, adjacency_codimension: int = 1):
+    def get_cell_to_cells_adjacency(self, adjacency_codimension: builtins.int = 1):
         """Compute cell-to-cells adjacency based on shared facets.
 
         Two cells are considered adjacent if they share a k-codimension facet.
@@ -2287,9 +2287,9 @@ class Mesh:
 
     def pad(
         self,
-        target_n_points: int | None = None,
-        target_n_cells: int | None = None,
-        data_padding_value: float = torch.nan,
+        target_n_points: builtins.int | None = None,
+        target_n_cells: builtins.int | None = None,
+        data_padding_value: builtins.float = torch.nan,
     ) -> "Mesh":
         """Pad points and cells arrays to specified sizes.
 
@@ -2408,7 +2408,9 @@ class Mesh:
         )
 
     def pad_to_next_power(
-        self, power: float = 1.5, data_padding_value: float = torch.nan
+        self,
+        power: builtins.float = 1.5,
+        data_padding_value: builtins.float = torch.nan,
     ) -> "Mesh":
         """Pads points and cells arrays to their next power of `power` (integer-floored).
 
@@ -2804,7 +2806,7 @@ class Mesh:
 
     def subdivide(
         self,
-        levels: int = 1,
+        levels: builtins.int = 1,
         filter: Literal["linear", "butterfly", "loop"] = "linear",
     ) -> "Mesh":
         """Subdivide the mesh using iterative application of subdivision schemes.
@@ -2903,10 +2905,10 @@ class Mesh:
 
     def clean(
         self,
-        tolerance: float = 1e-12,
-        merge_points: bool = True,
-        remove_duplicate_cells: bool = True,
-        remove_unused_points: bool = True,
+        tolerance: builtins.float = 1e-12,
+        merge_points: builtins.bool = True,
+        remove_duplicate_cells: builtins.bool = True,
+        remove_unused_points: builtins.bool = True,
     ) -> "Mesh":
         r"""Clean and repair this mesh.
 

--- a/physicsnemo/mesh/neighbors/_adjacency.py
+++ b/physicsnemo/mesh/neighbors/_adjacency.py
@@ -20,8 +20,6 @@ This module provides the Adjacency tensorclass for representing ragged arrays
 using offset-indices encoding, commonly used in graph and mesh processing.
 """
 
-# ``tensorclass`` conversion methods shadow builtin names during Python 3.14
-# annotation evaluation, so scalar types in the decorated class are qualified.
 import builtins
 
 import torch

--- a/physicsnemo/mesh/neighbors/_adjacency.py
+++ b/physicsnemo/mesh/neighbors/_adjacency.py
@@ -20,6 +20,10 @@ This module provides the Adjacency tensorclass for representing ragged arrays
 using offset-indices encoding, commonly used in graph and mesh processing.
 """
 
+# ``tensorclass`` conversion methods shadow builtin names during Python 3.14
+# annotation evaluation, so scalar types in the decorated class are qualified.
+import builtins
+
 import torch
 from jaxtyping import Int
 from tensordict import tensorclass
@@ -93,7 +97,7 @@ class Adjacency:
                     f"The offset-indices encoding requires offsets[-1] == len(indices)."
                 )
 
-    def to_list(self) -> list[list[int]]:
+    def to_list(self) -> list[list[builtins.int]]:
         """Convert adjacency to a ragged list-of-lists representation.
 
         This method is primarily for testing and comparison with other libraries.
@@ -133,12 +137,12 @@ class Adjacency:
         return result
 
     @property
-    def n_sources(self) -> int:
+    def n_sources(self) -> builtins.int:
         """Number of source elements (points or cells) in the adjacency."""
         return len(self.offsets) - 1
 
     @property
-    def n_total_neighbors(self) -> int:
+    def n_total_neighbors(self) -> builtins.int:
         """Total number of neighbor relationships across all sources."""
         return len(self.indices)
 
@@ -210,7 +214,7 @@ class Adjacency:
 
         return source_indices, self.indices
 
-    def truncate_per_source(self, max_count: int | None = None) -> "Adjacency":
+    def truncate_per_source(self, max_count: builtins.int | None = None) -> "Adjacency":
         """Limit each source to at most max_count neighbors.
 
         This is useful for capping the number of candidates in spatial queries

--- a/physicsnemo/mesh/spatial/bvh.py
+++ b/physicsnemo/mesh/spatial/bvh.py
@@ -25,8 +25,6 @@ O(log N) Python iterations instead of the O(N) iterations required by a naive
 sequential approach, enabling scalability to hundreds of millions of cells.
 """
 
-# ``tensorclass`` conversion methods shadow builtin names during Python 3.14
-# annotation evaluation, so scalar types in the decorated class are qualified.
 import builtins
 from typing import TYPE_CHECKING
 

--- a/physicsnemo/mesh/spatial/bvh.py
+++ b/physicsnemo/mesh/spatial/bvh.py
@@ -25,6 +25,9 @@ O(log N) Python iterations instead of the O(N) iterations required by a naive
 sequential approach, enabling scalability to hundreds of millions of cells.
 """
 
+# ``tensorclass`` conversion methods shadow builtin names during Python 3.14
+# annotation evaluation, so scalar types in the decorated class are qualified.
+import builtins
 from typing import TYPE_CHECKING
 
 import torch
@@ -312,12 +315,12 @@ class BVH:
     sorted_cell_order: Int[torch.Tensor, " n_cells"]
 
     @property
-    def n_nodes(self) -> int:
+    def n_nodes(self) -> builtins.int:
         """Number of nodes in the BVH."""
         return self.node_aabb_min.shape[0]
 
     @property
-    def n_spatial_dims(self) -> int:
+    def n_spatial_dims(self) -> builtins.int:
         """Dimensionality of the spatial space."""
         return self.node_aabb_min.shape[1]
 
@@ -327,7 +330,7 @@ class BVH:
         return self.node_aabb_min.device
 
     @classmethod
-    def from_mesh(cls, mesh: "Mesh", leaf_size: int = 1) -> "BVH":
+    def from_mesh(cls, mesh: "Mesh", leaf_size: builtins.int = 1) -> "BVH":
         """Construct a BVH from a mesh using morton-code LBVH.
 
         Cells are sorted by the morton code of their centroids, then the tree
@@ -498,8 +501,8 @@ class BVH:
     def _traverse(
         self,
         query_points: Float[torch.Tensor, "n_queries n_spatial_dims"],
-        max_candidates_per_point: int | None,
-        aabb_tolerance: float,
+        max_candidates_per_point: builtins.int | None,
+        aabb_tolerance: builtins.float,
     ) -> tuple[
         Int[torch.Tensor, " n_pairs"],
         Int[torch.Tensor, " n_pairs"],
@@ -609,8 +612,8 @@ class BVH:
     def find_candidate_cells(
         self,
         query_points: Float[torch.Tensor, "n_queries n_spatial_dims"],
-        max_candidates_per_point: int | None = 32,
-        aabb_tolerance: float = 1e-6,
+        max_candidates_per_point: builtins.int | None = 32,
+        aabb_tolerance: builtins.float = 1e-6,
     ) -> Adjacency:
         r"""Find candidate cells that might contain each query point.
 

--- a/physicsnemo/mesh/spatial/cluster_tree.py
+++ b/physicsnemo/mesh/spatial/cluster_tree.py
@@ -42,6 +42,9 @@ far-field monopole approximation. The two classes share
 independent.
 """
 
+# ``tensorclass`` conversion methods shadow builtin names during Python 3.14
+# annotation evaluation, so scalar types in the decorated classes are qualified.
+import builtins
 import logging
 from typing import NamedTuple
 
@@ -104,22 +107,22 @@ class DualInteractionPlan:
     fn_broadcast_counts: Int[torch.Tensor, " n_fn"]
 
     @property
-    def n_near(self) -> int:
+    def n_near(self) -> builtins.int:
         """Number of (near,near) exact individual interaction pairs."""
         return self.near_target_ids.shape[0]
 
     @property
-    def n_far_nodes(self) -> int:
+    def n_far_nodes(self) -> builtins.int:
         """Number of (far,far) node-to-node pairs (each = one kernel eval)."""
         return self.far_target_node_ids.shape[0]
 
     @property
-    def n_nf(self) -> int:
+    def n_nf(self) -> builtins.int:
         """Number of (near,far) target-point-to-source-node pairs."""
         return self.nf_target_ids.shape[0]
 
     @property
-    def n_fn(self) -> int:
+    def n_fn(self) -> builtins.int:
         """Number of (far,near) target-node-to-source-point pairs."""
         return self.fn_target_node_ids.shape[0]
 
@@ -631,17 +634,17 @@ class ClusterTree:
     max_depth: torch.Tensor
 
     @property
-    def n_nodes(self) -> int:
+    def n_nodes(self) -> builtins.int:
         """Number of nodes in the tree."""
         return self.node_aabb_min.shape[0]
 
     @property
-    def n_sources(self) -> int:
+    def n_sources(self) -> builtins.int:
         """Number of source points."""
         return self.sorted_source_order.shape[0]
 
     @property
-    def n_spatial_dims(self) -> int:
+    def n_spatial_dims(self) -> builtins.int:
         """Spatial dimensionality."""
         return self.node_aabb_min.shape[1]
 
@@ -650,7 +653,7 @@ class ClusterTree:
         cls,
         points: Float[torch.Tensor, "n_points n_dims"],
         *,
-        leaf_size: int = 1,
+        leaf_size: builtins.int = 1,
         areas: Float[torch.Tensor, " n_points"] | None = None,
     ) -> "ClusterTree":
         r"""Build a cluster tree from a set of points via morton-code LBVH.
@@ -905,9 +908,9 @@ class ClusterTree:
     def find_dual_interaction_pairs(
         self,
         target_tree: "ClusterTree",
-        theta: float = 1.0,
+        theta: builtins.float = 1.0,
         *,
-        expand_far_targets: bool = False,
+        expand_far_targets: builtins.bool = False,
     ) -> DualInteractionPlan:
         r"""Find near-field and far-field pairs via dual-tree traversal.
 

--- a/physicsnemo/mesh/spatial/cluster_tree.py
+++ b/physicsnemo/mesh/spatial/cluster_tree.py
@@ -42,8 +42,6 @@ far-field monopole approximation. The two classes share
 independent.
 """
 
-# ``tensorclass`` conversion methods shadow builtin names during Python 3.14
-# annotation evaluation, so scalar types in the decorated classes are qualified.
 import builtins
 import logging
 from typing import NamedTuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "A deep learning framework for AI-driven multi-physics systems"
 readme = "README.md"
 
 
-requires-python = ">=3.11,<=3.14"
+requires-python = ">=3.11,<3.15"
 
 license = "Apache-2.0"
 

--- a/test/mesh/io/io_zarr/test_reader_integration.py
+++ b/test/mesh/io/io_zarr/test_reader_integration.py
@@ -18,6 +18,8 @@
 subsample push-down (window reads must be bitwise-identical to an eager load
 followed by in-memory subsampling)."""
 
+from pathlib import Path
+
 import torch
 from conftest import assert_meshes_equal, make_domain_mesh, make_mesh
 
@@ -104,6 +106,6 @@ def test_mixed_directory_discovery(tmp_path):
     to_zarr(m1, tmp_path / "a.mesh.zarr")
     m2.save(tmp_path / "b.pmsh")
     reader = MeshReader(tmp_path, pattern="*.*")
-    metas = {reader[i][1]["source_path"].split("/")[-1]: reader[i][0] for i in (0, 1)}
+    metas = {Path(reader[i][1]["source_path"]).name: reader[i][0] for i in (0, 1)}
     assert_meshes_equal(m1, metas["a.mesh.zarr"])
     assert_meshes_equal(m2, metas["b.pmsh"])

--- a/test/mesh/test_tensorclass_annotations.py
+++ b/test/mesh/test_tensorclass_annotations.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for Python 3.14 tensorclass annotation evaluation."""
+
+import builtins
+import inspect
+from typing import get_args
+
+import pytest
+
+from physicsnemo.mesh import DomainMesh, Mesh
+from physicsnemo.mesh.neighbors import Adjacency
+from physicsnemo.mesh.spatial import BVH, ClusterTree, DualInteractionPlan
+from physicsnemo.mesh.spatial.cluster_tree import SourceAggregates
+
+
+def _annotation_parts(annotation):
+    """Yield an annotation and each recursively nested type argument."""
+    yield annotation
+    for argument in get_args(annotation):
+        yield from _annotation_parts(argument)
+
+
+def _physicsnemo_members(tensorclass):
+    """Yield functions defined directly on a PhysicsNeMo tensorclass."""
+    qualname_prefix = f"{tensorclass.__qualname__}."
+    for member in vars(tensorclass).values():
+        if isinstance(member, (classmethod, staticmethod)):
+            member = member.__func__
+        elif isinstance(member, property):
+            member = member.fget
+        if inspect.isfunction(member) and member.__qualname__.startswith(
+            qualname_prefix
+        ):
+            yield member
+
+
+@pytest.mark.parametrize(
+    "tensorclass",
+    (
+        Mesh,
+        DomainMesh,
+        Adjacency,
+        BVH,
+        ClusterTree,
+        DualInteractionPlan,
+        SourceAggregates,
+    ),
+)
+def test_tensorclass_annotations_are_introspectable(tensorclass):
+    """Tensor conversion methods must not shadow builtin type annotations."""
+    conversion_methods = {
+        member
+        for name, member in vars(tensorclass).items()
+        if name in vars(builtins)
+        and callable(member)
+        and member is not getattr(builtins, name)
+    }
+
+    for member in _physicsnemo_members(tensorclass):
+        try:
+            signature = inspect.signature(member)
+        except Exception as error:
+            pytest.fail(f"Could not inspect {member.__qualname__}: {error}")
+
+        annotations = [
+            parameter.annotation for parameter in signature.parameters.values()
+        ]
+        annotations.append(signature.return_annotation)
+        for annotation in annotations:
+            for part in _annotation_parts(annotation):
+                assert all(part is not method for method in conversion_methods), (
+                    f"{member.__qualname__} resolved a builtin type annotation to a "
+                    "tensorclass conversion method"
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <=3.14"
+requires-python = ">=3.11, <3.15"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32' and extra != 'extra-18-nvidia-physicsnemo-cu12' and extra == 'extra-18-nvidia-physicsnemo-cu13' and extra != 'extra-18-nvidia-physicsnemo-natten-cu12' and extra == 'extra-18-nvidia-physicsnemo-natten-cu13' and extra != 'extra-18-nvidia-physicsnemo-transformer-engine-cu12' and extra == 'extra-18-nvidia-physicsnemo-transformer-engine-cu13'",
     "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32' and extra != 'extra-18-nvidia-physicsnemo-cu12' and extra == 'extra-18-nvidia-physicsnemo-cu13' and extra != 'extra-18-nvidia-physicsnemo-natten-cu12' and extra == 'extra-18-nvidia-physicsnemo-natten-cu13' and extra != 'extra-18-nvidia-physicsnemo-transformer-engine-cu12' and extra == 'extra-18-nvidia-physicsnemo-transformer-engine-cu13'",


### PR DESCRIPTION
Closes #1952.
Closes #1953.
Supersedes #1954.

## Problem

The 2.2.0 metadata uses `Requires-Python: >=3.11,<=3.14`. Under PEP 440, that upper bound means `<=3.14.0`, so pip rejects every later Python 3.14 patch release.

The install workflow did not expose this before release because `uv sync` silently selected another compatible interpreter instead of the Python provisioned by `actions/setup-python`. Running the suite under an actual Python 3.14 interpreter also exposed deferred-annotation failures in mesh classes decorated with `tensorclass`.

## Changes

- Changes the package and lockfile bounds to `>=3.11,<3.15` and prepares version/changelog metadata for 2.2.1.
- Pins install CI to the exact `setup-python` executable, disables Python downloads, and checks the runtime minor version before testing.
- Pins reusable container CI to the container's `python3`, rejects uv-managed interpreters, and verifies both the container and venv Python minors. This closes the remaining path where an already-installed managed Python could be selected even with downloads disabled.
- Keeps ordinary PR and merge-group install CI at one Ubuntu/Python 3.12 job. Enables release-candidate branch validation and adds Python 3.14 to push, scheduled, and manual coverage; a one-off PR revision validated 3.14 across all supported runner platforms.
- Qualifies builtin scalar annotations in every affected mesh tensorclass and adds a regression covering both hard introspection failures and silently corrupted annotations.
- Makes the mixed zarr/memmap reader test use platform-native path handling; the prior `split("/")` assertion failed on Windows.

## Verification

- Full local CPython 3.14.0 suite: `15,785 passed, 2,598 skipped, 46 xfailed` with no failures.
- One-off runner validation after the version check reported Python 3.14: Linux x86, Linux ARM, macOS, and Windows all passed (`9,879 passed, 3,285 skipped, 23 xfailed` per platform). The Ubuntu/Python 3.12 control also passed: https://github.com/NVIDIA/physicsnemo/actions/runs/33423934187
- Routine PR install CI passed as exactly one Ubuntu/Python 3.12 job: https://github.com/NVIDIA/physicsnemo/actions/runs/33425937073
- Focused annotation and `DomainMesh.validate` regressions pass on CPython 3.14.0 and 3.13.9; all 110 PhysicsNeMo-defined tensorclass members are introspectable on CPython 3.14.0.
- With uv 0.11.7, reproduced that `UV_PYTHON=python3` plus disabled downloads can still select an installed uv-managed Python. Adding the system-only constraint selected `/usr/bin/python3` instead, and a cached wrong-minor venv was rebuilt on the requested system interpreter.
- `uv lock --check` passes with CPython 3.14. The built `nvidia_physicsnemo-2.2.1-py3-none-any.whl` declares `Requires-Python: <3.15,>=3.11`; pip accepts it on 3.14.6 and rejects it on 3.15.0.
- Changed-file pre-commit hooks, actionlint, and `git diff --check` pass.
- Current-head checks after the comment-only cleanup: https://github.com/NVIDIA/physicsnemo/actions/runs/33429516903 and https://github.com/NVIDIA/physicsnemo/actions/runs/33429510967
