### PR TITLE
Fix TypeError in sintering_physics deform_analyze plot call

### DIFF
--- a/examples/additive_manufacturing/sintering_physics/data_process/deform_analyze.py
+++ b/examples/additive_manufacturing/sintering_physics/data_process/deform_analyze.py
@@ -195,9 +195,9 @@ def read_solutions_data_temp_anchor(
             del_w.append(p_uvw[2])
 
     plot_p_deform(
-        build_name,
         temp_list,
         key_list=key_list,
+        stage_keys=None,
         del_u=del_u,
         del_v=del_v,
         del_w=del_w,


### PR DESCRIPTION
## Problem

`read_solutions_data_temp_anchor()` in
`examples/additive_manufacturing/sintering_physics/data_process/deform_analyze.py`
cannot reach its plotting step. It calls:

```python
plot_p_deform(
    build_name,
    temp_list,
    key_list=key_list,
    del_u=del_u, del_v=del_v, del_w=del_w,
    pid=read_point_id,
)
```

but the function is:

```python
def plot_p_deform(
    temp_list, key_list, stage_keys, del_u, del_v, del_w, pid=0, split_stages=False
):
```

`plot_p_deform` has no `build_name` parameter. Passing it first shifts every
positional argument by one — `build_name` binds to `temp_list`, and `temp_list`
binds to `key_list` — which then collides with the explicit `key_list=` keyword:

```
TypeError: plot_p_deform() got multiple values for argument 'key_list'
```

The required third parameter, `stage_keys`, is also never passed.

This is the last statement of the function, after the whole `.pvtu` solution
sweep has run, so every invocation does the full read and then dies at the plot.

## Fix

Drop `build_name` (the function neither takes nor uses a build name) and pass
`stage_keys`. `stage_keys` is only read inside the `if split_stages:` block, and
this call leaves `split_stages` at its default of `False`, so `None` preserves
the existing behavior without guessing at a value the caller does not have.

## Verification

No sintering dataset here, so I verified the argument binding — which is exactly
where it fails — by extracting `plot_p_deform`'s signature from the file's AST and
replaying both call shapes with `Signature.bind`:

```text
plot_p_deform (temp_list, key_list, stage_keys, del_u, del_v, del_w, pid=0, split_stages=False)
positional-only params: none
  as written (build_name first)            -> TypeError: multiple values for argument 'key_list'
  after patch                              -> binds OK
```

I explicitly checked that `plot_p_deform` has no positional-only (`/`) parameters —
with PEP 570 positional-only params a same-named keyword would be legal and this
would be a false alarm. It has none, so the collision is real.

Formatting, with the version pinned in `.pre-commit-config.yaml` (ruff v0.12.5), run
from the repo root:

```text
$ ruff format --check examples/additive_manufacturing/sintering_physics/data_process/deform_analyze.py
1 file already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
