### PR TITLE
Address indexing OOB in darcy datapipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixes out-of-bounds reads in the `Darcy2D` multi-grid solver for
+  `nr_multigrids >= 3` that could return huge or NaN pressure fields, and
+  corrects the coarse-node coordinates used by bilinear upsampling for
+  reduction factors greater than 2.
+
 ### Security
 
 ### Dependencies

--- a/physicsnemo/datapipes/benchmarks/darcy.py
+++ b/physicsnemo/datapipes/benchmarks/darcy.py
@@ -260,19 +260,22 @@ class Darcy2D(Datapipe):
                 ):
                     break
 
-            # upsample to higher resolution
+            # upsample to higher resolution. darcy1 holds the stale previous
+            # iterate at this point, so use it as the destination and swap.
             if grid_reduction_factor > 1:
                 wp.launch(
                     kernel=bilinear_upsample_batched_2d,
                     dim=self.dim,
                     inputs=[
                         self.darcy0,
+                        self.darcy1,
                         self.dim[1],
                         self.dim[2],
                         grid_reduction_factor,
                     ],
                     device=self.device,
                 )
+                (self.darcy0, self.darcy1) = (self.darcy1, self.darcy0)
 
     def __iter__(self) -> Tuple[Tensor, Tensor]:
         """

--- a/physicsnemo/datapipes/benchmarks/kernels/indexing.py
+++ b/physicsnemo/datapipes/benchmarks/kernels/indexing.py
@@ -57,6 +57,11 @@ def index_zero_edges_batched_2d(
 ):  # pragma: no cover
     """Index batched 2d array with zero on edges
 
+    Any index outside ``[0, lx) x [0, ly)`` returns zero. Multi-grid stencils
+    with a reduction factor greater than 2 can step several cells past the
+    boundary, so this must cover the whole out-of-range domain and not just
+    the immediately adjacent cell.
+
     Parameters
     ----------
     array : wp.array3d
@@ -77,16 +82,9 @@ def index_zero_edges_batched_2d(
     float
         Array value
     """
-    if x == -1:
+    if x < 0 or x >= lx or y < 0 or y >= ly:
         return 0.0
-    elif x == lx:
-        return 0.0
-    elif y == -1:
-        return 0.0
-    elif y == ly:
-        return 0.0
-    else:
-        return array[b, x, y]
+    return array[b, x, y]
 
 
 @wp.func

--- a/physicsnemo/datapipes/benchmarks/kernels/utils.py
+++ b/physicsnemo/datapipes/benchmarks/kernels/utils.py
@@ -31,14 +31,25 @@ from .indexing import index_zero_edges_batched_2d
 
 @wp.kernel
 def bilinear_upsample_batched_2d(
-    array: wp.array3d(dtype=float), lx: int, ly: int, grid_reduction_factor: int
+    src: wp.array3d(dtype=float),
+    dst: wp.array3d(dtype=float),
+    lx: int,
+    ly: int,
+    grid_reduction_factor: int,
 ):  # pragma: no cover
     """Bilinear upsampling from batch 2d array
 
+    Coarse-grid nodes live at indices ``k * grid_reduction_factor - 1`` and are
+    read from ``src``; every fine-grid node is written to ``dst``. Nodes outside
+    the array are treated as zero (Dirichlet boundary). ``src`` and ``dst`` must
+    not alias.
+
     Parameters
     ----------
-    array : wp.array3d
-        Array to perform upsampling on
+    src : wp.array3d
+        Array holding the coarse-grid solution
+    dst : wp.array3d
+        Array to write the upsampled solution to
     lx : int
         Grid size X
     ly : int
@@ -49,17 +60,17 @@ def bilinear_upsample_batched_2d(
     # get index
     b, x, y = wp.tid()
 
-    # get four neighbors coordinates
+    # nearest coarse node at or below, and the next coarse node above
     x_0 = x - (x + 1) % grid_reduction_factor
-    x_1 = x + (x + 1) % grid_reduction_factor
+    x_1 = x_0 + grid_reduction_factor
     y_0 = y - (y + 1) % grid_reduction_factor
-    y_1 = y + (y + 1) % grid_reduction_factor
+    y_1 = y_0 + grid_reduction_factor
 
     # simple linear upsampling
-    d_0_0 = index_zero_edges_batched_2d(array, b, x_0, y_0, lx, ly)
-    d_1_0 = index_zero_edges_batched_2d(array, b, x_1, y_0, lx, ly)
-    d_0_1 = index_zero_edges_batched_2d(array, b, x_0, y_1, lx, ly)
-    d_1_1 = index_zero_edges_batched_2d(array, b, x_1, y_1, lx, ly)
+    d_0_0 = index_zero_edges_batched_2d(src, b, x_0, y_0, lx, ly)
+    d_1_0 = index_zero_edges_batched_2d(src, b, x_1, y_0, lx, ly)
+    d_0_1 = index_zero_edges_batched_2d(src, b, x_0, y_1, lx, ly)
+    d_1_1 = index_zero_edges_batched_2d(src, b, x_1, y_1, lx, ly)
 
     # get relative distance
     rel_x = wp.float32(x - x_0) / wp.float32(grid_reduction_factor)
@@ -73,7 +84,7 @@ def bilinear_upsample_batched_2d(
     d = (1.0 - rel_y) * d_x_0 + rel_y * d_x_1
 
     # set interpolation
-    array[b, x, y] = d
+    dst[b, x, y] = d
 
 
 @wp.kernel

--- a/test/datapipes/test_darcy.py
+++ b/test/datapipes/test_darcy.py
@@ -16,6 +16,7 @@
 
 from typing import Tuple
 
+import numpy as np
 import pytest
 import torch
 
@@ -24,6 +25,136 @@ from test.conftest import requires_module
 from . import common
 
 Tensor = torch.Tensor
+
+
+def _bilinear_upsample_reference(coarse: np.ndarray, factor: int) -> np.ndarray:
+    """Numpy reference for ``bilinear_upsample_batched_2d``.
+
+    Coarse nodes sit at indices ``k * factor - 1``. Anything outside the array is
+    a zero Dirichlet boundary, including the coarse boundary node at ``-1`` and
+    the one past the last coarse node.
+    """
+    b, lx, ly = coarse.shape
+
+    def value(bi, x, y):
+        if 0 <= x < lx and 0 <= y < ly:
+            return coarse[bi, x, y]
+        return 0.0
+
+    out = np.zeros_like(coarse)
+    for bi in range(b):
+        for x in range(lx):
+            x0 = ((x + 1) // factor) * factor - 1
+            x1 = x0 + factor
+            rx = (x - x0) / factor
+            for y in range(ly):
+                y0 = ((y + 1) // factor) * factor - 1
+                y1 = y0 + factor
+                ry = (y - y0) / factor
+                d_x0 = (1 - rx) * value(bi, x0, y0) + rx * value(bi, x1, y0)
+                d_x1 = (1 - rx) * value(bi, x0, y1) + rx * value(bi, x1, y1)
+                out[bi, x, y] = (1 - ry) * d_x0 + ry * d_x1
+    return out
+
+
+@requires_module("warp")
+@pytest.mark.parametrize("factor", [2, 4, 8])
+def test_bilinear_upsample_kernel(factor, device, pytestconfig):
+    import warp as wp
+
+    from physicsnemo.datapipes.benchmarks.kernels.utils import (
+        bilinear_upsample_batched_2d,
+    )
+
+    wp.init()
+    resolution = 16
+    dim = (2, resolution + 1, resolution + 1)
+
+    # Only coarse nodes carry data; sample a bilinear polynomial there so the
+    # interior of the upsampled field must reproduce it exactly.
+    rng = np.random.default_rng(0)
+    a, b_, c, d = rng.uniform(-1.0, 1.0, size=4)
+    xs = np.arange(resolution + 1, dtype=np.float64)
+    poly = a + b_ * xs[:, None] + c * xs[None, :] + d * xs[:, None] * xs[None, :]
+    coarse = np.zeros(dim, dtype=np.float32)
+    coarse_idx = np.arange(factor - 1, resolution, factor)
+    coarse[:, coarse_idx[:, None], coarse_idx[None, :]] = poly[
+        coarse_idx[:, None], coarse_idx[None, :]
+    ]
+    coarse[1] *= 0.5
+
+    src = wp.array(coarse, dtype=float, device=device)
+    dst = wp.full(dim, 1.0e20, dtype=float, device=device)
+    wp.launch(
+        kernel=bilinear_upsample_batched_2d,
+        dim=dim,
+        inputs=[src, dst, dim[1], dim[2], factor],
+        device=device,
+    )
+    out = dst.numpy()
+
+    expected = _bilinear_upsample_reference(coarse, factor)
+    assert np.allclose(out, expected, rtol=1e-5, atol=1e-5)
+
+    # interior fine nodes bracketed by coarse nodes on all sides must match the
+    # polynomial exactly (bilinear interpolation is exact for bilinear data)
+    lo, hi = coarse_idx[0], coarse_idx[-1]
+    interior = np.s_[lo : hi + 1, lo : hi + 1]
+    assert np.allclose(out[0][interior], poly[interior], rtol=1e-4, atol=1e-4)
+    assert np.allclose(out[1][interior], 0.5 * poly[interior], rtol=1e-4, atol=1e-4)
+
+
+@requires_module("warp")
+@pytest.mark.parametrize("nr_multigrids", [3, 4])
+def test_darcy_2d_multigrid_stays_in_bounds(nr_multigrids, device, pytestconfig):
+    """Regression test for NVIDIA/physicsnemo#1958.
+
+    Alias the logical (1, 65, 65) solver buffers into padded allocations whose
+    halo is filled with a huge canary. A bounds-correct solver can never observe
+    the halo, so the returned field must stay finite and physically plausible.
+    """
+    import warp as wp
+
+    from physicsnemo.datapipes.benchmarks.darcy import Darcy2D
+
+    resolution = 64
+    logical = resolution + 1
+    padded = logical + 8  # covers the factor-8 far neighbor at index 71
+    canary = 1.0e20
+
+    datapipe = Darcy2D(
+        resolution=resolution,
+        batch_size=1,
+        nr_permeability_freq=5,
+        max_permeability=2.0,
+        min_permeability=0.5,
+        max_iterations=1000,
+        convergence_threshold=1e-4,
+        iterations_per_convergence_check=50,
+        nr_multigrids=nr_multigrids,
+        normaliser={"permeability": (0.0, 1.0), "darcy": (0.0, 1.0)},
+        device=device,
+    )
+
+    parents = []
+    for name in ("darcy0", "darcy1"):
+        parent = wp.full((1, padded, padded), canary, dtype=float, device=device)
+        parents.append(parent)
+        view = wp.array(
+            ptr=parent.ptr,
+            dtype=float,
+            shape=(1, logical, logical),
+            strides=parent.strides,
+            capacity=parent.capacity,
+            device=device,
+        )
+        setattr(datapipe, name, view)
+
+    darcy = next(iter(datapipe))["darcy"]
+    assert torch.isfinite(darcy).all()
+    # unnormalised pressure for this problem is O(1e-2); anything near the
+    # canary magnitude means the halo leaked into the solve
+    assert darcy.abs().max().item() < 1.0
 
 
 @requires_module("warp")


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

Fix indexing issues in the Darcy datapipes, which would let kernels read past the ends of arrays in some cases.  also uses out-of-place upsampling now, instead of inplace.

Closes #1958 .




## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [X] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
