### PR TITLE
Configure the distributed process-group timeout in code or environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `physicsnemo.datapipes` through it, so a `"."` in a YAML field name
   (`"solution.pressure"`) addresses a leaf inside a nested `TensorDict`.
   Nested `Mesh` data no longer needs to be flattened before use.
+- `DistributedManager` reads an optional `PHYSICSNEMO_DIST_TIMEOUT_S`
+  environment variable (seconds) and passes it as the process-group timeout
+  to `torch.distributed.init_process_group`. Unset keeps the backend default.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `physicsnemo.datapipes` through it, so a `"."` in a YAML field name
   (`"solution.pressure"`) addresses a leaf inside a nested `TensorDict`.
   Nested `Mesh` data no longer needs to be flattened before use.
-- `DistributedManager` reads an optional `PHYSICSNEMO_DIST_TIMEOUT_S`
-  environment variable (seconds) and passes it as the process-group timeout
-  to `torch.distributed.init_process_group`. Unset keeps the backend default.
+- `DistributedManager.initialize(timeout=...)` accepts numeric seconds or a
+  `timedelta` for the default process-group timeout. Explicit values override
+  `PHYSICSNEMO_DIST_TIMEOUT_S`; unset or empty configuration keeps PyTorch's
+  backend default. Invalid timeouts are rejected before initialization state
+  changes, allowing corrected configuration to be retried.
 
 ### Changed
 

--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -18,6 +18,7 @@ import atexit
 import os
 import queue
 import warnings
+from datetime import timedelta
 from typing import Optional, Tuple
 from warnings import warn
 
@@ -387,6 +388,10 @@ class DistributedManager(object):
         listed above. Initialization method can also be explicitly controlled using the
         `PHYSICSNEMO_DISTRIBUTED_INITIALIZATION_METHOD` environment variable and setting it
         to one of the options above.
+
+        The process-group timeout can be overridden by setting the
+        `PHYSICSNEMO_DIST_TIMEOUT_S` environment variable to a number of seconds.
+        When unset, the backend default (10 minutes for NCCL) is used.
         """
         if DistributedManager.is_initialized():
             warn("Distributed manager is already initialized")
@@ -590,6 +595,14 @@ class DistributedManager(object):
             )
 
         if manager._distributed:
+            # Optional process-group timeout override (seconds). The backend
+            # default (10 minutes for NCCL) is too long when a rank dies
+            # between collectives, since its peers hang for the full window,
+            # and too short when a long step or a stalled file system delays
+            # one rank. Unset leaves the backend default in place.
+            timeout_env = os.environ.get("PHYSICSNEMO_DIST_TIMEOUT_S")
+            timeout = timedelta(seconds=float(timeout_env)) if timeout_env else None
+
             # Setup distributed process group
             try:
                 dist.init_process_group(
@@ -597,6 +610,7 @@ class DistributedManager(object):
                     rank=manager.rank,
                     world_size=manager.world_size,
                     device_id=manager.device,
+                    timeout=timeout,
                 )
             except TypeError:
                 # device_id only introduced in PyTorch 2.3
@@ -604,6 +618,7 @@ class DistributedManager(object):
                     backend,
                     rank=manager.rank,
                     world_size=manager.world_size,
+                    timeout=timeout,
                 )
 
         if torch.cuda.is_available():

--- a/physicsnemo/distributed/manager.py
+++ b/physicsnemo/distributed/manager.py
@@ -19,6 +19,7 @@ import os
 import queue
 import warnings
 from datetime import timedelta
+from numbers import Real
 from typing import Optional, Tuple
 from warnings import warn
 
@@ -307,7 +308,44 @@ class DistributedManager(object):
             return "gloo"
 
     @staticmethod
-    def initialize_env():
+    def _resolve_timeout(timeout: float | timedelta | None) -> timedelta | None:
+        """Resolve an explicit timeout or environment value without changing state.
+
+        Empty environment values retain the backend default, as do unset
+        values. Explicit values take precedence, including when the environment
+        contains an invalid value. Positive numeric seconds must remain positive
+        after conversion to ``timedelta``'s microsecond resolution.
+        """
+        source = "timeout"
+        if timeout is None:
+            value = os.environ.get("PHYSICSNEMO_DIST_TIMEOUT_S")
+            if not value:
+                return None
+            source = "PHYSICSNEMO_DIST_TIMEOUT_S"
+            try:
+                timeout = float(value)
+            except (ValueError, OverflowError) as error:
+                raise ValueError(f"{source} must be a number of seconds") from error
+
+        if isinstance(timeout, timedelta):
+            resolved = timeout
+        else:
+            if isinstance(timeout, bool) or not isinstance(timeout, Real):
+                raise TypeError("timeout must be numeric seconds or a timedelta")
+            try:
+                resolved = timedelta(seconds=float(timeout))
+            except (ValueError, OverflowError) as error:
+                raise ValueError(
+                    f"{source} must be finite, positive, and representable as a timedelta"
+                ) from error
+        if resolved <= timedelta(0):
+            raise ValueError(
+                f"{source} must be positive at timedelta's microsecond resolution"
+            )
+        return resolved
+
+    @staticmethod
+    def initialize_env(*, timeout: float | timedelta | None = None):
         """Setup method using generic initialization"""
         rank = int(os.environ.get("RANK"))
         world_size = int(os.environ.get("WORLD_SIZE"))
@@ -332,10 +370,11 @@ class DistributedManager(object):
             addr=addr,
             port=port,
             backend=DistributedManager.get_available_backend(),
+            timeout=timeout,
         )
 
     @staticmethod
-    def initialize_open_mpi(addr, port):
+    def initialize_open_mpi(addr, port, *, timeout: float | timedelta | None = None):
         """Setup method using OpenMPI initialization"""
         rank = int(os.environ.get("OMPI_COMM_WORLD_RANK"))
         world_size = int(os.environ.get("OMPI_COMM_WORLD_SIZE"))
@@ -349,10 +388,11 @@ class DistributedManager(object):
             port=port,
             backend=DistributedManager.get_available_backend(),
             method="openmpi",
+            timeout=timeout,
         )
 
     @staticmethod
-    def initialize_slurm(port):
+    def initialize_slurm(port, *, timeout: float | timedelta | None = None):
         """Setup method using SLURM initialization"""
         rank = int(os.environ.get("SLURM_PROCID"))
         world_size = int(os.environ.get("SLURM_NPROCS"))
@@ -367,10 +407,11 @@ class DistributedManager(object):
             port=port,
             backend=DistributedManager.get_available_backend(),
             method="slurm",
+            timeout=timeout,
         )
 
     @staticmethod
-    def initialize():
+    def initialize(*, timeout: float | timedelta | None = None):
         """
         Initialize distributed manager
 
@@ -389,13 +430,35 @@ class DistributedManager(object):
         `PHYSICSNEMO_DISTRIBUTED_INITIALIZATION_METHOD` environment variable and setting it
         to one of the options above.
 
-        The process-group timeout can be overridden by setting the
-        `PHYSICSNEMO_DIST_TIMEOUT_S` environment variable to a number of seconds.
-        When unset, the backend default (10 minutes for NCCL) is used.
+        Parameters
+        ----------
+        timeout : float or datetime.timedelta or None, optional
+            Process-group timeout as numeric seconds (including fractional
+            seconds) or a ``timedelta``. For example,
+            ``DistributedManager.initialize(timeout=6000)``. An explicit value
+            overrides ``PHYSICSNEMO_DIST_TIMEOUT_S``. If ``None``, that environment
+            variable is read as seconds; unset or empty leaves PyTorch's backend
+            default unchanged. Values must be finite and positive at
+            ``timedelta``'s microsecond resolution. Set the same timeout on all
+            ranks. This configures the default process group; groups created
+            separately retain their own timeout policies.
+
+        Raises
+        ------
+        TypeError
+            If an explicit timeout is not numeric seconds or a ``timedelta``.
+        ValueError
+            If the selected timeout is invalid, nonpositive, or unrepresentable.
+            Validation precedes initialization state changes, so callers can
+            correct the configuration and retry.
         """
         if DistributedManager.is_initialized():
             warn("Distributed manager is already initialized")
             return
+
+        # Resolve before launcher autodetection: a bad timeout must not be
+        # mistaken for missing launcher variables by the TypeError fallback.
+        timeout = DistributedManager._resolve_timeout(timeout)
 
         addr = os.getenv("MASTER_ADDR", "localhost")
         port = os.getenv("MASTER_PORT", "12355")
@@ -410,23 +473,23 @@ class DistributedManager(object):
         )
         if initialization_method is None:
             try:
-                DistributedManager.initialize_env()
+                DistributedManager.initialize_env(timeout=timeout)
             except TypeError:
                 if "SLURM_PROCID" in os.environ:
-                    DistributedManager.initialize_slurm(port)
+                    DistributedManager.initialize_slurm(port, timeout=timeout)
                 elif "OMPI_COMM_WORLD_RANK" in os.environ:
-                    DistributedManager.initialize_open_mpi(addr, port)
+                    DistributedManager.initialize_open_mpi(addr, port, timeout=timeout)
                 else:
                     warn(
                         "Could not initialize using ENV, SLURM or OPENMPI methods. Assuming this is a single process job"
                     )
                     DistributedManager._shared_state["_is_initialized"] = True
         elif initialization_method == "ENV":
-            DistributedManager.initialize_env()
+            DistributedManager.initialize_env(timeout=timeout)
         elif initialization_method == "SLURM":
-            DistributedManager.initialize_slurm(port)
+            DistributedManager.initialize_slurm(port, timeout=timeout)
         elif initialization_method == "OPENMPI":
-            DistributedManager.initialize_open_mpi(addr, port)
+            DistributedManager.initialize_open_mpi(addr, port, timeout=timeout)
         else:
             raise RuntimeError(
                 "Unknown initialization method "
@@ -567,8 +630,16 @@ class DistributedManager(object):
         port="12355",
         backend="nccl",
         method="env",
+        *,
+        timeout: float | timedelta | None = None,
     ):
-        """Set up PyTorch distributed process group and update manager attributes"""
+        """Set up a process group and update manager attributes.
+
+        ``timeout`` accepts numeric seconds or a ``timedelta`` and takes
+        precedence over ``PHYSICSNEMO_DIST_TIMEOUT_S``, as in :meth:`initialize`.
+        Validate before mutating state, including for callers using setup directly.
+        """
+        timeout = DistributedManager._resolve_timeout(timeout)
         os.environ["MASTER_ADDR"] = addr
         os.environ["MASTER_PORT"] = str(port)
 
@@ -595,14 +666,6 @@ class DistributedManager(object):
             )
 
         if manager._distributed:
-            # Optional process-group timeout override (seconds). The backend
-            # default (10 minutes for NCCL) is too long when a rank dies
-            # between collectives, since its peers hang for the full window,
-            # and too short when a long step or a stalled file system delays
-            # one rank. Unset leaves the backend default in place.
-            timeout_env = os.environ.get("PHYSICSNEMO_DIST_TIMEOUT_S")
-            timeout = timedelta(seconds=float(timeout_env)) if timeout_env else None
-
             # Setup distributed process group
             try:
                 dist.init_process_group(

--- a/test/distributed/test_manager.py
+++ b/test/distributed/test_manager.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+from datetime import timedelta
 
 import pytest
 import torch
@@ -455,6 +456,37 @@ def test_isolate_torch_compile_cache_opt_out(monkeypatch):
     DistributedManager._isolate_torch_compile_cache(local_rank=1, world_size=4)
 
     assert "TORCHINDUCTOR_CACHE_DIR" not in os.environ
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [(None, None), ("90", timedelta(seconds=90)), ("0.5", timedelta(seconds=0.5))],
+)
+def test_manager_process_group_timeout(monkeypatch, env_value, expected):
+    """PHYSICSNEMO_DIST_TIMEOUT_S is forwarded to init_process_group; unset
+    leaves the backend default (timeout=None)."""
+    monkeypatch.setenv("MASTER_ADDR", "localhost")
+    monkeypatch.setenv("MASTER_PORT", "12345")
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "1")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    if env_value is None:
+        monkeypatch.delenv("PHYSICSNEMO_DIST_TIMEOUT_S", raising=False)
+    else:
+        monkeypatch.setenv("PHYSICSNEMO_DIST_TIMEOUT_S", env_value)
+
+    captured = {}
+
+    def fake_init_process_group(*args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        torch.distributed, "init_process_group", fake_init_process_group
+    )
+
+    DistributedManager.initialize()
+
+    assert captured["timeout"] == expected
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_manager_timeout.py
+++ b/test/distributed/test_manager_timeout.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Timeout configuration and real NCCL initialization for DistributedManager."""
+
+import os
+import socket
+from datetime import timedelta
+
+import numpy as np
+import pytest
+import torch
+import torch.distributed as dist
+
+from physicsnemo.distributed import DistributedManager
+
+_TIMEOUT_ENV = "PHYSICSNEMO_DIST_TIMEOUT_S"
+_LAUNCHER_ENV = {
+    "ENV": {"RANK": "0", "WORLD_SIZE": "2", "LOCAL_RANK": "0"},
+    "SLURM": {
+        "SLURM_PROCID": "0",
+        "SLURM_NPROCS": "2",
+        "SLURM_LOCALID": "0",
+        "SLURM_LAUNCH_NODE_IPADDR": "localhost",
+    },
+    "OPENMPI": {
+        "OMPI_COMM_WORLD_RANK": "0",
+        "OMPI_COMM_WORLD_SIZE": "2",
+        "OMPI_COMM_WORLD_LOCAL_RANK": "0",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_manager_environment(monkeypatch):
+    """Isolate launcher variables, singleton state, and initialization side effects."""
+    keys = {key for values in _LAUNCHER_ENV.values() for key in values} | {
+        _TIMEOUT_ENV,
+        "MASTER_ADDR",
+        "MASTER_PORT",
+        "PHYSICSNEMO_DISTRIBUTED_INITIALIZATION_METHOD",
+        "NCCL_ASYNC_ERROR_HANDLING",
+        "TORCH_NCCL_ASYNC_ERROR_HANDLING",
+        "TORCHINDUCTOR_CACHE_DIR",
+    }
+    for key in keys:
+        # Track originally absent variables too, since setup writes some of them.
+        monkeypatch.setenv(key, os.environ.get(key, ""))
+        monkeypatch.delenv(key)
+    monkeypatch.setattr(DistributedManager, "_shared_state", {})
+    random_state = np.random.get_state()
+    yield
+    np.random.set_state(random_state)
+
+
+@pytest.fixture
+def mock_process_group(monkeypatch):
+    """Record initialization without requiring a GPU, network, or process group."""
+    calls = []
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(dist, "is_available", lambda: True)
+    monkeypatch.setattr(
+        DistributedManager, "_isolate_torch_compile_cache", lambda *args: None
+    )
+    monkeypatch.setattr(
+        dist, "init_process_group", lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    return calls
+
+
+def _configure_launcher(monkeypatch, launcher, forced=False):
+    """Select one launcher through either auto-detection or its explicit override."""
+    monkeypatch.setenv("MASTER_ADDR", "localhost")
+    monkeypatch.setenv("MASTER_PORT", "12399")
+    for key, value in _LAUNCHER_ENV[launcher].items():
+        monkeypatch.setenv(key, value)
+    if forced:
+        monkeypatch.setenv("PHYSICSNEMO_DISTRIBUTED_INITIALIZATION_METHOD", launcher)
+
+
+@pytest.mark.parametrize("launcher", ["ENV", "SLURM", "OPENMPI"])
+@pytest.mark.parametrize("forced", [False, True], ids=["detected", "forced"])
+@pytest.mark.parametrize("legacy_signature", [False, True], ids=["current", "legacy"])
+@pytest.mark.parametrize(
+    ("argument", "environment", "expected"),
+    [
+        (None, None, None),
+        (None, "", None),
+        (None, "90.25", timedelta(seconds=90.25)),
+        (60.5, None, timedelta(seconds=60.5)),
+        (60, "invalid-but-overridden", timedelta(seconds=60)),
+        (timedelta(seconds=15.5), "90", timedelta(seconds=15.5)),
+    ],
+)
+def test_launcher_forwards_effective_timeout(
+    monkeypatch,
+    mock_process_group,
+    launcher,
+    forced,
+    legacy_signature,
+    argument,
+    environment,
+    expected,
+):
+    """All launchers and the old-PyTorch retry retain the chosen timeout."""
+    _configure_launcher(monkeypatch, launcher, forced)
+    if environment is not None:
+        monkeypatch.setenv(_TIMEOUT_ENV, environment)
+    if legacy_signature:
+
+        def legacy_init(*args, **kwargs):
+            """Model PyTorch releases that lack the device_id keyword."""
+            mock_process_group.append((args, kwargs))
+            if "device_id" in kwargs:
+                raise TypeError("unexpected keyword argument 'device_id'")
+
+        monkeypatch.setattr(dist, "init_process_group", legacy_init)
+
+    DistributedManager.initialize(timeout=argument)
+
+    assert DistributedManager.is_initialized()
+    assert len(mock_process_group) == (2 if legacy_signature else 1)
+    for args, kwargs in mock_process_group:
+        assert args == ("gloo",)
+        assert kwargs["timeout"] == expected
+        assert kwargs["rank"] == 0
+        assert kwargs["world_size"] == 2
+    if legacy_signature:
+        assert "device_id" not in mock_process_group[-1][1]
+
+
+@pytest.mark.parametrize(
+    ("argument", "environment", "expected"),
+    [
+        (None, "90.25", timedelta(seconds=90.25)),
+        (30, "invalid-but-overridden", timedelta(seconds=30)),
+        (timedelta(seconds=45), None, timedelta(seconds=45)),
+        (None, None, None),
+    ],
+)
+def test_direct_setup_accepts_timeout(
+    monkeypatch, mock_process_group, argument, environment, expected
+):
+    """Direct setup preserves the same explicit, environment, and default choices."""
+    if environment is not None:
+        monkeypatch.setenv(_TIMEOUT_ENV, environment)
+    DistributedManager.setup(
+        rank=0, world_size=2, local_rank=0, backend="gloo", timeout=argument
+    )
+    assert mock_process_group[0][1]["timeout"] == expected
+
+
+@pytest.mark.parametrize("entrypoint", ["initialize", "setup"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        True,
+        False,
+        "60",
+        object(),
+        0,
+        -1,
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        1e20,
+        10**400,
+        1e-9,
+        timedelta(0),
+        timedelta(seconds=-1),
+    ],
+)
+def test_invalid_api_timeout_leaves_manager_uninitialized(
+    monkeypatch, mock_process_group, entrypoint, value
+):
+    """Invalid public values fail before launcher fallback or singleton mutation."""
+    _configure_launcher(monkeypatch, "ENV")
+    method = getattr(DistributedManager, entrypoint)
+    with pytest.raises((TypeError, ValueError), match="timeout"):
+        method(timeout=value)
+    assert not DistributedManager.is_initialized()
+    assert not mock_process_group
+
+    if entrypoint == "setup":
+        method(local_rank=0, backend="gloo", timeout=30)
+    else:
+        method(timeout=30)
+    assert DistributedManager.is_initialized()
+    assert mock_process_group[0][1]["timeout"] == timedelta(seconds=30)
+
+
+@pytest.mark.parametrize("with_launcher", [False, True], ids=["serial", "distributed"])
+@pytest.mark.parametrize("value", ["bad", " ", "0", "-1", "nan", "inf", "1e20", "1e-9"])
+def test_invalid_environment_can_be_corrected_and_retried(
+    monkeypatch, mock_process_group, with_launcher, value
+):
+    """Invalid environment values cannot become successful serial fallback."""
+    if with_launcher:
+        _configure_launcher(monkeypatch, "ENV")
+    monkeypatch.setenv(_TIMEOUT_ENV, value)
+    with pytest.raises(ValueError, match="PHYSICSNEMO_DIST_TIMEOUT_S"):
+        DistributedManager.initialize()
+    assert not DistributedManager.is_initialized()
+    assert not mock_process_group
+
+    monkeypatch.setenv(_TIMEOUT_ENV, "30.25")
+    if with_launcher:
+        DistributedManager.initialize()
+        assert mock_process_group[0][1]["timeout"] == timedelta(seconds=30.25)
+    else:
+        with pytest.warns(UserWarning, match="single process"):
+            DistributedManager.initialize()
+        assert not mock_process_group
+    assert DistributedManager.is_initialized()
+
+
+def _nccl_timeout_worker(rank, port, source):
+    """Initialize two real CUDA ranks and exercise their configured process group."""
+    os.environ.update(
+        RANK=str(rank),
+        LOCAL_RANK=str(rank),
+        WORLD_SIZE="2",
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        PHYSICSNEMO_DISTRIBUTED_INITIALIZATION_METHOD="ENV",
+    )
+    DistributedManager._shared_state = {}
+    os.environ.pop(_TIMEOUT_ENV, None)
+    argument = None
+    if source in ("environment", "precedence"):
+        os.environ[_TIMEOUT_ENV] = "120.25" if source == "environment" else "180"
+    if source in ("argument", "precedence"):
+        argument = 120.25
+
+    real_init = dist.init_process_group
+    observed = []
+
+    def recording_init(*args, **kwargs):
+        """Observe the timeout while preserving real NCCL initialization."""
+        observed.append(kwargs.get("timeout"))
+        return real_init(*args, **kwargs)
+
+    dist.init_process_group = recording_init
+    try:
+        DistributedManager.initialize(timeout=argument)
+        manager = DistributedManager()
+        assert observed[-1] == timedelta(seconds=120.25)
+        assert dist.get_backend() == "nccl"
+        assert manager.world_size == 2
+        assert manager.rank == rank
+        value = torch.tensor(float(rank + 1), device=manager.device)
+        dist.all_reduce(value)
+        assert value.item() == 3.0
+    finally:
+        dist.init_process_group = real_init
+        if dist.is_initialized():
+            DistributedManager.cleanup()
+
+
+@pytest.mark.multigpu_dynamic
+@pytest.mark.parametrize("source", ["argument", "environment", "precedence"])
+def test_timeout_initializes_real_nccl_process_group(source):
+    """The configured timeout reaches a working two-GPU NCCL process group."""
+    assert torch.cuda.device_count() >= 2, "Two GPUs are required for this test"
+    assert dist.is_nccl_available(), "NCCL is required for this test"
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+    torch.multiprocessing.spawn(
+        _nccl_timeout_worker, args=(port, source), nprocs=2, join=True
+    )


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description

Add a configurable timeout for the default distributed process group:

```python
DistributedManager.initialize(timeout=6000)
```

The argument accepts numeric seconds (including fractional seconds) or `datetime.timedelta`. Explicit values override `PHYSICSNEMO_DIST_TIMEOUT_S`; with no argument, the environment variable supplies seconds. Unset or empty configuration preserves PyTorch's backend default.

Resolve and validate the selected timeout before initialization-state changes or launcher autodetection. Invalid types, nonfinite/nonpositive values, overflow, and durations that round to zero fail clearly, and corrected configuration can be retried. Explicit settings override even a malformed environment value.

The effective timeout reaches ENV, SLURM and OPENMPI initialization, direct setup, and both current and compatibility `init_process_group` calls. Use the same setting on all ranks. Separately created process groups retain their own timeout policies.

## Validation

- 120 new CPU-capable tests passed for precedence, fractional seconds/timedelta, all launcher routes, compatibility forwarding, direct setup, invalid configuration and corrected retries.
- Existing manager suite: 14 passed, 22 skipped.
- Three new `multigpu_dynamic` tests initialize two real CUDA/NCCL ranks, verify the configured argument/environment/precedence choice, perform an all-reduce and clean up. These were skipped locally because this machine has one GPU; the existing `ci:multi-gpu` label enables both CI streams on the updated trusted mirror.
- All changed-file pre-commit checks passed. The implementation received an independent code review.

## Checklist

- [x] Contribution guidelines followed; new commits carry sign-offs.
- [x] Regression tests, API documentation, and CHANGELOG updated.
- [x] No model implementation changes.
- [x] Fresh multi-GPU CI results pending.
