### PR TITLE
Write .mdlus checkpoints atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `nr_multigrids >= 3` that could return huge or NaN pressure fields, and
   corrects the coarse-node coordinates used by bilinear upsampling for
   reduction factors greater than 2.
+- `Module.save` now writes `.mdlus` checkpoints atomically (transfer to a
+  temporary sibling name, then rename into place), so a process killed
+  mid-write no longer leaves an unloadable truncated checkpoint. Also fixes
+  `legacy_format=True`, which failed with `FileNotFoundError` on current
+  fsspec versions.
 
 ### Security
 

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -92,11 +92,14 @@ def _put_atomic(fs, local_path: Path | str, file_name: str) -> None:
         else:
             fs.mv(tmp_name, file_name)
     except BaseException:
-        # Best-effort cleanup: never let a failing rm mask the transfer error.
+        # Best-effort cleanup: a failing rm must not replace the transfer error
+        # (interrupts are not Exceptions and still propagate from here).
         try:
             fs.rm(tmp_name)
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.getLogger("core.module").warning(
+                "Could not remove temporary checkpoint file %s: %s", tmp_name, exc
+            )
         raise
 
 

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set, Union
 
 import torch
+from fsspec.implementations.local import LocalFileSystem
 
 from physicsnemo.core.filesystem import _download_cached, _get_fs
 from physicsnemo.core.meta import ModelMetaData
@@ -76,15 +77,26 @@ def _put_atomic(fs, local_path: Path | str, file_name: str) -> None:
     The file is first transferred to a sibling temporary name and then moved
     into place, so that a process killed mid-transfer (e.g. a job hitting its
     wall-time limit) leaves either the previous complete file or the new one,
-    never a truncated archive. On failure the temporary file is removed.
+    never a truncated archive. On a local filesystem the final step is an
+    atomic ``os.replace``; on remote filesystems it is ``fs.mv``, which is only
+    as atomic as the backend makes it. A kill between the two steps can leave
+    a stray ``<file_name>.tmp-*`` file behind; the destination is unaffected.
     """
     tmp_name = f"{file_name}.tmp-{uuid.uuid4().hex}"
     try:
         fs.put(str(local_path), tmp_name)
-        fs.mv(tmp_name, file_name)
+        if isinstance(fs, LocalFileSystem):
+            # fs.mv is shutil.move, which refuses to overwrite an existing
+            # destination on Windows; os.replace overwrites atomically everywhere.
+            os.replace(fs._strip_protocol(tmp_name), fs._strip_protocol(file_name))
+        else:
+            fs.mv(tmp_name, file_name)
     except BaseException:
-        if fs.exists(tmp_name):
+        # Best-effort cleanup: never let a failing rm mask the transfer error.
+        try:
             fs.rm(tmp_name)
+        except Exception:
+            pass
         raise
 
 

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import importlib.metadata
 import inspect
@@ -71,20 +72,23 @@ def _load_state_dict_with_logging(
     return missing_keys, unexpected_keys
 
 
-def _put_atomic(fs, local_path: Path | str, file_name: str) -> None:
-    """Copy ``local_path`` to ``file_name`` on ``fs`` without exposing a partial file.
+@contextlib.contextmanager
+def _atomic_write(fs, file_name: str):
+    """Open ``file_name`` on ``fs`` for writing so the destination never holds a partial file.
 
-    The file is first transferred to a sibling temporary name and then moved
-    into place, so that a process killed mid-transfer (e.g. a job hitting its
-    wall-time limit) leaves either the previous complete file or the new one,
-    never a truncated archive. On a local filesystem the final step is an
-    atomic ``os.replace``; on remote filesystems it is ``fs.mv``, which is only
-    as atomic as the backend makes it. A kill between the two steps can leave
-    a stray ``<file_name>.tmp-*`` file behind; the destination is unaffected.
+    The data is written to a sibling temporary name and moved into place once
+    the ``with`` block exits cleanly, so a process killed mid-write (e.g. a job
+    hitting its wall-time limit) leaves either the previous complete file or
+    the new one, never a truncated archive. On a local filesystem the final
+    step is an atomic ``os.replace``; on remote filesystems it is ``fs.mv``,
+    which is only as atomic as the backend makes it. A kill between the two
+    steps can leave a stray ``<file_name>.tmp-*`` file behind; the destination
+    is unaffected.
     """
     tmp_name = f"{file_name}.tmp-{uuid.uuid4().hex}"
     try:
-        fs.put(str(local_path), tmp_name)
+        with fs.open(tmp_name, "wb") as f:
+            yield f
         if isinstance(fs, LocalFileSystem):
             # os.replace overwrites atomically on every platform; fs.mv does not.
             os.replace(fs._strip_protocol(tmp_name), fs._strip_protocol(file_name))
@@ -92,7 +96,8 @@ def _put_atomic(fs, local_path: Path | str, file_name: str) -> None:
             fs.mv(tmp_name, file_name)
     except BaseException:
         try:
-            fs.rm(tmp_name)
+            if fs.exists(tmp_name):
+                fs.rm(tmp_name)
         except Exception as exc:
             logging.getLogger("core.module").warning(
                 "Could not remove temporary checkpoint file %s: %s", tmp_name, exc
@@ -614,32 +619,24 @@ class Module(torch.nn.Module):
         fs = _get_fs(file_name)
 
         if not legacy_format:
-            # Save in zip format (default)
-            try:
-                with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-                    tmp_path = tmp.name
+            # Save in zip format (default), written straight to the destination
+            with (
+                _atomic_write(fs, file_name) as f,
+                zipfile.ZipFile(f, "w", zipfile.ZIP_STORED) as archive,
+            ):
+                # Save model state dict
+                state_dict_buffer = io.BytesIO()
+                _sd = _state_dict if _state_dict is not None else self.state_dict()
+                torch.save(_sd, state_dict_buffer)
+                archive.writestr("model.pt", state_dict_buffer.getvalue())
 
-                with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_STORED) as archive:
-                    # Save model state dict
-                    state_dict_buffer = io.BytesIO()
-                    _sd = _state_dict if _state_dict is not None else self.state_dict()
-                    torch.save(_sd, state_dict_buffer)
-                    archive.writestr("model.pt", state_dict_buffer.getvalue())
+                # Save args
+                args_str = json.dumps(_args)
+                archive.writestr("args.json", args_str)
 
-                    # Save args
-                    args_str = json.dumps(_args)
-                    archive.writestr("args.json", args_str)
-
-                    # Save metadata
-                    metadata_str = json.dumps(metadata_info)
-                    archive.writestr("metadata.json", metadata_str)
-
-                # Upload to final destination
-                _put_atomic(fs, tmp_path, file_name)
-            finally:
-                # Clean up temporary file
-                if os.path.exists(tmp_path):
-                    os.remove(tmp_path)
+                # Save metadata
+                metadata_str = json.dumps(metadata_info)
+                archive.writestr("metadata.json", metadata_str)
         else:
             # Save in legacy tar format
             with tempfile.TemporaryDirectory() as temp_dir:
@@ -657,13 +654,14 @@ class Module(torch.nn.Module):
                 with open(local_path / "metadata.json", "w") as f:
                     json.dump(metadata_info, f)
 
-                # Create tar archive
-                with tarfile.open(local_path / "model.tar", "w") as tar:
+                # Create tar archive, written straight to the destination
+                # ("w|" streams, so remote file objects need not be seekable)
+                with (
+                    _atomic_write(fs, file_name) as f,
+                    tarfile.open(fileobj=f, mode="w|") as tar,
+                ):
                     for file in local_path.iterdir():
                         tar.add(str(file), arcname=file.name)
-
-                # Upload to final destination
-                _put_atomic(fs, local_path / "model.tar", file_name)
 
     @staticmethod
     def _detect_checkpoint_format(file_path: str) -> str:

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -27,6 +27,7 @@ import os
 import re
 import tarfile
 import tempfile
+import uuid
 import warnings
 import zipfile
 from pathlib import Path
@@ -67,6 +68,24 @@ def _load_state_dict_with_logging(
             f"Unexpected keys when loading {module.__class__.__name__}: {unexpected_keys}"
         )
     return missing_keys, unexpected_keys
+
+
+def _put_atomic(fs, local_path: Path | str, file_name: str) -> None:
+    """Copy ``local_path`` to ``file_name`` on ``fs`` without exposing a partial file.
+
+    The file is first transferred to a sibling temporary name and then moved
+    into place, so that a process killed mid-transfer (e.g. a job hitting its
+    wall-time limit) leaves either the previous complete file or the new one,
+    never a truncated archive. On failure the temporary file is removed.
+    """
+    tmp_name = f"{file_name}.tmp-{uuid.uuid4().hex}"
+    try:
+        fs.put(str(local_path), tmp_name)
+        fs.mv(tmp_name, file_name)
+    except BaseException:
+        if fs.exists(tmp_name):
+            fs.rm(tmp_name)
+        raise
 
 
 def _ignore_device_buffer_keys(module, incompatible_keys):
@@ -604,7 +623,7 @@ class Module(torch.nn.Module):
                     archive.writestr("metadata.json", metadata_str)
 
                 # Upload to final destination
-                fs.put(tmp_path, file_name)
+                _put_atomic(fs, tmp_path, file_name)
             finally:
                 # Clean up temporary file
                 if os.path.exists(tmp_path):
@@ -632,7 +651,7 @@ class Module(torch.nn.Module):
                         tar.add(str(file), arcname=file.name)
 
                 # Upload to final destination
-                fs.put(local_path / "model.tar", file_name)
+                _put_atomic(fs, local_path / "model.tar", file_name)
 
     @staticmethod
     def _detect_checkpoint_format(file_path: str) -> str:

--- a/physicsnemo/core/module.py
+++ b/physicsnemo/core/module.py
@@ -86,14 +86,11 @@ def _put_atomic(fs, local_path: Path | str, file_name: str) -> None:
     try:
         fs.put(str(local_path), tmp_name)
         if isinstance(fs, LocalFileSystem):
-            # fs.mv is shutil.move, which refuses to overwrite an existing
-            # destination on Windows; os.replace overwrites atomically everywhere.
+            # os.replace overwrites atomically on every platform; fs.mv does not.
             os.replace(fs._strip_protocol(tmp_name), fs._strip_protocol(file_name))
         else:
             fs.mv(tmp_name, file_name)
     except BaseException:
-        # Best-effort cleanup: a failing rm must not replace the transfer error
-        # (interrupts are not Exceptions and still propagate from here).
         try:
             fs.rm(tmp_name)
         except Exception as exc:

--- a/test/core/test_module_nested.py
+++ b/test/core/test_module_nested.py
@@ -200,3 +200,40 @@ def test_load_from_checkpoint(device, override):
             )
     registry.__clear_registry__()
     registry.__restore_registry__()
+
+
+@pytest.mark.parametrize("legacy_format", [False, True], ids=["zip", "tar"])
+def test_save_overwrites_existing_checkpoint(tmp_path, legacy_format):
+    file_name = tmp_path / "checkpoint.mdlus"
+    M1(1.0).save(file_name, legacy_format=legacy_format)
+    M1(2.0).save(file_name, legacy_format=legacy_format)
+
+    m_loaded = M1.from_checkpoint(str(file_name))
+    assert m_loaded.b == 2.0
+    # No temporary files left next to the checkpoint
+    assert [p.name for p in tmp_path.iterdir()] == ["checkpoint.mdlus"]
+
+
+@pytest.mark.parametrize("legacy_format", [False, True], ids=["zip", "tar"])
+def test_save_failure_leaves_destination_intact(tmp_path, monkeypatch, legacy_format):
+    from fsspec.implementations.local import LocalFileSystem
+
+    file_name = tmp_path / "checkpoint.mdlus"
+    M1(1.0).save(file_name, legacy_format=legacy_format)
+    original_bytes = file_name.read_bytes()
+
+    # Simulate the process dying part-way through the transfer to the
+    # destination filesystem: a truncated file is written, then an error.
+    def truncated_put(self, lpath, rpath, *args, **kwargs):
+        with open(rpath, "wb") as f:
+            f.write(b"partial")
+        raise RuntimeError("killed mid-transfer")
+
+    monkeypatch.setattr(LocalFileSystem, "put", truncated_put)
+    with pytest.raises(RuntimeError, match="killed mid-transfer"):
+        M1(2.0).save(file_name, legacy_format=legacy_format)
+    monkeypatch.undo()
+
+    assert file_name.read_bytes() == original_bytes
+    assert [p.name for p in tmp_path.iterdir()] == ["checkpoint.mdlus"]
+    assert M1.from_checkpoint(str(file_name)).b == 1.0

--- a/test/core/test_module_nested.py
+++ b/test/core/test_module_nested.py
@@ -232,8 +232,26 @@ def test_save_failure_leaves_destination_intact(tmp_path, monkeypatch, legacy_fo
     monkeypatch.setattr(LocalFileSystem, "put", truncated_put)
     with pytest.raises(RuntimeError, match="killed mid-transfer"):
         M1(2.0).save(file_name, legacy_format=legacy_format)
-    monkeypatch.undo()
 
     assert file_name.read_bytes() == original_bytes
     assert [p.name for p in tmp_path.iterdir()] == ["checkpoint.mdlus"]
     assert M1.from_checkpoint(str(file_name)).b == 1.0
+
+
+def test_save_failure_cleanup_error_does_not_mask_transfer_error(tmp_path, monkeypatch):
+    """If removing the temporary file fails too, the transfer error still surfaces."""
+    from fsspec.implementations.local import LocalFileSystem
+
+    file_name = tmp_path / "checkpoint.mdlus"
+
+    def failing_put(self, lpath, rpath, *args, **kwargs):
+        raise RuntimeError("killed mid-transfer")
+
+    def failing_rm(self, path, *args, **kwargs):
+        raise OSError("filesystem unavailable")
+
+    monkeypatch.setattr(LocalFileSystem, "put", failing_put)
+    monkeypatch.setattr(LocalFileSystem, "rm", failing_rm)
+    with pytest.raises(RuntimeError, match="killed mid-transfer"):
+        M1(1.0).save(file_name)
+    assert list(tmp_path.iterdir()) == []

--- a/test/core/test_module_nested.py
+++ b/test/core/test_module_nested.py
@@ -238,8 +238,11 @@ def test_save_failure_leaves_destination_intact(tmp_path, monkeypatch, legacy_fo
     assert M1.from_checkpoint(str(file_name)).b == 1.0
 
 
-def test_save_failure_cleanup_error_does_not_mask_transfer_error(tmp_path, monkeypatch):
-    """If removing the temporary file fails too, the transfer error still surfaces."""
+def test_save_failure_cleanup_error_does_not_mask_transfer_error(
+    tmp_path, monkeypatch, caplog
+):
+    """If removing the temporary file fails too, the transfer error still surfaces
+    and the cleanup failure is logged rather than silently dropped."""
     from fsspec.implementations.local import LocalFileSystem
 
     file_name = tmp_path / "checkpoint.mdlus"
@@ -252,6 +255,8 @@ def test_save_failure_cleanup_error_does_not_mask_transfer_error(tmp_path, monke
 
     monkeypatch.setattr(LocalFileSystem, "put", failing_put)
     monkeypatch.setattr(LocalFileSystem, "rm", failing_rm)
-    with pytest.raises(RuntimeError, match="killed mid-transfer"):
-        M1(1.0).save(file_name)
+    with caplog.at_level("WARNING", logger="core.module"):
+        with pytest.raises(RuntimeError, match="killed mid-transfer"):
+            M1(1.0).save(file_name)
     assert list(tmp_path.iterdir()) == []
+    assert any("filesystem unavailable" in r.getMessage() for r in caplog.records)

--- a/test/core/test_module_nested.py
+++ b/test/core/test_module_nested.py
@@ -222,14 +222,17 @@ def test_save_failure_leaves_destination_intact(tmp_path, monkeypatch, legacy_fo
     M1(1.0).save(file_name, legacy_format=legacy_format)
     original_bytes = file_name.read_bytes()
 
-    # Simulate the process dying part-way through the transfer to the
-    # destination filesystem: a truncated file is written, then an error.
-    def truncated_put(self, lpath, rpath, *args, **kwargs):
-        with open(rpath, "wb") as f:
-            f.write(b"partial")
+    # Simulate the process dying part-way through writing the archive: some
+    # bytes reach the destination filesystem, then an error.
+    real_open = LocalFileSystem.open
+
+    def truncated_open(self, path, mode="rb", *args, **kwargs):
+        f = real_open(self, path, mode, *args, **kwargs)
+        f.write(b"partial")
+        f.close()
         raise RuntimeError("killed mid-transfer")
 
-    monkeypatch.setattr(LocalFileSystem, "put", truncated_put)
+    monkeypatch.setattr(LocalFileSystem, "open", truncated_open)
     with pytest.raises(RuntimeError, match="killed mid-transfer"):
         M1(2.0).save(file_name, legacy_format=legacy_format)
 
@@ -247,14 +250,14 @@ def test_save_failure_cleanup_error_does_not_mask_transfer_error(
 
     file_name = tmp_path / "checkpoint.mdlus"
 
-    def failing_put(self, lpath, rpath, *args, **kwargs):
+    def failing_open(self, path, mode="rb", *args, **kwargs):
         raise RuntimeError("killed mid-transfer")
 
-    def failing_rm(self, path, *args, **kwargs):
+    def failing_exists(self, path, *args, **kwargs):
         raise OSError("filesystem unavailable")
 
-    monkeypatch.setattr(LocalFileSystem, "put", failing_put)
-    monkeypatch.setattr(LocalFileSystem, "rm", failing_rm)
+    monkeypatch.setattr(LocalFileSystem, "open", failing_open)
+    monkeypatch.setattr(LocalFileSystem, "exists", failing_exists)
     with caplog.at_level("WARNING", logger="core.module"):
         with pytest.raises(RuntimeError, match="killed mid-transfer"):
             M1(1.0).save(file_name)


### PR DESCRIPTION
## What breaks today

`Module.save` builds the `.mdlus` archive in a local temp file and then copies it onto the destination with `fs.put(tmp, file_name)`. If the process is killed during that copy (we hit this when a Slurm job reached its wall-time limit mid-save), the destination is left as a truncated file that is neither a valid zip nor tar archive. Every later `from_checkpoint` / `load` then fails with `Could not determine checkpoint format`, and the previous good checkpoint at that path is gone.

Separately, `save(..., legacy_format=True)` is broken on current fsspec: it passes a `Path` to `fs.put`, which fsspec treats as a list of sources and therefore takes the destination as a directory, failing with `FileNotFoundError: .../checkpoint.mdlus/model.tar`.

## Fix

- Write the archive straight to a sibling temporary name on the destination filesystem (`<file_name>.tmp-<uuid>`, via `fs.open`) and move it into place once it is complete. There is no local staging file any more: one fewer copy, and no dependence on local scratch space.
- The final move is `os.replace` on local filesystems (atomic, and it overwrites an existing checkpoint on every platform) and `fs.mv` on remote ones, which is as atomic as the backend allows. The destination is therefore always either the old complete file or the new complete file.
- If writing fails, the temporary file is removed on a best-effort basis (a failing cleanup is logged and cannot replace the original error) and the error is re-raised.
- Both the zip (default) and legacy tar branches go through the same helper, which also fixes the broken tar branch.

## Unchanged

- Checkpoint format, public API, signature, and defaults.
- Existing checkpoints load as before.

## Tests

Added to `test/core/test_module_nested.py`, for both zip and tar:

- Saving over an existing checkpoint leaves a loadable file with the new weights and no temporary files next to it.
- A simulated failure mid-write (monkeypatched `LocalFileSystem.open` writes a few bytes, then raises) leaves the original destination byte-identical and loadable, with no partial file left behind.
- A failure during cleanup is logged and does not mask the original error.

The overwrite and mid-write tests fail on `main` and pass with this change. Also ran the rest of `test/core/test_module_nested.py`.
