### PR TITLE
Fix missing `sampler` argument in xaeronet volume dataloader demo

### DIFF
--- a/examples/cfd/external_aerodynamics/xaeronet/volume/dataloader.py
+++ b/examples/cfd/external_aerodynamics/xaeronet/volume/dataloader.py
@@ -99,6 +99,9 @@ def create_dataloader(
         file_list (list of str): List of paths to .h5 files.
         mean (np.ndarray): Global mean for normalization.
         std (np.ndarray): Global standard deviation for normalization.
+        sampler (Sampler or None): Sampler passed to the DataLoader. Use None for
+            the default sequential order.
+        nan_to_0 (bool): If True, NaNs in the loaded arrays are replaced with 0.
         batch_size (int): Number of samples per batch.
         num_workers (int): Number of worker processes for data loading.
         pin_memory (bool): If True, the data loader will copy tensors into CUDA pinned memory.
@@ -134,7 +137,7 @@ if __name__ == "__main__":
 
     # Create DataLoader
     dataloader = create_dataloader(
-        file_list, mean, std, nan_to_0=True, batch_size=2, num_workers=1
+        file_list, mean, std, sampler=None, nan_to_0=True, batch_size=2, num_workers=1
     )
 
     # Example usage


### PR DESCRIPTION
## Problem

`examples/cfd/external_aerodynamics/xaeronet/volume/dataloader.py` cannot be run as a
script. `create_dataloader` takes `sampler` as a **required positional** argument:

```python
def create_dataloader(
    file_list, mean, std, sampler, nan_to_0=True, batch_size=1, ...
):
```

but the `__main__` demo block at the bottom of the same file omits it:

```python
dataloader = create_dataloader(
    file_list, mean, std, nan_to_0=True, batch_size=2, num_workers=1
)
```

so `python dataloader.py` fails with
`TypeError: create_dataloader() missing 1 required positional argument: 'sampler'`
before any data is touched.

Two things show `sampler` was added to the signature after this demo was written and
the demo was never updated:

- The docstring documents `file_list`, `mean`, `std`, `batch_size`, `num_workers`,
  `pin_memory` and `prefetch_factor` — but neither `sampler` nor `nan_to_0`.
- The sibling `surface/dataloader.py` has the same `__main__` demo and runs fine,
  because its `create_dataloader` has no required `sampler`.

## Fix

Pass `sampler=None`, exactly as the real training code in the same example already
does at `volume/train.py`:

```python
valid_dataloader = create_dataloader(
    valid_dataset, mean, std, batch_size=1, num_workers=1, sampler=None
)
```

`DataLoader(sampler=None)` is the documented default (sequential order), so the demo
behaves as originally intended. Also documented `sampler` and `nan_to_0` in the
docstring.

## Verification

No GPU or DriveAer dataset here, so I verified the argument binding rather than
executing the loader — which is exactly where the failure is. Signatures were
extracted from the file's AST and each call shape replayed with `Signature.bind`:

```text
create_dataloader (file_list, mean, std, sampler, nan_to_0=True, batch_size=1,
                   num_workers=4, pin_memory=True, prefetch_factor=2)
  volume/train.py:118 (real production call)     -> binds OK
  volume/dataloader.py __main__ (as written)     -> TypeError: missing a required argument: 'sampler'
  volume/dataloader.py __main__ (patched)        -> binds OK
```

Formatting, with the version pinned in `.pre-commit-config.yaml` (ruff v0.12.5), run
from the repo root:

```text
$ ruff format --check examples/cfd/external_aerodynamics/xaeronet/volume/dataloader.py
1 file already formatted
```

(`ruff check` excludes `^examples/` in the pre-commit config; I confirmed the file's
`ruff check` output is byte-identical before and after this patch either way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
