### PR TITLE
Build transformer-engine-torch against the runtime torch (fixes nightly TE ImportError)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ conflicts = [
 torch-sparse = ["torch"]
 torch-cluster = ["torch"]
 torch-scatter = ["torch"]
+transformer-engine-torch = [{ requirement = "torch", match-runtime = true }]
 
 [[tool.uv.index]]
 name = "nvidia"


### PR DESCRIPTION
## Summary

Main's nightly has failed every night since 2026-09-05 with

```
ImportError: transformer_engine_torch.cpython-312-x86_64-linux-gnu.so:
  undefined symbol: _ZN3c104cuda19CUDAErrorLogCaptureC1Ev
```

`transformer-engine-torch` is built from its sdist in an isolated uv build environment. With no `extra-build-dependencies` entry it pulls whatever torch PyPI serves today (2.14), so the extension is compiled against a newer c10 ABI than the locked runtime torch (2.11.0+cu128). `c10::cuda::CUDAErrorLogCapture` exists in torch 2.14 and not in 2.11.

This was latent until the 09-05 nightly, when the cu12 uv download cache was evicted (repo cache went over the 10 GB cap) and TE was rebuilt cold. Every nightly since has hit the cache and reused the poisoned wheel.

## Change

One line in `pyproject.toml`: declare `torch` as an extra build dependency for `transformer-engine-torch` with `match-runtime = true`, the same pattern the PyG packages already use. This pins the build env's torch to the runtime version. No `uv.lock` change.

The same line is already on #1957 for the cu13 stack, where the branch nightly verified it end to end (frozen sync, lockfile guard, TE tests passing).

## Follow-up after merge

The cached cu12 uv slot still holds the bad wheel and must be deleted once so the next nightly rebuilds TE cleanly:

```
gh cache delete "uv-cache-nightly-cuda12.8.1-cudnn-devel-ubuntu24.04-py3.12-uv0.11.7-fullextras-latest" --repo NVIDIA/physicsnemo
```

Then dispatch the nightly. Note that last night's failed run published an empty `testmon-nightly-latest`, so PRs on main are currently running the full suite until a good nightly republishes the DB.

Until the slot is deleted, this PR's own GPU jobs will hit the poisoned cache and fail on the same ImportError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)