### PR TITLE
Fix missing `shapes` argument in DistributedIRFFT2 gather

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixes a `TypeError` in `DistributedIRFFT2` caused by a missing `shapes`
+  argument in the `gather_from_parallel_region` call inside
+  `conj_pad_helper_2d`.
 - Datapipe transforms, collators, readers, and the unified external aero
   recipe no longer silently skip or mis-handle nested `TensorDict` fields
   (membership was tested against top-level `td.keys()`, and

--- a/physicsnemo/distributed/fft.py
+++ b/physicsnemo/distributed/fft.py
@@ -39,7 +39,7 @@ def conj_pad_helper_2d(tensor, pad_dim, other_dim, new_size):
 
     # gather
     tensor_pad_gather = gather_from_parallel_region(
-        tensor_pad, dim=other_dim, group="spatial_parallel"
+        tensor_pad, dim=other_dim, shapes=None, group="spatial_parallel"
     )
 
     # flip dims


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

`conj_pad_helper_2d` in `physicsnemo/distributed/fft.py` calls
`gather_from_parallel_region` without the required `shapes` argument:

```python
tensor_pad_gather = gather_from_parallel_region(
    tensor_pad, dim=other_dim, group="spatial_parallel"
)
```

but the helper is defined in `physicsnemo/distributed/mappings.py` as

```python
def gather_from_parallel_region(input, dim, shapes, group):
```

`shapes` is positional-and-required and there is no `**kwargs`, so this raises

```
TypeError: gather_from_parallel_region() missing 1 required positional argument: 'shapes'
```

`conj_pad_helper_2d` is reached from `DistributedIRFFT2.forward` (`fft.py:191`),
so **every** `DistributedIRFFT2` forward pass fails. The failure happens at
argument-binding time, before any collective is issued, so it is not
GPU/rank-count dependent.

This is the only one of the five `gather_from_parallel_region` call sites that
omits `shapes` — the other four all pass it:

| Call site | Passes `shapes`? |
|---|---|
| `models/afno/distributed/afno.py:201` | ✅ `shapes=scatter_shapes` |
| `models/afno/distributed/layers.py:226` | ✅ `shapes=self.gather_shapes` |
| `models/afno/distributed/layers.py:353` | ✅ `shapes=self.in_shapes` |
| `models/afno/distributed/layers.py:631` | ✅ `shapes=gather_shapes` |
| `distributed/fft.py:41` | ❌ **missing** |

### Why `shapes=None`

`shapes=None` is explicitly supported and means "assume equal shape on all
ranks" (`all_gather_v_wrapper` in `distributed/utils.py`, whose own `sizes`
parameter defaults to `None`). That is the right value here:

- Both `DistributedRFFT2` and `DistributedIRFFT2` document their contract as
  *"a single global tensor which is distributed along a specified dimension
  into **chunks of equal size**"*.
- The gather is immediately paired with
  `scatter_to_parallel_region(tensor_pad_gather, dim=other_dim, group="spatial_parallel")`
  three statements later, which takes no `shapes` and splits evenly — so an
  even gather is what keeps the round trip symmetric.

The change is therefore behaviour-preserving relative to the documented intent;
it only makes the call actually bind.

### Verification

Since these paths are `# pragma: no cover` and need a multi-rank job, I verified
by replaying the real signature against the real call site with
`inspect.Signature.bind` (AST-extracted from the unmodified sources, so no
hand-copying):

```
BEFORE line 41: TypeError: missing a required argument: 'shapes'
AFTER  line 41: BINDS OK
```

`ruff check` / `ruff format --check` (v0.12.5, the pinned pre-commit version)
pass on the changed file.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

> Note on tests: the distributed FFT primitives have no existing multi-rank test
> and are marked `# pragma: no cover`, so I did not add one here. Happy to add a
> `torchrun`-based test if you would like it in this PR.

## Dependencies

None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
