### PR TITLE
Mesh: FieldLayout for packing named scalar and vector fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `physicsnemo.datapipes` through it, so a `"."` in a YAML field name
   (`"solution.pressure"`) addresses a leaf inside a nested `TensorDict`.
   Nested `Mesh` data no longer needs to be flattened before use.
+- Adds `physicsnemo.mesh.FieldLayout`, which packs the named scalar and vector
+  fields of a point `TensorDict` into two dense channel tensors in a fixed,
+  name-sorted order and unpacks them back, plus `validate_rank_spec` for
+  checking a `{name: rank}` schema.
 
 ### Changed
 

--- a/physicsnemo/mesh/__init__.py
+++ b/physicsnemo/mesh/__init__.py
@@ -16,22 +16,28 @@
 
 from physicsnemo.mesh.domain_mesh import DomainMesh
 from physicsnemo.mesh.fields import (
+    FieldLayout,
     RankSpecDict,
+    ScalarVectorFields,
     flatten_rank_spec,
     rank_counts,
     ranks_from_tensordict,
     validate_data_contains_ranks,
+    validate_rank_spec,
 )
 from physicsnemo.mesh.mesh import MESH_FIELD_ASSOCIATIONS, Mesh, MeshFieldAssociation
 
 __all__ = [
     "DomainMesh",
+    "FieldLayout",
     "MESH_FIELD_ASSOCIATIONS",
     "Mesh",
     "MeshFieldAssociation",
     "RankSpecDict",
+    "ScalarVectorFields",
     "flatten_rank_spec",
     "rank_counts",
     "ranks_from_tensordict",
     "validate_data_contains_ranks",
+    "validate_rank_spec",
 ]

--- a/physicsnemo/mesh/fields.py
+++ b/physicsnemo/mesh/fields.py
@@ -22,15 +22,21 @@ as static metadata. Specifications may be flat or nested to mirror a
 hierarchical TensorDict structure.
 
 This module contains the representation-neutral schema helpers originally
-implemented by GLOBE. Runtime grouping and packing of tensor data belongs to
-the consuming model rather than this metadata module.
+implemented by GLOBE, plus :class:`FieldLayout`, which packs the named scalar
+(rank-0) and vector (rank-1) fields of a point TensorDict into two dense
+channel tensors in a fixed, name-sorted order. Scalars and vectors are kept
+in separate tensors because they transform differently under a change of
+frame; a rank-1 leaf is a Cartesian vector, not an arbitrary feature axis.
 """
 
 from __future__ import annotations
 
 from collections import Counter
-from typing import TypeAlias, Union
+from collections.abc import Collection
+from copy import deepcopy
+from typing import NamedTuple, TypeAlias, Union, cast
 
+import torch
 from tensordict import TensorDict
 
 # TODO: replace with ``type RankSpecDict = ...`` after Python 3.11 support is
@@ -70,6 +76,68 @@ def flatten_rank_spec(rank_spec: RankSpecDict, sep: str = ".") -> dict[str, int]
         else:
             result[key] = value
     return result
+
+
+def validate_rank_spec(
+    rank_spec: RankSpecDict,
+    *,
+    allowed_ranks: Collection[int] | None = None,
+    source_label: str = "rank_spec",
+) -> None:
+    r"""Validate the structure and integer leaves of a rank specification.
+
+    Parameters
+    ----------
+    rank_spec : RankSpecDict
+        Rank specification to validate.
+    allowed_ranks : Collection[int] or None, optional
+        If supplied, every leaf must belong to this collection. Otherwise all
+        non-negative integer ranks are accepted.
+    source_label : str, default="rank_spec"
+        Human-readable name used in error messages.
+
+    Raises
+    ------
+    TypeError
+        If ``rank_spec`` is not a dict, a key is not a string, or a leaf is
+        not an integer.
+    ValueError
+        If a rank is negative or is not in ``allowed_ranks``.
+    """
+    allowed = None if allowed_ranks is None else frozenset(allowed_ranks)
+
+    def _validate(spec: RankSpecDict, path: tuple[str, ...]) -> None:
+        for key, value in spec.items():
+            if not isinstance(key, str):
+                raise TypeError(
+                    f"All keys in {source_label} must be strings; got "
+                    f"{key!r} at {'.'.join(path) or '<root>'}"
+                )
+            leaf_path = (*path, key)
+            if isinstance(value, dict):
+                _validate(value, leaf_path)
+                continue
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(
+                    f"Rank for {'.'.join(leaf_path)!r} in {source_label} must "
+                    f"be an integer, got {value!r}"
+                )
+            if value < 0:
+                raise ValueError(
+                    f"Rank for {'.'.join(leaf_path)!r} in {source_label} must "
+                    f"be non-negative, got {value}"
+                )
+            if allowed is not None and value not in allowed:
+                raise ValueError(
+                    f"Rank for {'.'.join(leaf_path)!r} in {source_label} must "
+                    f"be one of {sorted(allowed)}, got {value}"
+                )
+
+    if not isinstance(rank_spec, dict):
+        raise TypeError(
+            f"{source_label} must be a dict, got {type(rank_spec).__name__}"
+        )
+    _validate(rank_spec, ())
 
 
 def rank_counts(rank_spec: RankSpecDict) -> Counter[int]:
@@ -119,6 +187,7 @@ def validate_data_contains_ranks(
     ValueError
         If a declared field is missing or has a different rank.
     """
+    validate_rank_spec(declared_ranks, source_label="declared_ranks")
     declared = flatten_rank_spec(declared_ranks)
     actual = flatten_rank_spec(ranks_from_tensordict(data))
 
@@ -141,10 +210,237 @@ def validate_data_contains_ranks(
         )
 
 
+class ScalarVectorFields(NamedTuple):
+    r"""Dense scalar and vector channels for a collection of points.
+
+    ``scalars`` has shape ``(N, C_s)`` and ``vectors`` has shape
+    ``(N, C_v, D)``. The :class:`FieldLayout` that produced them defines
+    ``C_s``, ``C_v``, and ``D``.
+    """
+
+    scalars: torch.Tensor
+    vectors: torch.Tensor
+
+
+def _rank_entries(
+    rank_spec: RankSpecDict,
+    path: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], int]]:
+    """Return rank leaves as ``(key_path, rank)`` pairs."""
+    entries: list[tuple[tuple[str, ...], int]] = []
+    for key, value in rank_spec.items():
+        leaf_path = (*path, key)
+        if isinstance(value, dict):
+            entries.extend(_rank_entries(value, leaf_path))
+        else:
+            entries.append((leaf_path, value))
+    return entries
+
+
+class FieldLayout:
+    r"""Deterministic packing layout for named scalar and vector fields.
+
+    Channel order is lexicographic by the flattened field name and therefore
+    does not depend on dictionary or TensorDict construction order. Scalars
+    and vectors are packed into separate tensors so that code which must
+    respect their different transformation laws cannot accidentally mix them.
+
+    Parameters
+    ----------
+    rank_spec : RankSpecDict
+        Nested or flat field schema. Only rank-0 and rank-1 leaves are
+        supported.
+    spatial_dim : int
+        Cartesian vector dimension ``D``.
+    sep : str, default="."
+        Separator used to build the flattened names in ``scalar_names``,
+        ``vector_names``, and ``flat_rank_spec``.
+
+    Notes
+    -----
+    Each rank-0 leaf must have shape ``(N,)`` and each rank-1 leaf must have
+    shape ``(N, D)``. Multiple channels must be represented by multiple named
+    leaves rather than an extra unnamed feature dimension.
+
+    Examples
+    --------
+    >>> layout = FieldLayout({"velocity": 1, "pressure": 0}, spatial_dim=3)
+    >>> layout.scalar_names, layout.vector_names
+    (('pressure',), ('velocity',))
+    >>> data = TensorDict(
+    ...     {"pressure": torch.zeros(5), "velocity": torch.zeros(5, 3)},
+    ...     batch_size=[5],
+    ... )
+    >>> packed = layout.pack(data)
+    >>> packed.scalars.shape, packed.vectors.shape
+    (torch.Size([5, 1]), torch.Size([5, 1, 3]))
+    >>> sorted(layout.unpack(packed).keys())
+    ['pressure', 'velocity']
+    """
+
+    def __init__(
+        self,
+        rank_spec: RankSpecDict,
+        spatial_dim: int,
+        *,
+        sep: str = ".",
+    ) -> None:
+        validate_rank_spec(rank_spec, allowed_ranks=(0, 1))
+        if not isinstance(spatial_dim, int) or spatial_dim < 1:
+            raise ValueError(
+                f"spatial_dim must be a positive integer, got {spatial_dim!r}"
+            )
+
+        entries = [
+            (sep.join(path), path, rank) for path, rank in _rank_entries(rank_spec)
+        ]
+        if not entries:
+            raise ValueError("rank_spec must contain at least one field leaf")
+
+        # A literal key containing ``sep`` can collide with a nested path once
+        # flattened, which would make the channel order ambiguous.
+        names = [name for name, _, _ in entries]
+        if len(names) != len(set(names)):
+            raise ValueError(
+                f"rank_spec contains field paths that collide when flattened "
+                f"with separator {sep!r}"
+            )
+
+        entries.sort(key=lambda entry: entry[0])
+        self._rank_spec = deepcopy(rank_spec)
+        self.spatial_dim = spatial_dim
+        self.sep = sep
+        self._entries = tuple(entries)
+        self._scalar_entries = tuple(entry for entry in entries if entry[2] == 0)
+        self._vector_entries = tuple(entry for entry in entries if entry[2] == 1)
+
+    @property
+    def rank_spec(self) -> RankSpecDict:
+        """A copy of the named-field schema."""
+        return deepcopy(self._rank_spec)
+
+    @property
+    def flat_rank_spec(self) -> dict[str, int]:
+        """Field ranks keyed by flattened name, in packed order."""
+        return {name: rank for name, _, rank in self._entries}
+
+    @property
+    def scalar_names(self) -> tuple[str, ...]:
+        """Flattened names of scalar channels in packed order."""
+        return tuple(name for name, _, _ in self._scalar_entries)
+
+    @property
+    def vector_names(self) -> tuple[str, ...]:
+        """Flattened names of vector channels in packed order."""
+        return tuple(name for name, _, _ in self._vector_entries)
+
+    @property
+    def n_scalars(self) -> int:
+        """Number of packed scalar channels."""
+        return len(self._scalar_entries)
+
+    @property
+    def n_vectors(self) -> int:
+        """Number of packed vector channels."""
+        return len(self._vector_entries)
+
+    def pack(self, data: TensorDict) -> ScalarVectorFields:
+        r"""Pack named point fields into scalar and vector channel tensors.
+
+        ``data`` must have batch size ``(N,)``. Leaves not named in the layout
+        are ignored. All selected leaves must share dtype and device and have
+        the shapes described in the class docstring.
+        """
+        if data.batch_dims != 1:
+            raise ValueError(
+                "FieldLayout expects a point TensorDict with one batch dimension "
+                f"(N,), got batch_size={tuple(data.batch_size)}"
+            )
+        validate_data_contains_ranks(
+            data=data,
+            declared_ranks=self._rank_spec,
+            source_label="data",
+        )
+
+        n_points = data.batch_size[0]
+        tensors = [cast(torch.Tensor, data[path]) for _, path, _ in self._entries]
+        reference = tensors[0]
+        for (name, _, rank), tensor in zip(self._entries, tensors, strict=True):
+            expected = (n_points,) if rank == 0 else (n_points, self.spatial_dim)
+            if tuple(tensor.shape) != expected:
+                kind = "scalar" if rank == 0 else "vector"
+                raise ValueError(
+                    f"Field {name!r} is declared as a {kind} and must have "
+                    f"shape {expected}, got {tuple(tensor.shape)}"
+                )
+            if tensor.device != reference.device:
+                raise ValueError(
+                    f"All packed fields must share a device; field {name!r} is "
+                    f"on {tensor.device}, expected {reference.device}"
+                )
+            if tensor.dtype != reference.dtype:
+                raise ValueError(
+                    f"All packed fields must share a dtype; field {name!r} has "
+                    f"{tensor.dtype}, expected {reference.dtype}"
+                )
+
+        scalar_tensors = [
+            tensor
+            for (_, _, rank), tensor in zip(self._entries, tensors, strict=True)
+            if rank == 0
+        ]
+        vector_tensors = [
+            tensor
+            for (_, _, rank), tensor in zip(self._entries, tensors, strict=True)
+            if rank == 1
+        ]
+        scalars = (
+            torch.stack(scalar_tensors, dim=-1)
+            if scalar_tensors
+            else reference.new_empty((n_points, 0))
+        )
+        vectors = (
+            torch.stack(vector_tensors, dim=-2)
+            if vector_tensors
+            else reference.new_empty((n_points, 0, self.spatial_dim))
+        )
+        return ScalarVectorFields(scalars=scalars, vectors=vectors)
+
+    def unpack(self, fields: ScalarVectorFields) -> TensorDict:
+        r"""Unpack scalar and vector channels into a TensorDict matching ``rank_spec``."""
+        scalars, vectors = fields
+        if scalars.ndim != 2 or scalars.shape[1] != self.n_scalars:
+            raise ValueError(
+                f"scalars must have shape (N, {self.n_scalars}), got "
+                f"{tuple(scalars.shape)}"
+            )
+        n_points = scalars.shape[0]
+        expected_vectors = (n_points, self.n_vectors, self.spatial_dim)
+        if tuple(vectors.shape) != expected_vectors:
+            raise ValueError(
+                f"vectors must have shape {expected_vectors}, got "
+                f"{tuple(vectors.shape)}"
+            )
+        if vectors.device != scalars.device:
+            raise ValueError("scalars and vectors must be on the same device")
+        if vectors.dtype != scalars.dtype:
+            raise ValueError("scalars and vectors must have the same dtype")
+
+        out = TensorDict({}, batch_size=[n_points], device=scalars.device)
+        for index, (_, path, _) in enumerate(self._scalar_entries):
+            out[path] = scalars[:, index]
+        for index, (_, path, _) in enumerate(self._vector_entries):
+            out[path] = vectors[:, index, :]
+        return out
+
+
 __all__ = [
+    "FieldLayout",
     "RankSpecDict",
+    "ScalarVectorFields",
     "flatten_rank_spec",
     "rank_counts",
     "ranks_from_tensordict",
     "validate_data_contains_ranks",
+    "validate_rank_spec",
 ]

--- a/physicsnemo/mesh/fields.py
+++ b/physicsnemo/mesh/fields.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Collection
 from copy import deepcopy
-from typing import NamedTuple, TypeAlias, Union, cast
+from typing import NamedTuple, TypeAlias, Union
 
 import torch
 from tensordict import TensorDict
@@ -356,14 +356,18 @@ class FieldLayout:
                 "FieldLayout expects a point TensorDict with one batch dimension "
                 f"(N,), got batch_size={tuple(data.batch_size)}"
             )
-        validate_data_contains_ranks(
-            data=data,
-            declared_ranks=self._rank_spec,
-            source_label="data",
-        )
-
         n_points = data.batch_size[0]
-        tensors = [cast(torch.Tensor, data[path]) for _, path, _ in self._entries]
+        tensors: list[torch.Tensor] = []
+        for name, path, rank in self._entries:
+            tensor = data.get(path, None)
+            if tensor is None:
+                raise ValueError(
+                    f"data is missing leaf {name!r} (declared rank {rank})"
+                )
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(f"Field {name!r} must be a tensor")
+            tensors.append(tensor)
+
         reference = tensors[0]
         for (name, _, rank), tensor in zip(self._entries, tensors, strict=True):
             expected = (n_points,) if rank == 0 else (n_points, self.spatial_dim)

--- a/test/mesh/test_fields.py
+++ b/test/mesh/test_fields.py
@@ -19,16 +19,20 @@ import torch
 from tensordict import TensorDict
 
 from physicsnemo.mesh import (
+    FieldLayout,
+    ScalarVectorFields,
     flatten_rank_spec,
     rank_counts,
     ranks_from_tensordict,
     validate_data_contains_ranks,
+    validate_rank_spec,
 )
 
 
 def _mixed_fields(n: int = 4) -> TensorDict:
     return TensorDict(
         {
+            # Deliberately not in lexicographic order.
             "wind": torch.arange(n * 3, dtype=torch.float32).reshape(n, 3),
             "state": {"temperature": torch.arange(n, dtype=torch.float32) + 20},
             "displacement": -torch.arange(n * 3, dtype=torch.float32).reshape(n, 3),
@@ -69,3 +73,162 @@ def test_validate_data_contains_ranks_reports_schema_errors():
         "  - missing leaf 'velocity' (declared rank 1)\n"
         "  - rank mismatch for 'pressure': declared 0, got 1"
     )
+
+
+def test_validate_rank_spec():
+    validate_rank_spec({"scalar": 0, "nested": {"tensor": 2}})
+    with pytest.raises(ValueError, match="'nested.tensor'.*must be one of .* got 2"):
+        validate_rank_spec({"nested": {"tensor": 2}}, allowed_ranks=(0, 1))
+    with pytest.raises(TypeError, match="must be an integer"):
+        validate_rank_spec({"bad": True})
+    with pytest.raises(ValueError, match="must be non-negative"):
+        validate_rank_spec({"bad": -1})
+    with pytest.raises(TypeError, match="must be strings"):
+        validate_rank_spec({1: 0})
+    with pytest.raises(TypeError, match="must be a dict"):
+        validate_rank_spec([("pressure", 0)])
+
+
+def test_field_layout_pack_is_deterministic_and_round_trips():
+    ranks = {
+        "wind": 1,
+        "state": {"temperature": 0},
+        "pressure": 0,
+        "displacement": 1,
+    }
+    reordered_ranks = {
+        "pressure": 0,
+        "displacement": 1,
+        "state": {"temperature": 0},
+        "wind": 1,
+    }
+    data = _mixed_fields()
+    layout = FieldLayout(ranks, spatial_dim=3)
+    reordered_layout = FieldLayout(reordered_ranks, spatial_dim=3)
+
+    assert layout.scalar_names == ("pressure", "state.temperature")
+    assert layout.vector_names == ("displacement", "wind")
+    assert (layout.n_scalars, layout.n_vectors) == (2, 2)
+    assert layout.flat_rank_spec == {
+        "displacement": 1,
+        "pressure": 0,
+        "state.temperature": 0,
+        "wind": 1,
+    }
+    assert layout.rank_spec == ranks
+    assert layout.rank_spec is not layout.rank_spec
+
+    packed = layout.pack(data)
+    reordered = reordered_layout.pack(data)
+    torch.testing.assert_close(packed.scalars, reordered.scalars)
+    torch.testing.assert_close(packed.vectors, reordered.vectors)
+    torch.testing.assert_close(
+        packed.scalars,
+        torch.stack((data["pressure"], data["state", "temperature"]), dim=-1),
+    )
+    torch.testing.assert_close(
+        packed.vectors,
+        torch.stack((data["displacement"], data["wind"]), dim=-2),
+    )
+
+    unpacked = layout.unpack(packed)
+    assert set(unpacked.keys()) == {"displacement", "pressure", "state", "wind"}
+    for key in ("pressure", ("state", "temperature"), "displacement", "wind"):
+        torch.testing.assert_close(unpacked[key], data[key])
+
+
+def test_field_layout_vectors_rotate_with_the_frame():
+    data = _mixed_fields()
+    layout = FieldLayout(
+        {"pressure": 0, "wind": 1, "displacement": 1},
+        spatial_dim=3,
+    )
+    packed = layout.pack(data)
+    rotation = torch.tensor([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    rotated_data = data.clone()
+    rotated_data["wind"] = data["wind"] @ rotation.T
+    rotated_data["displacement"] = data["displacement"] @ rotation.T
+    rotated = layout.pack(rotated_data)
+
+    torch.testing.assert_close(rotated.scalars, packed.scalars)
+    torch.testing.assert_close(rotated.vectors, packed.vectors @ rotation.T)
+
+
+@pytest.mark.parametrize(
+    ("ranks", "expected_scalar_shape", "expected_vector_shape"),
+    [
+        ({"pressure": 0}, (4, 1), (4, 0, 3)),
+        ({"wind": 1}, (4, 0), (4, 1, 3)),
+    ],
+)
+def test_field_layout_supports_scalar_or_vector_only(
+    ranks, expected_scalar_shape, expected_vector_shape
+):
+    layout = FieldLayout(ranks, spatial_dim=3)
+    packed = layout.pack(_mixed_fields())
+    assert packed.scalars.shape == expected_scalar_shape
+    assert packed.vectors.shape == expected_vector_shape
+    round_trip = layout.pack(layout.unpack(packed))
+    torch.testing.assert_close(round_trip.scalars, packed.scalars)
+    torch.testing.assert_close(round_trip.vectors, packed.vectors)
+
+
+def test_field_layout_rejects_invalid_layouts():
+    with pytest.raises(ValueError, match="must be one of .* got 2"):
+        FieldLayout({"stress": 2}, spatial_dim=3)
+    with pytest.raises(ValueError, match="spatial_dim must be a positive integer"):
+        FieldLayout({"pressure": 0}, spatial_dim=0)
+    with pytest.raises(ValueError, match="at least one field leaf"):
+        FieldLayout({}, spatial_dim=3)
+    with pytest.raises(ValueError, match="collide when flattened"):
+        FieldLayout({"a.b": 0, "a": {"b": 0}}, spatial_dim=3)
+
+
+def test_field_layout_pack_validates_data():
+    layout = FieldLayout({"pressure": 0, "velocity": 1}, spatial_dim=3)
+
+    batched = TensorDict(
+        {"pressure": torch.zeros(2, 5), "velocity": torch.zeros(2, 5, 3)},
+        batch_size=[2, 5],
+    )
+    with pytest.raises(ValueError, match="one batch dimension"):
+        layout.pack(batched)
+
+    missing = TensorDict({"pressure": torch.zeros(5)}, batch_size=[5])
+    with pytest.raises(ValueError, match="missing leaf 'velocity'"):
+        layout.pack(missing)
+
+    wrong_dim = TensorDict(
+        {"pressure": torch.zeros(5), "velocity": torch.zeros(5, 2)}, batch_size=[5]
+    )
+    with pytest.raises(ValueError, match=r"must have shape \(5, 3\)"):
+        layout.pack(wrong_dim)
+
+    mixed_dtype = TensorDict(
+        {
+            "pressure": torch.zeros(5, dtype=torch.float64),
+            "velocity": torch.zeros(5, 3, dtype=torch.float32),
+        },
+        batch_size=[5],
+    )
+    with pytest.raises(ValueError, match="must share a dtype"):
+        layout.pack(mixed_dtype)
+
+
+def test_field_layout_unpack_validates_packed_shapes_and_dtype():
+    layout = FieldLayout({"pressure": 0, "velocity": 1}, spatial_dim=3)
+    with pytest.raises(ValueError, match=r"scalars must have shape \(N, 1\)"):
+        layout.unpack(
+            ScalarVectorFields(scalars=torch.empty(5, 2), vectors=torch.empty(5, 1, 3))
+        )
+    with pytest.raises(ValueError, match="vectors must have shape"):
+        layout.unpack(
+            ScalarVectorFields(scalars=torch.empty(5, 1), vectors=torch.empty(4, 1, 3))
+        )
+    with pytest.raises(ValueError, match="must have the same dtype"):
+        layout.unpack(
+            ScalarVectorFields(
+                scalars=torch.empty(5, 1, dtype=torch.float32),
+                vectors=torch.empty(5, 1, 3, dtype=torch.float64),
+            )
+        )

--- a/test/mesh/test_fields.py
+++ b/test/mesh/test_fields.py
@@ -154,6 +154,52 @@ def test_field_layout_vectors_rotate_with_the_frame():
     torch.testing.assert_close(rotated.vectors, packed.vectors @ rotation.T)
 
 
+def test_field_layout_ignores_unselected_metadata_and_colliding_names():
+    """Unselected leaves cannot override a selected tuple path's validation."""
+    layout = FieldLayout({"a": {"b": 0}}, spatial_dim=3)
+    data = TensorDict(
+        {
+            "a": {"b": torch.arange(4, dtype=torch.float32)},
+            "a.b": torch.ones(4, 3),
+            "case": "metadata",
+        },
+        batch_size=[4],
+    )
+
+    packed = layout.pack(data)
+
+    torch.testing.assert_close(packed.scalars[:, 0], data["a", "b"])
+    assert packed.vectors.shape == (4, 0, 3)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_field_layout_custom_separator_preserves_distinct_tuple_paths(reverse):
+    """Literal dots stay distinct from nested paths in either insertion order."""
+    layout = FieldLayout({"a.b": 0, "a": {"b": 1}}, spatial_dim=3, sep="/")
+    entries = [
+        ("a.b", torch.arange(4, dtype=torch.float32)),
+        ("a", {"b": torch.ones(4, 3)}),
+    ]
+    if reverse:
+        entries.reverse()
+    data = TensorDict(dict(entries), batch_size=[4])
+
+    packed = layout.pack(data)
+    unpacked = layout.unpack(packed)
+
+    assert layout.scalar_names == ("a.b",)
+    assert layout.vector_names == ("a/b",)
+    torch.testing.assert_close(unpacked["a.b"], data["a.b"])
+    torch.testing.assert_close(unpacked["a", "b"], data["a", "b"])
+
+
+def test_field_layout_rejects_selected_nontensor_leaf():
+    """A selected metadata leaf gets a field-specific error."""
+    data = TensorDict({"case": "metadata"}, batch_size=[4])
+    with pytest.raises(TypeError, match="Field 'case' must be a tensor"):
+        FieldLayout({"case": 0}, spatial_dim=3).pack(data)
+
+
 @pytest.mark.parametrize(
     ("ranks", "expected_scalar_shape", "expected_vector_shape"),
     [


### PR DESCRIPTION
## Description

Add `FieldLayout(rank_spec, spatial_dim)` to pack named scalar and Cartesian-vector fields from a point `TensorDict` into separate channel tensors and unpack them into their named hierarchy. Channel order is sorted by flattened name, independent of dictionary insertion order. Scalars have shape `(N, C_s)` and vectors `(N, C_v, D)`.

Packing validates only the selected tuple paths. Unselected tensors or metadata cannot interfere with validation, and literal separators remain distinct from nested paths when the configured flattened names do not collide. Selected leaves must have the declared scalar/vector shape and share dtype/device. `ScalarVectorFields` represents the packed pair; layout properties expose channel names, counts and rank schemas.

The new `validate_rank_spec` validates schema keys and non-negative integer ranks. `validate_data_contains_ranks` now rejects malformed schemas up front; valid existing GLOBE schemas retain their behavior. New public symbols are exported from `physicsnemo.mesh`.

## Validation

- 18 tests passed across `test/mesh/test_fields.py` and `test/models/globe/test_validation.py`.
- Regression coverage includes ignored metadata, unrelated literal-dot keys, custom separators with reversed input insertion order, and selected non-tensor leaves.
- All changed-file pre-commit hooks passed, including import-linter.
- Local validation used Python 3.14, PyTorch 2.12 and TensorDict 0.14.
