### PR TITLE
Unified aero recipe: rename the misnamed "rmse" loss to relative_mse (deprecated alias kept)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Unified external aerodynamics recipe: `training.loss_type: rmse` is
   deprecated in favour of `relative_mse`, which names what it always
-  computed (target-normalized relative MSE, no square root); `relative_l2`
-  is added for the square root. Both delegate to
-  `physicsnemo.metrics.general.relative_error`. `rmse` still works and
+  computed (target-normalized relative MSE, no square root) and delegates
+  to `physicsnemo.metrics.general.relative_error`. `rmse` still works and
   warns.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- Unified external aerodynamics recipe: `training.loss_type: rmse` is
+  deprecated in favour of `relative_mse`, which names what it always
+  computed (target-normalized relative MSE, no square root); `relative_l2`
+  is added for the square root. Both delegate to
+  `physicsnemo.metrics.general.relative_error`. `rmse` still works and
+  warns.
+
 ### Removed
 
 ### Fixed

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
@@ -314,7 +314,10 @@ For each field, the loss type is applied per the field's type (`scalar`
 or `vector`); per-field losses are then weighted by the optional
 `training.field_weights` block in the model YAML and summed.
 
-Supported loss types: Huber (default), MSE, relative MSE.
+Supported loss types (`training.loss_type`): `huber` (default), `mse`,
+`relative_mse` (`sum((pred - target)^2) / sum(target^2)`, per field), and
+`relative_l2` (its square root). `rmse` is a deprecated alias for
+`relative_mse` and warns.
 Supported metrics: relative L1, relative L2, MAE.
 
 **`training.field_weights`** is a model-side dict that multiplies each
@@ -772,7 +775,7 @@ TensorBoard / JSONL files; no external tracker required.
 | `src/nondim.py` | Recipe-local transform: `NonDimensionalizeByMetadata` (with `inverse` / `inverse_td` for re-dimensionalization). Registered into the global datapipe registry. Supports pressure, stress, velocity, temperature, density, and identity field types. |
 | `src/forward_kwargs.py` | Spec resolver. Walks declarative `forward_kwargs:` specs (paths, lists, nested dicts, `expand_like` modifiers) into actual `model.forward()` kwargs against a DomainMesh. Also provides `extract_targets` (interior.point_data lookup by target name). |
 | `src/collate.py` | `build_collate_fn(input_type, forward_kwargs_spec, target_config)`. Resolves forward kwargs from each `DomainMesh` sample, extracts targets from `interior.point_data`. For `input_type='tensors'`, batch-wraps tensors with the right token / per-element padding; for `input_type='mesh'`, passes Mesh / dict / scalar values through unchanged. |
-| `src/loss.py` | `LossCalculator` — TensorDict-based loss for mixed scalar/vector fields. Supports Huber, MSE, relative MSE. Optional `field_weights` per-field multiplicative weights. Normalizes total loss by number of output channels. |
+| `src/loss.py` | `LossCalculator` — TensorDict-based loss for mixed scalar/vector fields. Supports Huber, MSE, relative MSE, relative L2. Optional `field_weights` per-field multiplicative weights. Normalizes total loss by number of output channels. |
 | `src/metrics.py` | `MetricCalculator` — TensorDict-based metrics (relative L1, relative L2, MAE) with optional distributed all-reduce; reports per-field and per-component (x/y/z) metrics for vector fields. `resolve_metrics(cfg)` reads the recipe-side `cfg.metrics`. |
 | `src/output_normalize.py` | `normalize_output_to_tensordict` (Mesh -> `point_data.select`, tensor -> per-target slicing via `split_concat_by_target`) and `require_output_type(cfg)`. Tensorboard-free so the unit tests can import it directly. |
 | `src/forces.py` | Integrated aerodynamic force/moment coefficients from surface predictions. `force_moment_coefficients` integrates the traction `-Cp*n + Cf` over the vehicle via `Mesh.integrate`, projected onto drag/lift/side + roll/pitch/yaw axes; `ForceContext` / `ForceAccumulator` wrap the per-run config + accumulation. |

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/README.md
@@ -314,9 +314,9 @@ For each field, the loss type is applied per the field's type (`scalar`
 or `vector`); per-field losses are then weighted by the optional
 `training.field_weights` block in the model YAML and summed.
 
-Supported loss types (`training.loss_type`): `huber` (default), `mse`,
-`relative_mse` (`sum((pred - target)^2) / sum(target^2)`, per field), and
-`relative_l2` (its square root). `rmse` is a deprecated alias for
+Supported loss types (`training.loss_type`): `huber` (default), `mse`, and
+`relative_mse` (`sum((pred - target)^2) / sum(target^2)`, per field; per
+component and summed for vector fields). `rmse` is a deprecated alias for
 `relative_mse` and warns.
 Supported metrics: relative L1, relative L2, MAE.
 
@@ -775,7 +775,7 @@ TensorBoard / JSONL files; no external tracker required.
 | `src/nondim.py` | Recipe-local transform: `NonDimensionalizeByMetadata` (with `inverse` / `inverse_td` for re-dimensionalization). Registered into the global datapipe registry. Supports pressure, stress, velocity, temperature, density, and identity field types. |
 | `src/forward_kwargs.py` | Spec resolver. Walks declarative `forward_kwargs:` specs (paths, lists, nested dicts, `expand_like` modifiers) into actual `model.forward()` kwargs against a DomainMesh. Also provides `extract_targets` (interior.point_data lookup by target name). |
 | `src/collate.py` | `build_collate_fn(input_type, forward_kwargs_spec, target_config)`. Resolves forward kwargs from each `DomainMesh` sample, extracts targets from `interior.point_data`. For `input_type='tensors'`, batch-wraps tensors with the right token / per-element padding; for `input_type='mesh'`, passes Mesh / dict / scalar values through unchanged. |
-| `src/loss.py` | `LossCalculator` — TensorDict-based loss for mixed scalar/vector fields. Supports Huber, MSE, relative MSE, relative L2. Optional `field_weights` per-field multiplicative weights. Normalizes total loss by number of output channels. |
+| `src/loss.py` | `LossCalculator` — TensorDict-based loss for mixed scalar/vector fields. Supports Huber, MSE, relative MSE. Optional `field_weights` per-field multiplicative weights. Normalizes total loss by number of output channels. |
 | `src/metrics.py` | `MetricCalculator` — TensorDict-based metrics (relative L1, relative L2, MAE) with optional distributed all-reduce; reports per-field and per-component (x/y/z) metrics for vector fields. `resolve_metrics(cfg)` reads the recipe-side `cfg.metrics`. |
 | `src/output_normalize.py` | `normalize_output_to_tensordict` (Mesh -> `point_data.select`, tensor -> per-target slicing via `split_concat_by_target`) and `require_output_type(cfg)`. Tensorboard-free so the unit tests can import it directly. |
 | `src/forces.py` | Integrated aerodynamic force/moment coefficients from surface predictions. `force_moment_coefficients` integrates the traction `-Cp*n + Cf` over the vehicle via `Mesh.integrate`, projected onto drag/lift/side + roll/pitch/yaw axes; `ForceContext` / `ForceAccumulator` wrap the per-run config + accumulation. |

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/loss.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/loss.py
@@ -46,7 +46,7 @@ from tensordict import TensorDict
 from utils import FieldType, align_scalar_shapes, field_dim, validate_field_coverage
 
 from physicsnemo.datapipes.keys import as_nested_key
-from physicsnemo.metrics.general.relative_error import relative_l2, relative_mse
+from physicsnemo.metrics.general.relative_error import relative_mse
 
 _LOGGER = logging.getLogger("training.loss")
 
@@ -56,8 +56,8 @@ DEFAULT_HUBER_DELTA = 1.0
 ### always computed is the target-normalized relative MSE (no square root
 ### anywhere), so the old name misled anyone comparing against reported RMSE
 ### numbers. ``LossCalculator`` rewrites it on construction with a warning.
-LossType = Literal["huber", "mse", "relative_mse", "relative_l2", "rmse"]
-_VALID_LOSS_TYPES = ("huber", "mse", "relative_mse", "relative_l2", "rmse")
+LossType = Literal["huber", "mse", "relative_mse", "rmse"]
+_VALID_LOSS_TYPES = ("huber", "mse", "relative_mse", "rmse")
 
 
 ### ---------------------------------------------------------------------------
@@ -92,8 +92,6 @@ def _scalar_loss(
         return torch.mean((pred - target) ** 2)
     if loss_type == "relative_mse":
         return relative_mse(pred, target, eps=eps)
-    if loss_type == "relative_l2":
-        return relative_l2(pred, target, eps=eps)
     raise ValueError(f"Unknown loss_type {loss_type!r}")
 
 
@@ -117,15 +115,11 @@ def _vector_loss(
         )
     n_components = pred.shape[-1]
 
-    ### Relative errors: each component normalized by its own target energy
+    ### Relative MSE: each component normalized by its own target energy
     ### (reduce over every axis but the last), then summed across components.
     if loss_type == "relative_mse":
         return torch.sum(
             relative_mse(pred, target, dim=tuple(range(pred.ndim - 1)), eps=eps)
-        )
-    if loss_type == "relative_l2":
-        return torch.sum(
-            relative_l2(pred, target, dim=tuple(range(pred.ndim - 1)), eps=eps)
         )
 
     total = torch.zeros((), device=pred.device, dtype=pred.dtype)
@@ -152,10 +146,10 @@ class LossCalculator:
         target_config: ``{name: scalar|vector}`` mapping. Iteration order
             determines the order in the loss dict and the channel weighting
             in the total.
-        loss_type: One of ``"huber"``, ``"mse"``, ``"relative_mse"``
-            (``sum((pred - target)^2) / sum(target^2)``), or ``"relative_l2"``
-            (its square root). ``"rmse"`` is a deprecated alias for
-            ``"relative_mse"`` and warns.
+        loss_type: One of ``"huber"``, ``"mse"``, or ``"relative_mse"``
+            (``sum((pred - target)^2) / sum(target^2)``). ``"rmse"`` is
+            accepted only as a deprecated alias for ``"relative_mse"`` and
+            warns.
         n_spatial_dims: Vector field dimensionality. Used to compute
             channel counts for the normalization denominator.
         field_weights: Optional per-field multiplicative weights. Each
@@ -194,8 +188,10 @@ class LossCalculator:
             warnings.warn(
                 'loss_type="rmse" is a deprecated misnomer: the quantity it '
                 "computes is the target-normalized relative MSE (no square "
-                'root). Use "relative_mse" (identical quantity) or '
-                '"relative_l2" (its square root). The alias will be removed.',
+                'root). Use "relative_mse", which computes the same quantity '
+                "for any target with nonzero energy (only the denominator "
+                "floor for an all-zero target differs). The alias will be "
+                "removed.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/loss.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/src/loss.py
@@ -36,6 +36,7 @@ to how many channels each field contributes.
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Literal
 
 import torch
@@ -45,12 +46,18 @@ from tensordict import TensorDict
 from utils import FieldType, align_scalar_shapes, field_dim, validate_field_coverage
 
 from physicsnemo.datapipes.keys import as_nested_key
+from physicsnemo.metrics.general.relative_error import relative_l2, relative_mse
 
 _LOGGER = logging.getLogger("training.loss")
 
 DEFAULT_HUBER_DELTA = 1.0
 
-LossType = Literal["huber", "mse", "rmse"]
+### ``"rmse"`` is a deprecated alias for ``"relative_mse"``: the quantity it
+### always computed is the target-normalized relative MSE (no square root
+### anywhere), so the old name misled anyone comparing against reported RMSE
+### numbers. ``LossCalculator`` rewrites it on construction with a warning.
+LossType = Literal["huber", "mse", "relative_mse", "relative_l2", "rmse"]
+_VALID_LOSS_TYPES = ("huber", "mse", "relative_mse", "relative_l2", "rmse")
 
 
 ### ---------------------------------------------------------------------------
@@ -83,10 +90,10 @@ def _scalar_loss(
         return F.huber_loss(pred, target, reduction="mean", delta=delta)
     if loss_type == "mse":
         return torch.mean((pred - target) ** 2)
-    if loss_type == "rmse":
-        num = torch.mean((pred - target) ** 2)
-        denom = torch.mean(target**2)
-        return num / (denom + eps)
+    if loss_type == "relative_mse":
+        return relative_mse(pred, target, eps=eps)
+    if loss_type == "relative_l2":
+        return relative_l2(pred, target, eps=eps)
     raise ValueError(f"Unknown loss_type {loss_type!r}")
 
 
@@ -100,8 +107,8 @@ def _vector_loss(
     """Per-component scalar loss summed across components.
 
     For a vector field of dimension ``D``, the result is
-    ``D * mean_huber_over_all_elements`` (or the MSE / RMSE analogue),
-    not a single mean over the flattened tensor.
+    ``D * mean_huber_over_all_elements`` (or the MSE / relative-error
+    analogue), not a single mean over the flattened tensor.
     """
     if pred.shape != target.shape:
         raise ValueError(
@@ -110,11 +117,16 @@ def _vector_loss(
         )
     n_components = pred.shape[-1]
 
-    if loss_type == "rmse":
-        ### Per-component relative MSE, summed.
-        diff_sq = torch.mean((pred - target) ** 2, dim=tuple(range(pred.ndim - 1)))
-        target_sq = torch.mean(target**2, dim=tuple(range(pred.ndim - 1)))
-        return torch.sum(diff_sq / (target_sq + eps))
+    ### Relative errors: each component normalized by its own target energy
+    ### (reduce over every axis but the last), then summed across components.
+    if loss_type == "relative_mse":
+        return torch.sum(
+            relative_mse(pred, target, dim=tuple(range(pred.ndim - 1)), eps=eps)
+        )
+    if loss_type == "relative_l2":
+        return torch.sum(
+            relative_l2(pred, target, dim=tuple(range(pred.ndim - 1)), eps=eps)
+        )
 
     total = torch.zeros((), device=pred.device, dtype=pred.dtype)
     for i in range(n_components):
@@ -140,7 +152,10 @@ class LossCalculator:
         target_config: ``{name: scalar|vector}`` mapping. Iteration order
             determines the order in the loss dict and the channel weighting
             in the total.
-        loss_type: One of ``"huber"``, ``"mse"``, ``"rmse"``.
+        loss_type: One of ``"huber"``, ``"mse"``, ``"relative_mse"``
+            (``sum((pred - target)^2) / sum(target^2)``), or ``"relative_l2"``
+            (its square root). ``"rmse"`` is a deprecated alias for
+            ``"relative_mse"`` and warns.
         n_spatial_dims: Vector field dimensionality. Used to compute
             channel counts for the normalization denominator.
         field_weights: Optional per-field multiplicative weights. Each
@@ -167,11 +182,24 @@ class LossCalculator:
         normalize_by_channels: bool = True,
         delta: float = DEFAULT_HUBER_DELTA,
     ) -> None:
-        if loss_type not in ("huber", "mse", "rmse"):
+        if loss_type not in _VALID_LOSS_TYPES:
             raise ValueError(
                 f"Unknown loss_type {loss_type!r}; expected one of "
-                f"'huber', 'mse', 'rmse'."
+                f"{_VALID_LOSS_TYPES!r}."
             )
+        if loss_type == "rmse":
+            ### FutureWarning rather than DeprecationWarning: this is a
+            ### user-facing config value, and DeprecationWarning is hidden
+            ### by default outside ``__main__``.
+            warnings.warn(
+                'loss_type="rmse" is a deprecated misnomer: the quantity it '
+                "computes is the target-normalized relative MSE (no square "
+                'root). Use "relative_mse" (identical quantity) or '
+                '"relative_l2" (its square root). The alias will be removed.',
+                FutureWarning,
+                stacklevel=2,
+            )
+            loss_type = "relative_mse"
         ### `target_config` values are required to be lowercase per the
         ### `FieldType` contract; we copy the dict verbatim so callers can
         ### mutate their original without affecting us.

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_loss_equivalence.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_loss_equivalence.py
@@ -147,9 +147,7 @@ class TestReferenceTotal:
         assert "loss/total" in loss_dict
         assert torch.allclose(loss_dict["loss/total"], ref_total, atol=1e-7, rtol=1e-6)
 
-    @pytest.mark.parametrize(
-        "loss_type", ["huber", "mse", "relative_mse", "relative_l2"]
-    )
+    @pytest.mark.parametrize("loss_type", ["huber", "mse", "relative_mse"])
     def test_per_field_keys_match_target_config(self, loss_type):
         """Per field keys match target config."""
         torch.manual_seed(0)
@@ -182,7 +180,7 @@ def _random_fields(seed: int = 11) -> tuple[TensorDict, TensorDict]:
 
 
 class TestRelativeLosses:
-    """``relative_mse`` / ``relative_l2`` semantics and the ``"rmse"`` alias."""
+    """``relative_mse`` semantics and the ``"rmse"`` alias."""
 
     def test_relative_mse_is_target_normalized_mse_per_field(self):
         """Scalar: ``mean(err^2) / mean(target^2)``; vector: per component, summed."""
@@ -200,27 +198,6 @@ class TestRelativeLosses:
         )
         assert torch.allclose(ldict["loss/pressure"], ref_scalar, rtol=1e-6)
         assert torch.allclose(ldict["loss/wss"], ref_vector, rtol=1e-6)
-
-    def test_relative_l2_is_sqrt_of_relative_mse_per_field(self):
-        """``relative_l2`` takes the root per field (before channel normalization)."""
-        pred, target = _random_fields()
-        target_config = {"pressure": "scalar", "wss": "vector"}
-        _, mse_dict = LossCalculator(target_config, loss_type="relative_mse")(
-            pred, target
-        )
-        _, l2_dict = LossCalculator(target_config, loss_type="relative_l2")(
-            pred, target
-        )
-        assert torch.allclose(
-            l2_dict["loss/pressure"], mse_dict["loss/pressure"].sqrt()
-        )
-        ### The vector field sums per-component roots, so it is not simply the
-        ### root of the summed relative MSE; check it against the components.
-        p, t = pred["wss"], target["wss"]
-        ref = torch.sum(
-            (torch.mean((p - t) ** 2, dim=(0, 1)) / torch.mean(t**2, dim=(0, 1))).sqrt()
-        )
-        assert torch.allclose(l2_dict["loss/wss"], ref, rtol=1e-6)
 
     def test_rmse_alias_warns_and_matches_relative_mse(self):
         """``"rmse"`` warns once at construction and computes ``relative_mse``."""

--- a/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_loss_equivalence.py
+++ b/examples/cfd/external_aerodynamics/unified_external_aero_recipe/tests/test_loss_equivalence.py
@@ -147,7 +147,9 @@ class TestReferenceTotal:
         assert "loss/total" in loss_dict
         assert torch.allclose(loss_dict["loss/total"], ref_total, atol=1e-7, rtol=1e-6)
 
-    @pytest.mark.parametrize("loss_type", ["huber", "mse"])
+    @pytest.mark.parametrize(
+        "loss_type", ["huber", "mse", "relative_mse", "relative_l2"]
+    )
     def test_per_field_keys_match_target_config(self, loss_type):
         """Per field keys match target config."""
         torch.manual_seed(0)
@@ -164,6 +166,81 @@ class TestReferenceTotal:
         ### iterating it directly raises StopIteration (no batch dim to walk),
         ### so we materialise the keys explicitly.
         assert set(ldict.keys()) == {"loss/pressure", "loss/wss", "loss/total"}
+
+
+### ---------------------------------------------------------------------------
+### Relative losses and the deprecated "rmse" alias
+### ---------------------------------------------------------------------------
+
+
+def _random_fields(seed: int = 11) -> tuple[TensorDict, TensorDict]:
+    """One scalar and one vector field, ``(1, N)`` and ``(1, N, 3)``."""
+    torch.manual_seed(seed)
+    pred = _make_td({"pressure": torch.randn(1, 40), "wss": torch.randn(1, 40, 3)})
+    target = _make_td({"pressure": torch.randn(1, 40), "wss": torch.randn(1, 40, 3)})
+    return pred, target
+
+
+class TestRelativeLosses:
+    """``relative_mse`` / ``relative_l2`` semantics and the ``"rmse"`` alias."""
+
+    def test_relative_mse_is_target_normalized_mse_per_field(self):
+        """Scalar: ``mean(err^2) / mean(target^2)``; vector: per component, summed."""
+        pred, target = _random_fields()
+        lc = LossCalculator(
+            {"pressure": "scalar", "wss": "vector"}, loss_type="relative_mse"
+        )
+        _, ldict = lc(pred, target)
+
+        p, t = pred["pressure"], target["pressure"]
+        ref_scalar = torch.mean((p - t) ** 2) / torch.mean(t**2)
+        p, t = pred["wss"], target["wss"]
+        ref_vector = torch.sum(
+            torch.mean((p - t) ** 2, dim=(0, 1)) / torch.mean(t**2, dim=(0, 1))
+        )
+        assert torch.allclose(ldict["loss/pressure"], ref_scalar, rtol=1e-6)
+        assert torch.allclose(ldict["loss/wss"], ref_vector, rtol=1e-6)
+
+    def test_relative_l2_is_sqrt_of_relative_mse_per_field(self):
+        """``relative_l2`` takes the root per field (before channel normalization)."""
+        pred, target = _random_fields()
+        target_config = {"pressure": "scalar", "wss": "vector"}
+        _, mse_dict = LossCalculator(target_config, loss_type="relative_mse")(
+            pred, target
+        )
+        _, l2_dict = LossCalculator(target_config, loss_type="relative_l2")(
+            pred, target
+        )
+        assert torch.allclose(
+            l2_dict["loss/pressure"], mse_dict["loss/pressure"].sqrt()
+        )
+        ### The vector field sums per-component roots, so it is not simply the
+        ### root of the summed relative MSE; check it against the components.
+        p, t = pred["wss"], target["wss"]
+        ref = torch.sum(
+            (torch.mean((p - t) ** 2, dim=(0, 1)) / torch.mean(t**2, dim=(0, 1))).sqrt()
+        )
+        assert torch.allclose(l2_dict["loss/wss"], ref, rtol=1e-6)
+
+    def test_rmse_alias_warns_and_matches_relative_mse(self):
+        """``"rmse"`` warns once at construction and computes ``relative_mse``."""
+        pred, target = _random_fields()
+        target_config = {"pressure": "scalar", "wss": "vector"}
+        with pytest.warns(FutureWarning, match='Use "relative_mse"'):
+            legacy = LossCalculator(target_config, loss_type="rmse")
+        assert legacy.loss_type == "relative_mse"
+
+        canonical = LossCalculator(target_config, loss_type="relative_mse")
+        legacy_total, legacy_dict = legacy(pred, target)
+        total, ldict = canonical(pred, target)
+        assert torch.equal(legacy_total, total)
+        for key in ldict.keys():
+            assert torch.equal(legacy_dict[key], ldict[key])
+
+    def test_unknown_loss_type_rejected(self):
+        """Typos fail at construction with the accepted names in the message."""
+        with pytest.raises(ValueError, match="relative_mse"):
+            LossCalculator({"pressure": "scalar"}, loss_type="rsme")
 
 
 ### ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a misleading loss name in the unified external aero recipe's `src/loss.py`.

**What is wrong today.** `training.loss_type: rmse` does not compute a root-mean-square error. For each field it computes

```
mean((pred - target)^2) / mean(target^2)
```

(per component and summed, for vector fields) with no square root anywhere. That is the target-normalized *relative MSE*. Anyone comparing a training curve labelled "rmse" against reported RMSE numbers is comparing different quantities.

**What this does.**

- Adds `relative_mse` as the `loss_type` name for the quantity the old name computed. It delegates to `physicsnemo.metrics.general.relative_error.relative_mse` (from #1746) instead of a hand-rolled ratio.
- Keeps `rmse` as a deprecated alias: `LossCalculator` rewrites it to `relative_mse` at construction and emits a `FutureWarning` naming the replacement. (FutureWarning rather than DeprecationWarning because it is a user-facing config value and DeprecationWarning is hidden by default outside `__main__`.)
- Updates the README's loss-type list and adds a CHANGELOG entry under Deprecated.
- No shipped config uses `rmse`; `base.yaml` defaults to `huber`, which is untouched.
- No new loss types are added. Relative L2 remains available as a reported metric only; it is not offered as a training loss (its gradient is undefined at exactly zero error).

**Numerical change for existing configs.** `huber` and `mse` are untouched. For `rmse` -> `relative_mse` the ratio is identical for any target with nonzero energy (`mean/mean == sum/sum`). The only difference is the `1e-8` guard on the denominator: previously added to `mean(target^2)`, now a floor on `sum(target^2)` inside the shared implementation. For a field whose target is identically zero, the new value is larger by the element count; both values are meaningless in that case (a finite error divided by `1e-8`), and the warning text states the difference.

## Tests

`tests/test_loss_equivalence.py` (16 passed):

- `relative_mse` per-field values match the explicit target-normalized formula for a scalar field and a per-component-summed vector field.
- `rmse` warns at construction, reports `loss_type == "relative_mse"`, and produces bit-identical totals and per-field values to `relative_mse`.
- Unknown loss types are rejected with the accepted names in the message; per-field key tests cover `relative_mse`.
