### PR TITLE
Unified aero recipe: coordinate step failures and restore scheduler/scaler state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Unified external aerodynamics recipe: a data-loading or forward-pass
-  failure on one rank now fails every rank together instead of leaving the
-  others hanging in the next collective until the NCCL timeout; an optional
-  `training.divergence_loss_threshold` aborts on non-finite or exploding
-  losses; the epoch-mode scheduler is stepped before the checkpoint is
-  written so a resumed run matches a continuous one (older checkpoints are
-  migrated on load); fp16 `GradScaler` state is checkpointed; the final
-  epoch is always checkpointed.
+- Unified external aerodynamics recipe: synchronizes data-loading failures
+  before DDP forward and forward/loss failures before backward; failures
+  inside model collectives or backward still rely on the process-group
+  timeout. An optional `training.divergence_loss_threshold` aborts on
+  non-finite or exploding losses. Epoch schedulers advance before saving,
+  legacy scheduler state is migrated, fp16 `GradScaler` state is persisted,
+  and the final epoch is always checkpointed. Resume metadata reports
+  scheduler/scaler restoration; exact trajectory continuation is unverified
+  because RNG and stochastic data state are not restored.
 - Datapipe transforms, collators, readers, and the unified external aero
   recipe no longer silently skip or mis-handle nested `TensorDict` fields
   (membership was tested against top-level `td.keys()`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unified external aerodynamics recipe: a data-loading or forward-pass
+  failure on one rank now fails every rank together instead of leaving the
+  others hanging in the next collective until the NCCL timeout; an optional
+  `training.divergence_loss_threshold` aborts on non-finite or exploding
+  losses; the epoch-mode scheduler is stepped before the checkpoint is
+  written so a resumed run matches a continuous one (older checkpoints are
+  migrated on load); fp16 `GradScaler` state is checkpointed; the final
+  epoch is always checkpointed.
 - Datapipe transforms, collators, readers, and the unified external aero
   recipe no longer silently skip or mis-handle nested `TensorDict` fields
   (membership was tested against top-level `td.keys()`, and

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
@@ -36,6 +36,12 @@ training:
   loss_type: "huber"
   batch_size: 1
   scheduler_update_mode: "epoch"
+  # Every step already passes a rank-synchronized failure barrier before
+  # backward (any rank's data/forward exception fails all ranks loudly
+  # instead of hanging the collective). Set a positive value here to also
+  # treat a non-finite loss, or a finite loss above the value, as a step
+  # failure (adds one host sync per step for the loss read).
+  divergence_loss_threshold: null
   optimizer:
     weight_decay: 1.0e-4
     betas: [0.9, 0.999]

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/conf/base.yaml
@@ -36,11 +36,11 @@ training:
   loss_type: "huber"
   batch_size: 1
   scheduler_update_mode: "epoch"
-  # Every step already passes a rank-synchronized failure barrier before
-  # backward (any rank's data/forward exception fails all ranks loudly
-  # instead of hanging the collective). Set a positive value here to also
-  # treat a non-finite loss, or a finite loss above the value, as a step
-  # failure (adds one host sync per step for the loss read).
+  # Each step synchronizes loading/transfer errors before DDP forward and
+  # forward/loss errors before backward. Failures inside model collectives
+  # or backward still rely on the process-group timeout. Set a positive
+  # value to also reject non-finite losses or losses above this value
+  # (adds one host sync per step for the loss read).
   divergence_loss_threshold: null
   optimizer:
     weight_decay: 1.0e-4

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/train.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/train.py
@@ -33,6 +33,7 @@ Usage::
     python src/train.py benchmark_io=true +training.benchmark_max_steps=20
 """
 
+import math
 import os
 import time
 from collections.abc import Callable, Iterator, Mapping
@@ -76,6 +77,12 @@ from physicsnemo.utils.profiling import Profiler, profile
 ### batch loop after this many steps. Keeps profiling traces short enough
 ### to be useful without changing the rest of the training contract.
 _PROFILE_MAX_STEPS = 10
+
+### Key under which the recipe stores its own block in the checkpoint
+### ``metadata`` dict. Its presence marks a checkpoint as written after the
+### scheduler-ordering fix in ``_finish_epoch`` (see
+### ``_reconcile_loaded_checkpoint``).
+_CHECKPOINT_METADATA_KEY = "unified_external_aero_recipe"
 
 
 ### ---------------------------------------------------------------------------
@@ -277,6 +284,187 @@ def forward_pass(
 ### ---------------------------------------------------------------------------
 
 
+def _raise_if_divergent_loss(
+    loss: Float[torch.Tensor, ""],
+    *,
+    mode: Literal["train", "val"],
+    epoch: int,
+    step: int,
+    threshold: float | None,
+) -> None:
+    """Raise locally when this rank's loss is non-finite or above *threshold*.
+
+    Purely rank-local (one device-to-host sync, no collective): cross-rank
+    synchronization of the failure is the job of
+    :func:`_step_failure_barrier`, which every step passes through before
+    backward.  Invoked only when ``training.divergence_loss_threshold`` is
+    configured.
+    """
+    local_loss = loss.detach().item()
+    if not math.isfinite(local_loss):
+        reason = "non-finite"
+    elif threshold is not None and local_loss > threshold:
+        reason = f"above {threshold:g}"
+    else:
+        return
+    raise RuntimeError(
+        f"{mode} loss guard triggered at epoch {epoch}, step {step}: "
+        f"local loss {local_loss!r} is {reason}"
+    )
+
+
+def _step_failure_barrier(
+    step_error: BaseException | None,
+    *,
+    mode: Literal["train", "val"],
+    epoch: int,
+    step: int,
+    dist_manager: DistributedManager,
+) -> None:
+    """Fail every rank together when any rank's step failed.
+
+    A rank that raises anywhere between two collectives (data loading, a
+    transform, forward, a validation check in the model) would otherwise
+    exit alone while its peers block in the next allreduce until the
+    process-group timeout fires (10 minutes by default for NCCL), with no
+    hint of which rank failed or why.  Every step therefore all-reduces a
+    failure flag at one fixed point before backward: the failing rank
+    re-raises its real exception, and healthy peers raise a "peer rank
+    failed" error instead of hanging.  Cost is one tiny collective plus a
+    host read per step, alongside the logging reduce the loop already
+    pays.  Residual exposure: a rank whose CUDA context is already dead
+    may fail inside this barrier itself; the process-group timeout is the
+    backstop for that case.
+    """
+    if dist_manager.world_size > 1:
+        flag = torch.tensor(
+            0 if step_error is None else 1,
+            dtype=torch.int32,
+            device=dist_manager.device,
+        )
+        dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+        if not bool(flag.item()):
+            return
+        if step_error is None:
+            raise RuntimeError(
+                f"a peer rank failed during {mode} epoch {epoch}, step {step}; "
+                "failing together instead of hanging in the next collective"
+            )
+    if step_error is not None:
+        raise RuntimeError(
+            f"{mode} step failed at epoch {epoch}, step {step} on this rank; "
+            "all ranks are stopping together"
+        ) from step_error
+
+
+def _finish_epoch(
+    *,
+    epoch: int,
+    num_epochs: int,
+    cfg: DictConfig,
+    scheduler: torch.optim.lr_scheduler.LRScheduler,
+    ckpt_args: dict[str, Any],
+    normalizer: Any | None,
+    is_rank0: bool,
+) -> bool:
+    """Advance epoch state and save periodic or terminal checkpoints.
+
+    The checkpoint index is the number of completed epochs, which is also the
+    next epoch index consumed by ``range(loaded_epoch, num_epochs)`` on resume.
+    Epoch-based schedulers advance first so the persisted state is exactly the
+    state used by the resumed epoch.  The final epoch is always saved; one
+    combined condition prevents a duplicate save when it is also periodic.
+    """
+    if cfg.training.get("scheduler_update_mode", "epoch") == "epoch":
+        scheduler.step()
+
+    is_periodic = epoch % cfg.training.save_interval == 0
+    is_terminal = epoch + 1 == num_epochs
+    if not is_rank0 or not (is_periodic or is_terminal):
+        return False
+
+    completed_epochs = epoch + 1
+    ### The one fact resume needs: whether fp16 GradScaler state was
+    ### persisted.  The metadata block's presence also marks the checkpoint
+    ### as post-dating the scheduler-ordering fix (see
+    ### ``_reconcile_loaded_checkpoint``).
+    checkpoint_metadata = {
+        _CHECKPOINT_METADATA_KEY: {
+            "scaler_state_saved": ckpt_args.get("scaler") is not None,
+        }
+    }
+    save_checkpoint(
+        **ckpt_args,
+        epoch=completed_epochs,
+        metadata=checkpoint_metadata,
+    )
+    if normalizer is not None:
+        norm_path = os.path.join(ckpt_args["path"], "norm_stats.pt")
+        torch.save(normalizer.stats, norm_path)
+    return True
+
+
+def _reconcile_loaded_checkpoint(
+    *,
+    loaded_epoch: int,
+    metadata: dict[str, Any],
+    scheduler: torch.optim.lr_scheduler.LRScheduler,
+    scheduler_update_mode: str,
+    scaler: GradScaler | None,
+    logger: Any,
+) -> dict[str, Any]:
+    """Migrate legacy recipe checkpoint state and report resume fidelity.
+
+    Checkpoints written before the recipe metadata block existed stored an
+    epoch-mode scheduler before its end-of-epoch ``step()``.  Their epoch
+    value already meant "completed epochs", so advancing the restored
+    scheduler once recovers the state that continuous training would have
+    used next.  Those checkpoints did not save the fp16 ``GradScaler`` at
+    all; that state is not reconstructable and is reported as a non-exact
+    resume instead of being silently reset.
+    """
+    report: dict[str, Any] = {
+        "loaded_epoch": loaded_epoch,
+        "legacy_checkpoint": False,
+        "legacy_scheduler_step_applied": False,
+        "resume_exact": True,
+    }
+    if loaded_epoch == 0:
+        report["checkpoint_found"] = False
+        return report
+
+    report["checkpoint_found"] = True
+    recipe_metadata = metadata.get(_CHECKPOINT_METADATA_KEY)
+    if recipe_metadata is not None:
+        if scaler is not None and not recipe_metadata.get("scaler_state_saved", False):
+            report["resume_exact"] = False
+            report["non_exact_reason"] = "checkpoint declared no fp16 scaler state"
+            logger.warning(
+                "Checkpoint declares that fp16 GradScaler state was not saved; "
+                "resume is not numerically equivalent to a continuous run."
+            )
+        return report
+
+    report["legacy_checkpoint"] = True
+    if scheduler_update_mode == "epoch":
+        scheduler.step()
+        report["legacy_scheduler_step_applied"] = True
+        logger.warning(
+            "Migrated an unversioned legacy checkpoint by advancing the "
+            "epoch-mode scheduler once: historical recipe checkpoints were "
+            "saved before their end-of-epoch scheduler step."
+        )
+    if scaler is not None:
+        report["resume_exact"] = False
+        report["non_exact_reason"] = "legacy checkpoint has no recoverable scaler state"
+        logger.warning(
+            "Unversioned legacy fp16 checkpoints did not persist GradScaler "
+            "state. The model/optimizer/scheduler resume was loaded, but the "
+            "training trajectory is explicitly non-exact."
+        )
+    return report
+
+
 def _run_epoch(
     dataloader: DataLoader,
     model: torch.nn.Module,
@@ -339,22 +527,56 @@ def _run_epoch(
     total_losses_td: TensorDict | None = None
     total_metrics_td: TensorDict | None = None
     precision = getattr(cfg, "precision", "float32")
+    divergence_loss_threshold = cfg.training.get("divergence_loss_threshold", None)
+    if divergence_loss_threshold is not None:
+        divergence_loss_threshold = float(divergence_loss_threshold)
+        if (
+            not math.isfinite(divergence_loss_threshold)
+            or divergence_loss_threshold <= 0
+        ):
+            raise ValueError("training.divergence_loss_threshold must be positive")
     n_local = 0
     num_steps = len(dataloader)
     epoch_t0 = time.perf_counter()
     with grad_ctx:
         step_t0 = time.perf_counter()
-        for i, batch in enumerate(dataloader):
-            batch = recursive_to_device(batch, dist_manager.device)
+        ### Manual iteration so the loader's own __next__ (which re-raises
+        ### per-sample transform/reader failures) sits inside the step's
+        ### failure barrier along with the forward pass. Per-rank step
+        ### counts are equal by sampler construction, so every rank runs
+        ### the same number of barrier collectives.
+        iterator = iter(dataloader)
+        for i in range(num_steps):
+            step_error: BaseException | None = None
+            try:
+                batch = next(iterator)
+                batch = recursive_to_device(batch, dist_manager.device)
 
-            loss, losses, metrics = forward_pass(
-                batch,
-                model,
-                precision,
-                loss_calculator,
-                metric_calculator,
-                output_type=output_type,
-                target_config=target_config,
+                loss, losses, metrics = forward_pass(
+                    batch,
+                    model,
+                    precision,
+                    loss_calculator,
+                    metric_calculator,
+                    output_type=output_type,
+                    target_config=target_config,
+                )
+
+                if divergence_loss_threshold is not None:
+                    _raise_if_divergent_loss(
+                        loss,
+                        mode=mode,
+                        epoch=epoch,
+                        step=i,
+                        threshold=divergence_loss_threshold,
+                    )
+            except Exception as err:  # noqa: BLE001 -- barrier re-raises
+                step_error = err
+                logger.error(
+                    f"{mode} step {i} (epoch {epoch}) failed on this rank: {err!r}"
+                )
+            _step_failure_barrier(
+                step_error, mode=mode, epoch=epoch, step=i, dist_manager=dist_manager
             )
 
             if is_train:
@@ -903,9 +1125,25 @@ def main(cfg: DictConfig) -> None:
         "path": os.path.join(checkpoint_dir, cfg.run_id, "checkpoints"),
         "optimizer": optimizer,
         "scheduler": scheduler,
+        "scaler": scaler,
         "models": model,
     }
-    loaded_epoch = load_checkpoint(device=device, **ckpt_args)
+    checkpoint_metadata: dict[str, Any] = {}
+    loaded_epoch = load_checkpoint(
+        device=device,
+        metadata_dict=checkpoint_metadata,
+        **ckpt_args,
+    )
+    resume_report = _reconcile_loaded_checkpoint(
+        loaded_epoch=loaded_epoch,
+        metadata=checkpoint_metadata,
+        scheduler=scheduler,
+        scheduler_update_mode=cfg.training.get("scheduler_update_mode", "epoch"),
+        scaler=scaler,
+        logger=logger,
+    )
+    if is_rank0 and log_jsonl is not None:
+        log_jsonl({"phase": "checkpoint_resume", **resume_report})
 
     if cfg.compile:
         model = torch.compile(model)
@@ -973,14 +1211,15 @@ def main(cfg: DictConfig) -> None:
                     f"{table}\n"
                 )
 
-            if epoch % cfg.training.save_interval == 0 and is_rank0:
-                save_checkpoint(**ckpt_args, epoch=epoch + 1)
-                if normalizer is not None:
-                    norm_path = os.path.join(ckpt_args["path"], "norm_stats.pt")
-                    torch.save(normalizer.stats, norm_path)
-
-            if cfg.training.get("scheduler_update_mode", "epoch") == "epoch":
-                scheduler.step()
+            _finish_epoch(
+                epoch=epoch,
+                num_epochs=num_epochs,
+                cfg=cfg,
+                scheduler=scheduler,
+                ckpt_args=ckpt_args,
+                normalizer=normalizer,
+                is_rank0=is_rank0,
+            )
 
     if is_rank0:
         if train_writer is not None:

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/train.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/train.py
@@ -320,21 +320,20 @@ def _step_failure_barrier(
     epoch: int,
     step: int,
     dist_manager: DistributedManager,
+    phase: str = "step",
 ) -> None:
-    """Fail every rank together when any rank's step failed.
+    """Fail every rank together at a shared boundary between collectives.
 
-    A rank that raises anywhere between two collectives (data loading, a
-    transform, forward, a validation check in the model) would otherwise
-    exit alone while its peers block in the next allreduce until the
-    process-group timeout fires (10 minutes by default for NCCL), with no
-    hint of which rank failed or why.  Every step therefore all-reduces a
-    failure flag at one fixed point before backward: the failing rank
-    re-raises its real exception, and healthy peers raise a "peer rank
-    failed" error instead of hanging.  Cost is one tiny collective plus a
-    host read per step, alongside the logging reduce the loop already
-    pays.  Residual exposure: a rank whose CUDA context is already dead
-    may fail inside this barrier itself; the process-group timeout is the
-    backstop for that case.
+    Every rank must reach this rendezvous in the same collective order. The
+    epoch loop calls it after loading/transfer, before DDP forward can run
+    buffer broadcasts or rebuild buckets, and again after forward/loss,
+    before backward. A failing rank preserves its original exception and
+    peers raise a coordinated failure. Each rendezvous costs one tiny
+    all-reduce and a host read.
+
+    Errors inside model collectives, backward, or an unusable CUDA context
+    can prevent ranks from reaching the same rendezvous. The process-group
+    timeout remains the backstop for those failures.
     """
     if dist_manager.world_size > 1:
         flag = torch.tensor(
@@ -347,12 +346,14 @@ def _step_failure_barrier(
             return
         if step_error is None:
             raise RuntimeError(
-                f"a peer rank failed during {mode} epoch {epoch}, step {step}; "
+                f"a peer rank failed during {mode} epoch {epoch}, step {step} "
+                f"({phase}); "
                 "failing together instead of hanging in the next collective"
             )
     if step_error is not None:
         raise RuntimeError(
-            f"{mode} step failed at epoch {epoch}, step {step} on this rank; "
+            f"{mode} step failed at epoch {epoch}, step {step} on this rank "
+            f"({phase}); "
             "all ranks are stopping together"
         ) from step_error
 
@@ -384,8 +385,8 @@ def _finish_epoch(
         return False
 
     completed_epochs = epoch + 1
-    ### The one fact resume needs: whether fp16 GradScaler state was
-    ### persisted.  The metadata block's presence also marks the checkpoint
+    ### Record whether fp16 GradScaler state was persisted. RNG and
+    ### stochastic data state are not saved here. The block also marks the checkpoint
     ### as post-dating the scheduler-ordering fix (see
     ### ``_reconcile_loaded_checkpoint``).
     checkpoint_metadata = {
@@ -413,32 +414,40 @@ def _reconcile_loaded_checkpoint(
     scaler: GradScaler | None,
     logger: Any,
 ) -> dict[str, Any]:
-    """Migrate legacy recipe checkpoint state and report resume fidelity.
+    """Migrate legacy state and report scheduler/scaler restoration.
 
     Checkpoints written before the recipe metadata block existed stored an
     epoch-mode scheduler before its end-of-epoch ``step()``.  Their epoch
     value already meant "completed epochs", so advancing the restored
     scheduler once recovers the state that continuous training would have
     used next.  Those checkpoints did not save the fp16 ``GradScaler`` at
-    all; that state is not reconstructable and is reported as a non-exact
-    resume instead of being silently reset.
+    all; that state is not reconstructable and is reported as missing.
+    This only describes scheduler/scaler state. Checkpoints do not restore
+    RNG or stochastic data state, so exact trajectory continuation remains
+    unverified even when both scheduler and scaler are restored.
     """
     report: dict[str, Any] = {
         "loaded_epoch": loaded_epoch,
         "legacy_checkpoint": False,
         "legacy_scheduler_step_applied": False,
-        "resume_exact": True,
+        "scheduler_scaler_state_restored": False,
+        "trajectory_exactness": "not_applicable",
     }
     if loaded_epoch == 0:
         report["checkpoint_found"] = False
         return report
 
     report["checkpoint_found"] = True
+    report["scheduler_scaler_state_restored"] = True
+    report["trajectory_exactness"] = "unverified"
+    report["trajectory_exactness_reason"] = (
+        "RNG and stochastic data state are not saved or restored"
+    )
     recipe_metadata = metadata.get(_CHECKPOINT_METADATA_KEY)
     if recipe_metadata is not None:
         if scaler is not None and not recipe_metadata.get("scaler_state_saved", False):
-            report["resume_exact"] = False
-            report["non_exact_reason"] = "checkpoint declared no fp16 scaler state"
+            report["scheduler_scaler_state_restored"] = False
+            report["missing_state_reason"] = "checkpoint declared no fp16 scaler state"
             logger.warning(
                 "Checkpoint declares that fp16 GradScaler state was not saved; "
                 "resume is not numerically equivalent to a continuous run."
@@ -455,8 +464,10 @@ def _reconcile_loaded_checkpoint(
             "saved before their end-of-epoch scheduler step."
         )
     if scaler is not None:
-        report["resume_exact"] = False
-        report["non_exact_reason"] = "legacy checkpoint has no recoverable scaler state"
+        report["scheduler_scaler_state_restored"] = False
+        report["missing_state_reason"] = (
+            "legacy checkpoint has no recoverable scaler state"
+        )
         logger.warning(
             "Unversioned legacy fp16 checkpoints did not persist GradScaler "
             "state. The model/optimizer/scheduler resume was loaded, but the "
@@ -540,18 +551,33 @@ def _run_epoch(
     epoch_t0 = time.perf_counter()
     with grad_ctx:
         step_t0 = time.perf_counter()
-        ### Manual iteration so the loader's own __next__ (which re-raises
-        ### per-sample transform/reader failures) sits inside the step's
-        ### failure barrier along with the forward pass. Per-rank step
-        ### counts are equal by sampler construction, so every rank runs
-        ### the same number of barrier collectives.
-        iterator = iter(dataloader)
+        ### Samplers provide equal per-rank step counts. Include iterator
+        ### initialization in the loading phase so worker startup failures
+        ### also rendezvous before any healthy rank enters DDP forward.
+        iterator = None
         for i in range(num_steps):
             step_error: BaseException | None = None
             try:
+                if iterator is None:
+                    iterator = iter(dataloader)
                 batch = next(iterator)
                 batch = recursive_to_device(batch, dist_manager.device)
+            except Exception as err:  # noqa: BLE001 -- barrier re-raises
+                step_error = err
+                logger.error(
+                    f"{mode} data loading at step {i} (epoch {epoch}) failed: {err!r}"
+                )
+            _step_failure_barrier(
+                step_error,
+                mode=mode,
+                epoch=epoch,
+                step=i,
+                dist_manager=dist_manager,
+                phase="data loading",
+            )
 
+            step_error = None
+            try:
                 loss, losses, metrics = forward_pass(
                     batch,
                     model,
@@ -576,7 +602,12 @@ def _run_epoch(
                     f"{mode} step {i} (epoch {epoch}) failed on this rank: {err!r}"
                 )
             _step_failure_barrier(
-                step_error, mode=mode, epoch=epoch, step=i, dist_manager=dist_manager
+                step_error,
+                mode=mode,
+                epoch=epoch,
+                step=i,
+                dist_manager=dist_manager,
+                phase="forward/loss",
             )
 
             if is_train:

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_train_helpers.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_train_helpers.py
@@ -34,11 +34,12 @@ handling for:
   single-process path must equal plain ``total_loss / n`` + per-leaf
   ``sum / n`` averaging.
 - :func:`train._step_failure_barrier` / :func:`train._raise_if_divergent_loss`:
-  a failed or divergent step on one rank must surface on every rank before
-  backward instead of hanging the next collective.
+  loading failures rendezvous before DDP forward, and local forward/loss
+  failures rendezvous before backward.
 - :func:`train._finish_epoch` / :func:`train._reconcile_loaded_checkpoint`:
   the epoch-mode scheduler advances before the checkpoint is written, so a
-  resumed run reproduces the continuous one; older checkpoints are migrated.
+  resumed scheduler/scaler state is restored; older checkpoints are migrated.
+  Stochastic trajectory fidelity remains unverified without RNG restoration.
 
 (The analogous tests for the shared, tensorboard-free
 :func:`utils.recursive_to_device` live in ``test_utils.py``, outside
@@ -47,6 +48,7 @@ this module's tensorboard skip guard.)
 
 from __future__ import annotations
 
+from datetime import timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -482,6 +484,97 @@ class TestLossDivergenceGuard:
         assert not called
 
 
+class _TwoStepLoader:
+    """Yield one healthy batch, then optionally fail on a chosen rank."""
+
+    def __init__(self, batch, *, fail):
+        """Store the common batch and this rank's failure switch."""
+        self.batch = batch
+        self.fail = fail
+
+    def __len__(self):
+        """Report equal step counts on both ranks."""
+        return 2
+
+    def __iter__(self):
+        """Fail after one complete step, when DDP may rebuild its buckets."""
+        yield self.batch
+        if self.fail:
+            raise ValueError("corrupt second sample")
+        yield self.batch
+
+
+def _ddp_loading_failure_worker(rank, store_uri, mode, failing_rank):
+    """Exercise the real epoch loop with a rank-local second-load failure."""
+    torch.set_num_threads(1)
+    train.dist.init_process_group(
+        "gloo",
+        init_method=store_uri,
+        rank=rank,
+        world_size=2,
+        timeout=timedelta(seconds=10),
+    )
+    try:
+        base = torch.nn.Linear(2, 1)
+        base.register_buffer("marker", torch.ones(1))
+        model = torch.nn.parallel.DistributedDataParallel(base)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+        batch = {
+            "forward_kwargs": {"input": torch.ones(1, 3, 2)},
+            "targets": TensorDict({"pressure": torch.ones(1, 3)}, batch_size=[1, 3]),
+        }
+        cfg = OmegaConf.create(
+            {
+                "precision": "float32",
+                "profile": False,
+                "training": {"scheduler_update_mode": "epoch"},
+            }
+        )
+        expected = (
+            "step failed at epoch 0, step 1"
+            if rank == failing_rank
+            else "peer rank failed during"
+        )
+        with pytest.raises(RuntimeError, match=expected) as exc:
+            _run_epoch(
+                _TwoStepLoader(batch, fail=rank == failing_rank),
+                model,
+                train.LossCalculator({"pressure": "scalar"}, loss_type="mse"),
+                train.MetricCalculator({"pressure": "scalar"}),
+                SimpleNamespace(info=lambda *a, **k: None, error=lambda *a, **k: None),
+                0,
+                cfg,
+                SimpleNamespace(rank=rank, world_size=2, device=torch.device("cpu")),
+                mode=mode,
+                output_type="tensors",
+                target_config={"pressure": "scalar"},
+                optimizer=optimizer,
+                scheduler=scheduler,
+            )
+        assert "data loading" in str(exc.value)
+        if rank == failing_rank:
+            assert isinstance(exc.value.__cause__, ValueError)
+            assert str(exc.value.__cause__) == "corrupt second sample"
+        else:
+            assert exc.value.__cause__ is None
+    finally:
+        train.dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not torch.distributed.is_gloo_available(), reason="requires Gloo")
+@pytest.mark.parametrize("mode", ["train", "val"])
+@pytest.mark.parametrize("failing_rank", [0, 1])
+def test_ddp_loading_failure_precedes_forward(tmp_path, mode, failing_rank):
+    """Both ranks raise the intended error instead of a mismatched-collective timeout."""
+    torch.multiprocessing.spawn(
+        _ddp_loading_failure_worker,
+        args=((tmp_path / "store").as_uri(), mode, failing_rank),
+        nprocs=2,
+        join=True,
+    )
+
+
 ### ---------------------------------------------------------------------------
 ### Epoch completion / checkpoint ordering
 ### ---------------------------------------------------------------------------
@@ -567,9 +660,9 @@ class TestFinishEpoch:
         )
         assert saved_epochs == [1]
 
-    def test_real_save_resume_matches_continuous_decay_crossing(self, tmp_path):
-        """A checkpoint after the epoch step reproduces one continuous run."""
-
+    @pytest.mark.parametrize("dropout", [0.0, 0.5])
+    def test_real_save_resume_reports_state_fidelity(self, tmp_path, dropout):
+        """Restore scheduler state without promising stochastic trajectory fidelity."""
         features = torch.tensor(
             [[0.5, -1.0], [1.5, 0.25], [-0.75, 0.4]], dtype=torch.float64
         )
@@ -577,7 +670,11 @@ class TestFinishEpoch:
 
         def build_state():
             torch.manual_seed(1701)
-            model = torch.nn.Linear(2, 1, dtype=torch.float64)
+            model = torch.nn.Sequential(
+                torch.nn.Linear(2, 4, dtype=torch.float64),
+                torch.nn.Dropout(dropout),
+                torch.nn.Linear(4, 1, dtype=torch.float64),
+            )
             optimizer = torch.optim.AdamW(
                 model.parameters(), lr=0.03, weight_decay=0.01
             )
@@ -586,62 +683,104 @@ class TestFinishEpoch:
             )
             return model, optimizer, scheduler
 
-        def step_epoch(model, optimizer, scheduler):
+        def step_epoch(model, optimizer, scheduler, epoch, checkpoint_dir=None):
             optimizer.zero_grad()
             loss = (model(features) - targets).square().sum()
             loss.backward()
             optimizer.step()
-            scheduler.step()
+            _finish_epoch(
+                epoch=epoch,
+                num_epochs=3 if checkpoint_dir is not None else 6,
+                cfg=self._cfg(save_interval=1000),
+                scheduler=scheduler,
+                ckpt_args={
+                    "path": checkpoint_dir or tmp_path / "unused",
+                    "models": model,
+                    "optimizer": optimizer,
+                    "scheduler": scheduler,
+                },
+                normalizer=None,
+                is_rank0=checkpoint_dir is not None,
+            )
             return (
                 loss.detach().clone(),
-                model.weight.detach().clone(),
-                model.bias.detach().clone(),
+                torch.nn.utils.parameters_to_vector(model.parameters())
+                .detach()
+                .clone(),
                 optimizer.param_groups[0]["lr"],
             )
 
         continuous_model, continuous_opt, continuous_sched = build_state()
         continuous_history = [
-            step_epoch(continuous_model, continuous_opt, continuous_sched)
-            for _ in range(6)
+            step_epoch(continuous_model, continuous_opt, continuous_sched, epoch)
+            for epoch in range(6)
         ]
 
         first_model, first_opt, first_sched = build_state()
-        resumed_history = [
-            step_epoch(first_model, first_opt, first_sched) for _ in range(3)
-        ]
         checkpoint_dir = tmp_path / "resume"
-        train.save_checkpoint(
-            path=checkpoint_dir,
-            models=first_model,
-            optimizer=first_opt,
-            scheduler=first_sched,
-            epoch=3,
-        )
-
+        resumed_history = [
+            step_epoch(
+                first_model,
+                first_opt,
+                first_sched,
+                epoch,
+                checkpoint_dir if epoch == 2 else None,
+            )
+            for epoch in range(3)
+        ]
         resumed_model, resumed_opt, resumed_sched = build_state()
+        metadata = {}
         loaded_epoch = train.load_checkpoint(
             path=checkpoint_dir,
             models=resumed_model,
             optimizer=resumed_opt,
             scheduler=resumed_sched,
+            metadata_dict=metadata,
             device="cpu",
         )
         assert loaded_epoch == 3
+        report = _reconcile_loaded_checkpoint(
+            loaded_epoch=loaded_epoch,
+            metadata=metadata,
+            scheduler=resumed_sched,
+            scheduler_update_mode="epoch",
+            scaler=None,
+            logger=SimpleNamespace(warning=lambda message: pytest.fail(message)),
+        )
+        assert not report["legacy_checkpoint"]
+        assert report["scheduler_scaler_state_restored"]
+        assert report["trajectory_exactness"] == "unverified"
+        assert "RNG" in report["trajectory_exactness_reason"]
+        assert "resume_exact" not in report
         resumed_history.extend(
-            step_epoch(resumed_model, resumed_opt, resumed_sched)
-            for _ in range(loaded_epoch, 6)
+            step_epoch(resumed_model, resumed_opt, resumed_sched, epoch)
+            for epoch in range(loaded_epoch, 6)
         )
 
-        assert len(continuous_history) == len(resumed_history) == 6
-        for expected, actual in zip(continuous_history, resumed_history, strict=True):
-            for expected_tensor, actual_tensor in zip(
-                expected[:3], actual[:3], strict=True
-            ):
-                assert torch.equal(expected_tensor, actual_tensor)
-            assert expected[3] == actual[3]
         assert continuous_sched.state_dict() == resumed_sched.state_dict()
-        assert torch.equal(continuous_model.weight, resumed_model.weight)
-        assert torch.equal(continuous_model.bias, resumed_model.bias)
+        for epoch, (expected, actual) in enumerate(
+            zip(continuous_history, resumed_history, strict=True)
+        ):
+            assert expected[2] == actual[2]
+            if dropout == 0.0 or epoch < loaded_epoch:
+                assert torch.equal(expected[0], actual[0])
+                assert torch.equal(expected[1], actual[1])
+        if dropout:
+            assert not torch.equal(continuous_history[-1][1], resumed_history[-1][1])
+
+    def test_no_checkpoint_does_not_report_restored_state(self):
+        """A fresh run has no restored state or trajectory-fidelity assessment."""
+        report = _reconcile_loaded_checkpoint(
+            loaded_epoch=0,
+            metadata={},
+            scheduler=SimpleNamespace(step=lambda: pytest.fail("unexpected step")),
+            scheduler_update_mode="epoch",
+            scaler=None,
+            logger=SimpleNamespace(warning=lambda message: pytest.fail(message)),
+        )
+        assert not report["checkpoint_found"]
+        assert not report["scheduler_scaler_state_restored"]
+        assert report["trajectory_exactness"] == "not_applicable"
 
     def test_legacy_epoch_checkpoint_scheduler_is_migrated(self, tmp_path):
         """Old pre-step scheduler state is advanced to the continuous state."""
@@ -688,10 +827,11 @@ class TestFinishEpoch:
         assert resumed_scheduler.last_epoch == 2
         assert resumed_optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
         assert report["legacy_scheduler_step_applied"]
-        assert report["resume_exact"]
+        assert report["scheduler_scaler_state_restored"]
+        assert report["trajectory_exactness"] == "unverified"
         assert len(messages) == 1
 
-    def test_legacy_fp16_resume_is_explicitly_nonexact(self):
+    def test_legacy_fp16_resume_reports_missing_scaler(self):
         """A pre-metadata checkpoint resumed under fp16 is flagged as non-exact."""
         messages = []
         scaler = SimpleNamespace()
@@ -704,11 +844,11 @@ class TestFinishEpoch:
             logger=SimpleNamespace(warning=messages.append),
         )
 
-        assert not report["resume_exact"]
-        assert "scaler" in report["non_exact_reason"]
+        assert not report["scheduler_scaler_state_restored"]
+        assert "scaler" in report["missing_state_reason"]
         assert len(messages) == 1
 
-    def test_metadata_checkpoint_without_saved_scaler_is_nonexact(self):
+    def test_metadata_checkpoint_reports_missing_scaler(self):
         """A post-fix fp32 checkpoint resumed under fp16 is flagged, not migrated."""
         messages = []
         report = _reconcile_loaded_checkpoint(
@@ -722,5 +862,5 @@ class TestFinishEpoch:
 
         assert not report["legacy_checkpoint"]
         assert not report["legacy_scheduler_step_applied"]
-        assert not report["resume_exact"]
+        assert not report["scheduler_scaler_state_restored"]
         assert len(messages) == 1

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_train_helpers.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_train_helpers.py
@@ -33,6 +33,12 @@ handling for:
   sums over the global sample count (used per step and per epoch); its
   single-process path must equal plain ``total_loss / n`` + per-leaf
   ``sum / n`` averaging.
+- :func:`train._step_failure_barrier` / :func:`train._raise_if_divergent_loss`:
+  a failed or divergent step on one rank must surface on every rank before
+  backward instead of hanging the next collective.
+- :func:`train._finish_epoch` / :func:`train._reconcile_loaded_checkpoint`:
+  the epoch-mode scheduler advances before the checkpoint is written, so a
+  resumed run reproduces the continuous one; older checkpoints are migrated.
 
 (The analogous tests for the shared, tensorboard-free
 :func:`utils.recursive_to_device` live in ``test_utils.py``, outside
@@ -41,8 +47,11 @@ this module's tensorboard skip guard.)
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
+from omegaconf import OmegaConf
 from tensordict import TensorDict
 
 ### `train.py` imports `torch.utils.tensorboard.SummaryWriter` at module
@@ -53,9 +62,15 @@ from tensordict import TensorDict
 ### directly (no skip).
 pytest.importorskip("tensorboard")
 
+import train  # noqa: E402  -- monkeypatch module globals in focused tests
 from output_normalize import normalize_output_to_tensordict  # noqa: E402
 from train import (  # noqa: E402  -- after the skip guard
+    _finish_epoch,
+    _raise_if_divergent_loss,
+    _step_failure_barrier,
+    _reconcile_loaded_checkpoint,
     _reduce_and_average,
+    _run_epoch,
     _walk_batch_for_logging,
 )
 
@@ -244,3 +259,468 @@ class TestReduceAndAverage:
         )
         assert loss == pytest.approx(7.0)
         assert losses == {} and metrics == {}
+
+
+### ---------------------------------------------------------------------------
+### Loss divergence guard
+### ---------------------------------------------------------------------------
+
+
+class TestLossDivergenceGuard:
+    """Tests for the synchronized, pre-backward loss guard."""
+
+    @staticmethod
+    def _dist_manager(*, world_size: int = 1) -> SimpleNamespace:
+        return SimpleNamespace(
+            rank=0, world_size=world_size, device=torch.device("cpu")
+        )
+
+    def test_finite_loss_at_threshold_passes(self):
+        """The optional threshold is strict: equality is still accepted."""
+        _raise_if_divergent_loss(
+            torch.tensor(1000.0),
+            mode="train",
+            epoch=3,
+            step=7,
+            threshold=1000.0,
+        )
+
+    @pytest.mark.parametrize(
+        ("loss", "message"),
+        [
+            (float("nan"), "non-finite"),
+            (float("inf"), "non-finite"),
+            (1000.1, "above 1000"),
+        ],
+    )
+    def test_local_nonfinite_or_threshold_failure_raises(self, loss, message):
+        """NaN, inf, and above-threshold losses each raise with a clear reason."""
+        with pytest.raises(RuntimeError, match=message):
+            _raise_if_divergent_loss(
+                torch.tensor(loss),
+                mode="val",
+                epoch=2,
+                step=4,
+                threshold=1000.0,
+            )
+
+    def test_barrier_is_noop_on_healthy_step(self):
+        """Single process, no error: the barrier returns without a collective."""
+        _step_failure_barrier(
+            None, mode="train", epoch=1, step=2, dist_manager=self._dist_manager()
+        )
+
+    def test_barrier_reraises_local_error_with_cause(self):
+        """The failing rank's original exception is chained as ``__cause__``."""
+        original = ValueError("corrupt sample")
+        with pytest.raises(RuntimeError, match="step failed at epoch 5") as info:
+            _step_failure_barrier(
+                original,
+                mode="train",
+                epoch=5,
+                step=9,
+                dist_manager=self._dist_manager(),
+            )
+        assert info.value.__cause__ is original
+
+    def test_barrier_synchronizes_peer_failure(self, monkeypatch):
+        """A healthy rank raises too when the reduced any-rank flag is set."""
+
+        def report_remote_failure(flag, op):
+            assert op == torch.distributed.ReduceOp.MAX
+            flag.fill_(1)
+
+        monkeypatch.setattr(train.dist, "all_reduce", report_remote_failure)
+        with pytest.raises(RuntimeError, match="peer rank failed"):
+            _step_failure_barrier(
+                None,
+                mode="train",
+                epoch=0,
+                step=0,
+                dist_manager=self._dist_manager(world_size=2),
+            )
+
+    def test_barrier_healthy_when_no_rank_failed(self, monkeypatch):
+        """Multi-rank, all healthy: the reduced flag stays 0 and nothing raises."""
+
+        def report_no_failure(flag, op):
+            assert op == torch.distributed.ReduceOp.MAX
+
+        monkeypatch.setattr(train.dist, "all_reduce", report_no_failure)
+        _step_failure_barrier(
+            None,
+            mode="val",
+            epoch=0,
+            step=0,
+            dist_manager=self._dist_manager(world_size=2),
+        )
+
+    @pytest.mark.parametrize("mode", ["train", "val"])
+    def test_epoch_loop_checks_before_backward_in_both_modes(self, mode, monkeypatch):
+        """A NaN from forward aborts train and val; train creates no gradient."""
+        model = torch.nn.Linear(1, 1, bias=False)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+        nan = torch.tensor(float("nan"))
+
+        def divergent_forward(*args, **kwargs):
+            loss = model.weight.sum() * nan
+            values = TensorDict({"loss/test": loss.detach()})
+            return loss, values, values.clone()
+
+        monkeypatch.setattr(train, "forward_pass", divergent_forward)
+        cfg = OmegaConf.create(
+            {
+                "precision": "float32",
+                "profile": False,
+                "training": {
+                    "scheduler_update_mode": "epoch",
+                    "divergence_loss_threshold": 1.0e6,
+                },
+            }
+        )
+        kwargs = {}
+        if mode == "train":
+            kwargs = {"optimizer": optimizer, "scheduler": scheduler}
+
+        with pytest.raises(RuntimeError, match=rf"{mode} step failed at epoch"):
+            _run_epoch(
+                [{}],
+                model,
+                None,
+                None,
+                SimpleNamespace(
+                    info=lambda *args, **kwargs: None,
+                    error=lambda *args, **kwargs: None,
+                ),
+                0,
+                cfg,
+                self._dist_manager(),
+                mode=mode,
+                output_type="tensors",
+                target_config={"pressure": "scalar"},
+                **kwargs,
+            )
+        assert model.weight.grad is None
+
+    def test_default_null_threshold_runs_no_per_step_guard(self, monkeypatch):
+        """With the knob unset, the loop must not pay the guard's host sync."""
+
+        def forbidden_guard(*args, **kwargs):
+            raise AssertionError("guard must not run when threshold is null")
+
+        def finite_forward(*args, **kwargs):
+            loss = torch.tensor(0.5, requires_grad=True)
+            values = TensorDict({"loss/test": loss.detach()})
+            return loss, values, values.clone()
+
+        monkeypatch.setattr(train, "_raise_if_divergent_loss", forbidden_guard)
+        monkeypatch.setattr(train, "forward_pass", finite_forward)
+        cfg = OmegaConf.create(
+            {
+                "precision": "float32",
+                "profile": False,
+                "training": {
+                    "scheduler_update_mode": "epoch",
+                    "divergence_loss_threshold": None,
+                },
+            }
+        )
+        _run_epoch(
+            [{}],
+            torch.nn.Linear(1, 1),
+            None,
+            None,
+            SimpleNamespace(
+                info=lambda *args, **kwargs: None, error=lambda *args, **kwargs: None
+            ),
+            0,
+            cfg,
+            self._dist_manager(),
+            mode="val",
+            output_type="tensors",
+            target_config={"pressure": "scalar"},
+        )
+
+    def test_invalid_threshold_fails_before_forward(self, monkeypatch):
+        """A non-positive threshold is a config error caught before any step runs."""
+        called = False
+
+        def forward(*args, **kwargs):
+            nonlocal called
+            called = True
+            raise AssertionError("forward should not run")
+
+        monkeypatch.setattr(train, "forward_pass", forward)
+        cfg = OmegaConf.create(
+            {
+                "precision": "float32",
+                "profile": False,
+                "training": {
+                    "scheduler_update_mode": "epoch",
+                    "divergence_loss_threshold": 0,
+                },
+            }
+        )
+        with pytest.raises(ValueError, match="must be positive"):
+            _run_epoch(
+                [{}],
+                torch.nn.Linear(1, 1),
+                None,
+                None,
+                SimpleNamespace(
+                    info=lambda *args, **kwargs: None,
+                    error=lambda *args, **kwargs: None,
+                ),
+                0,
+                cfg,
+                self._dist_manager(),
+                mode="val",
+                output_type="tensors",
+                target_config={"pressure": "scalar"},
+            )
+        assert not called
+
+
+### ---------------------------------------------------------------------------
+### Epoch completion / checkpoint ordering
+### ---------------------------------------------------------------------------
+
+
+class TestFinishEpoch:
+    """Tests for scheduler/checkpoint ordering and terminal persistence."""
+
+    @staticmethod
+    def _cfg(*, save_interval: int, scheduler_update_mode: str = "epoch"):
+        return OmegaConf.create(
+            {
+                "training": {
+                    "save_interval": save_interval,
+                    "scheduler_update_mode": scheduler_update_mode,
+                }
+            }
+        )
+
+    def test_scheduler_advances_before_checkpoint_and_epoch_is_next(self, monkeypatch):
+        """Epoch-mode scheduler steps first; the saved epoch is the resume index."""
+        events = []
+        scheduler = SimpleNamespace(step=lambda: events.append("scheduler"))
+
+        def save(**kwargs):
+            metadata = kwargs["metadata"]["unified_external_aero_recipe"]
+            events.append(
+                ("checkpoint", kwargs["epoch"], metadata["scaler_state_saved"])
+            )
+
+        monkeypatch.setattr(train, "save_checkpoint", save)
+        saved = _finish_epoch(
+            epoch=4,
+            num_epochs=5,
+            cfg=self._cfg(save_interval=2),
+            scheduler=scheduler,
+            ckpt_args={"path": "/unused"},
+            normalizer=None,
+            is_rank0=True,
+        )
+
+        assert saved
+        ### Epoch 4 is both periodic and terminal, but is persisted once as
+        ### five completed epochs / the next resume index.
+        assert events == ["scheduler", ("checkpoint", 5, False)]
+
+    def test_nonperiodic_terminal_is_always_saved(self, monkeypatch):
+        """The last epoch is checkpointed even when it is off the periodic cadence."""
+        saved_epochs = []
+        monkeypatch.setattr(
+            train,
+            "save_checkpoint",
+            lambda **kwargs: saved_epochs.append(kwargs["epoch"]),
+        )
+        saved = _finish_epoch(
+            epoch=4,
+            num_epochs=5,
+            cfg=self._cfg(save_interval=3, scheduler_update_mode="step"),
+            scheduler=SimpleNamespace(step=lambda: pytest.fail("unexpected step")),
+            ckpt_args={"path": "/unused"},
+            normalizer=None,
+            is_rank0=True,
+        )
+        assert saved
+        assert saved_epochs == [5]
+
+    def test_existing_periodic_cadence_is_preserved(self, monkeypatch):
+        """The historical epoch-0 save remains checkpoint 1."""
+        saved_epochs = []
+        monkeypatch.setattr(
+            train,
+            "save_checkpoint",
+            lambda **kwargs: saved_epochs.append(kwargs["epoch"]),
+        )
+        _finish_epoch(
+            epoch=0,
+            num_epochs=500,
+            cfg=self._cfg(save_interval=25, scheduler_update_mode="step"),
+            scheduler=SimpleNamespace(step=lambda: pytest.fail("unexpected step")),
+            ckpt_args={"path": "/unused"},
+            normalizer=None,
+            is_rank0=True,
+        )
+        assert saved_epochs == [1]
+
+    def test_real_save_resume_matches_continuous_decay_crossing(self, tmp_path):
+        """A checkpoint after the epoch step reproduces one continuous run."""
+
+        features = torch.tensor(
+            [[0.5, -1.0], [1.5, 0.25], [-0.75, 0.4]], dtype=torch.float64
+        )
+        targets = torch.tensor([[0.2], [-0.1], [0.7]], dtype=torch.float64)
+
+        def build_state():
+            torch.manual_seed(1701)
+            model = torch.nn.Linear(2, 1, dtype=torch.float64)
+            optimizer = torch.optim.AdamW(
+                model.parameters(), lr=0.03, weight_decay=0.01
+            )
+            scheduler = torch.optim.lr_scheduler.StepLR(
+                optimizer, step_size=3, gamma=0.2
+            )
+            return model, optimizer, scheduler
+
+        def step_epoch(model, optimizer, scheduler):
+            optimizer.zero_grad()
+            loss = (model(features) - targets).square().sum()
+            loss.backward()
+            optimizer.step()
+            scheduler.step()
+            return (
+                loss.detach().clone(),
+                model.weight.detach().clone(),
+                model.bias.detach().clone(),
+                optimizer.param_groups[0]["lr"],
+            )
+
+        continuous_model, continuous_opt, continuous_sched = build_state()
+        continuous_history = [
+            step_epoch(continuous_model, continuous_opt, continuous_sched)
+            for _ in range(6)
+        ]
+
+        first_model, first_opt, first_sched = build_state()
+        resumed_history = [
+            step_epoch(first_model, first_opt, first_sched) for _ in range(3)
+        ]
+        checkpoint_dir = tmp_path / "resume"
+        train.save_checkpoint(
+            path=checkpoint_dir,
+            models=first_model,
+            optimizer=first_opt,
+            scheduler=first_sched,
+            epoch=3,
+        )
+
+        resumed_model, resumed_opt, resumed_sched = build_state()
+        loaded_epoch = train.load_checkpoint(
+            path=checkpoint_dir,
+            models=resumed_model,
+            optimizer=resumed_opt,
+            scheduler=resumed_sched,
+            device="cpu",
+        )
+        assert loaded_epoch == 3
+        resumed_history.extend(
+            step_epoch(resumed_model, resumed_opt, resumed_sched)
+            for _ in range(loaded_epoch, 6)
+        )
+
+        assert len(continuous_history) == len(resumed_history) == 6
+        for expected, actual in zip(continuous_history, resumed_history, strict=True):
+            for expected_tensor, actual_tensor in zip(
+                expected[:3], actual[:3], strict=True
+            ):
+                assert torch.equal(expected_tensor, actual_tensor)
+            assert expected[3] == actual[3]
+        assert continuous_sched.state_dict() == resumed_sched.state_dict()
+        assert torch.equal(continuous_model.weight, resumed_model.weight)
+        assert torch.equal(continuous_model.bias, resumed_model.bias)
+
+    def test_legacy_epoch_checkpoint_scheduler_is_migrated(self, tmp_path):
+        """Old pre-step scheduler state is advanced to the continuous state."""
+        model = torch.nn.Linear(1, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
+        scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=2, gamma=0.1)
+
+        ### Reproduce the old ordering after two completed epochs: epoch 1
+        ### stepped, then checkpoint 2 was written before the epoch-2 step.
+        optimizer.step()
+        scheduler.step()
+        train.save_checkpoint(
+            path=tmp_path,
+            models=model,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            epoch=2,
+        )
+
+        resumed_model = torch.nn.Linear(1, 1)
+        resumed_optimizer = torch.optim.SGD(resumed_model.parameters(), lr=1.0)
+        resumed_scheduler = torch.optim.lr_scheduler.StepLR(
+            resumed_optimizer, step_size=2, gamma=0.1
+        )
+        metadata = {}
+        loaded_epoch = train.load_checkpoint(
+            path=tmp_path,
+            models=resumed_model,
+            optimizer=resumed_optimizer,
+            scheduler=resumed_scheduler,
+            metadata_dict=metadata,
+            device="cpu",
+        )
+        messages = []
+        report = _reconcile_loaded_checkpoint(
+            loaded_epoch=loaded_epoch,
+            metadata=metadata,
+            scheduler=resumed_scheduler,
+            scheduler_update_mode="epoch",
+            scaler=None,
+            logger=SimpleNamespace(warning=messages.append),
+        )
+
+        assert resumed_scheduler.last_epoch == 2
+        assert resumed_optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
+        assert report["legacy_scheduler_step_applied"]
+        assert report["resume_exact"]
+        assert len(messages) == 1
+
+    def test_legacy_fp16_resume_is_explicitly_nonexact(self):
+        """A pre-metadata checkpoint resumed under fp16 is flagged as non-exact."""
+        messages = []
+        scaler = SimpleNamespace()
+        report = _reconcile_loaded_checkpoint(
+            loaded_epoch=25,
+            metadata={},
+            scheduler=SimpleNamespace(step=lambda: None),
+            scheduler_update_mode="step",
+            scaler=scaler,
+            logger=SimpleNamespace(warning=messages.append),
+        )
+
+        assert not report["resume_exact"]
+        assert "scaler" in report["non_exact_reason"]
+        assert len(messages) == 1
+
+    def test_metadata_checkpoint_without_saved_scaler_is_nonexact(self):
+        """A post-fix fp32 checkpoint resumed under fp16 is flagged, not migrated."""
+        messages = []
+        report = _reconcile_loaded_checkpoint(
+            loaded_epoch=4,
+            metadata={"unified_external_aero_recipe": {"scaler_state_saved": False}},
+            scheduler=SimpleNamespace(step=lambda: pytest.fail("unexpected step")),
+            scheduler_update_mode="epoch",
+            scaler=SimpleNamespace(),
+            logger=SimpleNamespace(warning=messages.append),
+        )
+
+        assert not report["legacy_checkpoint"]
+        assert not report["legacy_scheduler_step_applied"]
+        assert not report["resume_exact"]
+        assert len(messages) == 1


### PR DESCRIPTION
## Description

Coordinate rank-local data-loading and device-transfer failures before DDP forward, then forward/loss failures before backward. This prevents a failed loader from entering the error all-reduce while a healthy rank is inside DDP buffer synchronization or bucket rebuilding. Errors identify the phase and retain the failing rank's original exception. Failures inside model collectives, backward, or an unusable CUDA context still rely on the process-group timeout.

An optional `training.divergence_loss_threshold` rejects non-finite or excessive losses. Epoch schedulers advance before checkpointing, legacy pre-step scheduler state is migrated, fp16 GradScaler state is saved, and terminal epochs are checkpointed even off the periodic cadence.

The checkpoint-resume record reports `scheduler_scaler_state_restored` and identifies missing scaler state. `trajectory_exactness` is `unverified`: RNG and stochastic data state are not restored, so this change does not promise exact stochastic continuation.

## Validation

- 36 focused training-helper tests passed, including real CPU/Gloo DDP epoch-loop tests for second-load failures on either rank in both training and validation.
- Real save/load tests exercise `_finish_epoch` and reconciliation, verifying scheduler continuity and deterministic continuation while demonstrating that dropout continuation remains unverified.
- All changed-file pre-commit hooks passed.
- Independently reviewed by a second agent. Merged current main; no full GPU recipe run was performed.
